### PR TITLE
Convert to using Chapel's nilability feature

### DIFF
--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -22,7 +22,7 @@ module ArgSortMsg
     use UnorderedCopy;
     use UnorderedAtomics;
 
-    //use Sort only;
+    use Sort only;
     use RadixSortLSD;
     
     // thresholds for different sized sorts
@@ -379,8 +379,9 @@ module ArgSortMsg
         var ivname = st.nextName();
         if v {try! writeln("%s %s : %s %s".format(cmd, name, ivname));try! stdout.flush();}
 
-        var gEnt: borrowed GenSymEntry = st.lookup(name);
-        if (gEnt == nil) {return unknownSymbolError(pn,name);}
+        var gEnt_: borrowed GenSymEntry? = st.lookup(name);
+        if (gEnt_ == nil) {return unknownSymbolError(pn,name);}
+        var gEnt = gEnt_!;
 
         select (gEnt.dtype) {
             when (DType.Int64) {
@@ -396,7 +397,7 @@ module ArgSortMsg
 
     /* localArgsort takes a pdarray and returns an index vector which sorts the array on a per-locale basis */
     proc localArgsortMsg(reqMsg: string, st: borrowed SymTab): string {
-      var pn = "localArgsort";
+        var pn = "localArgsort";
         var repMsg: string; // response message
         var fields = reqMsg.split(); // split request into fields
         var cmd = fields[1];
@@ -406,8 +407,9 @@ module ArgSortMsg
         var ivname = st.nextName();
         if v {try! writeln("%s %s : %s %s".format(cmd, name, ivname));try! stdout.flush();}
 
-        var gEnt: borrowed GenSymEntry = st.lookup(name);
-        if (gEnt == nil) {return unknownSymbolError(pn,name);}
+        var gEnt_: borrowed GenSymEntry? = st.lookup(name);
+        if (gEnt_ == nil) {return unknownSymbolError(pn,name);}
+        var gEnt = gEnt_!;
 
         select (gEnt.dtype) {
             when (DType.Int64) {

--- a/src/EfuncMsg.chpl
+++ b/src/EfuncMsg.chpl
@@ -36,8 +36,9 @@ module EfuncMsg
         var rname = st.nextName();
         if v {try! writeln("%s %s %s : %s".format(cmd,efunc,name,rname));try! stdout.flush();}
 
-        var gEnt: borrowed GenSymEntry = st.lookup(name);
-        if (gEnt == nil) {return unknownSymbolError("efunc",name);}
+        var gEnt_: borrowed GenSymEntry? = st.lookup(name);
+        if (gEnt_ == nil) {return unknownSymbolError("efunc",name);}
+        var gEnt = gEnt_!;
        
         select (gEnt.dtype) {
             when (DType.Int64) {
@@ -155,12 +156,18 @@ module EfuncMsg
         var rname = st.nextName();
 	if v {try! writeln("%s %s %s %s %s %s : %s".format(cmd,efunc,name1,name2,name3,rname));try! stdout.flush();}
 
-        var g1: borrowed GenSymEntry = st.lookup(name1);
-        if (g1 == nil) {return unknownSymbolError("efunc",name1);}
-	var g2: borrowed GenSymEntry = st.lookup(name2);
-	if (g2 == nil) {return unknownSymbolError("efunc",name2);}
-	var g3: borrowed GenSymEntry = st.lookup(name3);
-	if (g3 == nil) {return unknownSymbolError("efunc",name3);}
+        var g1_: borrowed GenSymEntry? = st.lookup(name1);
+        if (g1_ == nil) {return unknownSymbolError("efunc",name1);}
+        var g1 = g1_!;
+
+        var g2_: borrowed GenSymEntry? = st.lookup(name2);
+        if (g2_ == nil) {return unknownSymbolError("efunc",name2);}
+        var g2 = g2_!;
+
+        var g3_: borrowed GenSymEntry? = st.lookup(name3);
+        if (g3_ == nil) {return unknownSymbolError("efunc",name3);}
+        var g3 = g3_!;
+
 	if !((g1.size == g2.size) && (g2.size == g3.size)) {
 	  return "Error: size mismatch in arguments to efunc3vv";
 	}
@@ -229,10 +236,14 @@ module EfuncMsg
         var rname = st.nextName();
 	if v {try! writeln("%s %s %s %s %s %s %s : %s".format(cmd,efunc,name1,name2,dtype,value,rname));try! stdout.flush();}
 
-        var g1: borrowed GenSymEntry = st.lookup(name1);
-        if (g1 == nil) {return unknownSymbolError("efunc",name1);}
-	var g2: borrowed GenSymEntry = st.lookup(name2);
-	if (g2 == nil) {return unknownSymbolError("efunc",name2);}
+        var g1_: borrowed GenSymEntry? = st.lookup(name1);
+        if (g1_ == nil) {return unknownSymbolError("efunc",name1);}
+        var g1 = g1_!;
+
+        var g2_: borrowed GenSymEntry? = st.lookup(name2);
+        if (g2_ == nil) {return unknownSymbolError("efunc",name2);}
+        var g2 = g2_!;
+
 	if !(g1.size == g2.size) {
 	  return "Error: size mismatch in arguments to efunc3vs";
 	}
@@ -301,10 +312,14 @@ module EfuncMsg
         var rname = st.nextName();
 	if v {try! writeln("%s %s %s %s %s %s %s : %s".format(cmd,efunc,name1,dtype,value,name2,rname));try! stdout.flush();}
 
-        var g1: borrowed GenSymEntry = st.lookup(name1);
-        if (g1 == nil) {return unknownSymbolError("efunc",name1);}
-	var g2: borrowed GenSymEntry = st.lookup(name2);
-	if (g2 == nil) {return unknownSymbolError("efunc",name2);}
+        var g1_: borrowed GenSymEntry? = st.lookup(name1);
+        if (g1_ == nil) {return unknownSymbolError("efunc",name1);}
+        var g1 = g1_!;
+
+        var g2_: borrowed GenSymEntry? = st.lookup(name2);
+        if (g2_ == nil) {return unknownSymbolError("efunc",name2);}
+        var g2 = g2_!;
+
 	if !(g1.size == g2.size) {
 	  return "Error: size mismatch in arguments to efunc3sv";
 	}
@@ -374,8 +389,10 @@ module EfuncMsg
         var rname = st.nextName();
 	if v {try! writeln("%s %s %s %s %s %s %s %s : %s".format(cmd,efunc,name1,dtype1,value1,dtype2,value2,rname));try! stdout.flush();}
 
-        var g1: borrowed GenSymEntry = st.lookup(name1);
-        if (g1 == nil) {return unknownSymbolError("efunc",name1);}
+        var g1_: borrowed GenSymEntry? = st.lookup(name1);
+        if (g1_ == nil) {return unknownSymbolError("efunc",name1);}
+        var g1 = g1_!;
+
         select (g1.dtype, dtype1, dtype1) {
 	when (DType.Bool, DType.Int64, DType.Int64) {
 	  var e1 = toSymEntry(g1, bool);

--- a/src/FindSegmentsMsg.chpl
+++ b/src/FindSegmentsMsg.chpl
@@ -36,8 +36,9 @@ module FindSegmentsMsg
         var sname = st.nextName(); // segments
         var uname = st.nextName(); // unique keys
 
-        var kEnt: borrowed GenSymEntry = st.lookup(kname);
-        if (kEnt == nil) {return unknownSymbolError(pn,kname);}
+        var kEnt_: borrowed GenSymEntry? = st.lookup(kname);
+        if (kEnt_ == nil) {return unknownSymbolError(pn,kname);}
+        var kEnt = kEnt_!;
 
         select (kEnt.dtype) {
             when (DType.Int64) {
@@ -87,8 +88,9 @@ module FindSegmentsMsg
         var sname = st.nextName(); // segments
         var uname = st.nextName(); // unique keys
 
-        var kEnt: borrowed GenSymEntry = st.lookup(kname);
-        if (kEnt == nil) {return unknownSymbolError(pn,kname);}
+        var kEnt_: borrowed GenSymEntry? = st.lookup(kname);
+        if (kEnt_ == nil) {return unknownSymbolError(pn,kname);}
+        var kEnt = kEnt_!;
 
         select (kEnt.dtype) {
             when (DType.Int64) {

--- a/src/HistogramMsg.chpl
+++ b/src/HistogramMsg.chpl
@@ -23,8 +23,9 @@ module HistogramMsg
         var rname = st.nextName();
         if v {try! writeln("%s %s %i : %s".format(cmd, name, bins, rname));try! stdout.flush();}
 
-        var gEnt: borrowed GenSymEntry = st.lookup(name);
-        if (gEnt == nil) {return unknownSymbolError("histogram",name);}
+        var gEnt_: borrowed GenSymEntry? = st.lookup(name);
+        if (gEnt_ == nil) {return unknownSymbolError("histogram",name);}
+        var gEnt = gEnt_!;
 
         // helper nested procedure
         proc histogramHelper(type t) {

--- a/src/In1dMsg.chpl
+++ b/src/In1dMsg.chpl
@@ -37,10 +37,13 @@ module In1dMsg
         var rname = st.nextName();
         if v {try! writeln("%s %s %s : %s".format(cmd, name, sname, rname));try! stdout.flush();}
 
-        var gAr1: borrowed GenSymEntry = st.lookup(name);
-        if (gAr1 == nil) {return unknownSymbolError("in1d",name);}
-        var gAr2: borrowed GenSymEntry = st.lookup(sname);
-        if (gAr2 == nil) {return unknownSymbolError("in1d",sname);}
+        var gAr1_: borrowed GenSymEntry? = st.lookup(name);
+        if (gAr1_ == nil) {return unknownSymbolError("in1d",name);}
+        var gAr1 = gAr1_!;
+
+        var gAr2_: borrowed GenSymEntry? = st.lookup(sname);
+        if (gAr2_ == nil) {return unknownSymbolError("in1d",sname);}
+        var gAr2 = gAr2_!;
 
         select (gAr1.dtype, gAr2.dtype) {
             when (DType.Int64, DType.Int64) {

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -17,8 +17,9 @@ module IndexingMsg
         var idx = try! fields[3]:int;
         if v {try! writeln("%s %s %i".format(cmd, name, idx));try! stdout.flush();}
 
-         var gEnt: borrowed GenSymEntry = st.lookup(name);
-         if (gEnt == nil) {return unknownSymbolError(pn,name);}
+         var gEnt_: borrowed GenSymEntry? = st.lookup(name);
+         if (gEnt_ == nil) {return unknownSymbolError(pn,name);}
+         var gEnt = gEnt_!;
          
          select (gEnt.dtype) {
              when (DType.Int64) {
@@ -65,8 +66,9 @@ module IndexingMsg
 
         if v {try! writeln("%s %s %i %i %i : %t , %s".format(cmd, name, start, stop, stride, slice, rname));try! stdout.flush();}
 
-        var gEnt: borrowed GenSymEntry = st.lookup(name);
-        if (gEnt == nil) {return unknownSymbolError(pn,name);}
+        var gEnt_: borrowed GenSymEntry? = st.lookup(name);
+        if (gEnt_ == nil) {return unknownSymbolError(pn,name);}
+        var gEnt = gEnt_!;
 
         proc sliceHelper(type t) {
           var e = toSymEntry(gEnt,t);
@@ -107,10 +109,13 @@ module IndexingMsg
 
         if v {try! writeln("%s %s %s : %s".format(cmd, name, iname, rname));try! stdout.flush();}
 
-        var gX: borrowed GenSymEntry = st.lookup(name);
-        if (gX == nil) {return unknownSymbolError(pn,name);}
-        var gIV: borrowed GenSymEntry = st.lookup(iname);
-        if (gIV == nil) {return unknownSymbolError(pn,iname);}
+        var gX_: borrowed GenSymEntry? = st.lookup(name);
+        if (gX_ == nil) {return unknownSymbolError(pn,name);}
+        var gX = gX_!;
+
+        var gIV_: borrowed GenSymEntry? = st.lookup(iname);
+        if (gIV_ == nil) {return unknownSymbolError(pn,iname);}
+        var gIV = gIV_!;
 
         /* proc ivInt64Helper(type XType) { */
         /*     var e = toSymEntry(gX,XType); */
@@ -247,8 +252,9 @@ module IndexingMsg
         var value = fields[5];
         if v {try! writeln("%s %s %i %s %s".format(cmd, name, idx, dtype2str(dtype), value));try! stdout.flush();}
 
-         var gEnt: borrowed GenSymEntry = st.lookup(name);
-         if (gEnt == nil) {return unknownSymbolError(pn,name);}
+         var gEnt_: borrowed GenSymEntry? = st.lookup(name);
+         if (gEnt_ == nil) {return unknownSymbolError(pn,name);}
+         var gEnt = gEnt_!;
 
          select (gEnt.dtype, dtype) {
              when (DType.Int64, DType.Int64) {
@@ -323,10 +329,13 @@ module IndexingMsg
 
         if v {try! writeln("%s %s %s %s %s".format(cmd, name, iname, dtype2str(dtype), value));try! stdout.flush();}
 
-        var gX: borrowed GenSymEntry = st.lookup(name);
-        if (gX == nil) {return unknownSymbolError(pn,name);}
-        var gIV: borrowed GenSymEntry = st.lookup(iname);
-        if (gIV == nil) {return unknownSymbolError(pn,iname);}
+        var gX_: borrowed GenSymEntry? = st.lookup(name);
+        if (gX_ == nil) {return unknownSymbolError(pn,name);}
+        var gX = gX_!;
+
+        var gIV_: borrowed GenSymEntry? = st.lookup(iname);
+        if (gIV_ == nil) {return unknownSymbolError(pn,iname);}
+        var gIV = gIV_!;
 
         proc idxToValHelper(type Xtype, type IVtype, type dtype): string {
             var e = toSymEntry(gX,Xtype);
@@ -373,12 +382,17 @@ module IndexingMsg
 
         if v {try! writeln("%s %s %s %s".format(cmd, name, iname, yname));try! stdout.flush();}
 
-        var gX: borrowed GenSymEntry = st.lookup(name);
-        if (gX == nil) {return unknownSymbolError(pn,name);}
-        var gIV: borrowed GenSymEntry = st.lookup(iname);
-        if (gIV == nil) {return unknownSymbolError(pn,iname);}
-        var gY: borrowed GenSymEntry = st.lookup(yname);
-        if (gY == nil) {return unknownSymbolError(pn,yname);}
+        var gX_: borrowed GenSymEntry? = st.lookup(name);
+        if (gX_ == nil) {return unknownSymbolError(pn,name);}
+        var gX = gX_!;
+
+        var gIV_: borrowed GenSymEntry? = st.lookup(iname);
+        if (gIV_ == nil) {return unknownSymbolError(pn,iname);}
+        var gIV = gIV_!;
+
+        var gY_: borrowed GenSymEntry? = st.lookup(yname);
+        if (gY_ == nil) {return unknownSymbolError(pn,yname);}
+        var gY = gY_!;
 
         // add check to make syre IV and Y are same size
         if (gIV.size != gY.size) {return try! "Error: %s: size mismatch %i %i".format(pn,gIV.size, gY.size);}
@@ -445,8 +459,9 @@ module IndexingMsg
 
         if v {try! writeln("%s %s %i %i %i %s %s".format(cmd, name, start, stop, stride, dtype2str(dtype), value));try! stdout.flush();}
         
-        var gEnt: borrowed GenSymEntry = st.lookup(name);
-        if (gEnt == nil) {return unknownSymbolError(pn,name);}
+        var gEnt_: borrowed GenSymEntry? = st.lookup(name);
+        if (gEnt_ == nil) {return unknownSymbolError(pn,name);}
+        var gEnt = gEnt_!;
 
         select (gEnt.dtype, dtype) {
             when (DType.Int64, DType.Int64) {
@@ -531,10 +546,13 @@ module IndexingMsg
 
         if v {try! writeln("%s %s %i %i %i %s".format(cmd, name, start, stop, stride, yname));try! stdout.flush();}
 
-        var gX: borrowed GenSymEntry = st.lookup(name);
-        if (gX == nil) {return unknownSymbolError(pn,name);}
-        var gY: borrowed GenSymEntry = st.lookup(yname);
-        if (gY == nil) {return unknownSymbolError(pn,yname);}
+        var gX_: borrowed GenSymEntry? = st.lookup(name);
+        if (gX_ == nil) {return unknownSymbolError(pn,name);}
+        var gX = gX_!;
+
+        var gY_: borrowed GenSymEntry? = st.lookup(yname);
+        if (gY_ == nil) {return unknownSymbolError(pn,yname);}
+        var gY = gY_!;
 
         // add check to make syre IV and Y are same size
         if (slice.size != gY.size) {return try! "Error: %s: size mismatch %i %i".format(pn,slice.size, gY.size);}

--- a/src/MsgProcessing.chpl
+++ b/src/MsgProcessing.chpl
@@ -259,8 +259,9 @@ module MsgProcessing
         var dtype = str2dtype(fields[3]);
         var value = fields[4];
 
-        var gEnt: borrowed GenSymEntry = st.lookup(name);
-        if (gEnt == nil) {return unknownSymbolError("set",name);}
+        var gEnt_: borrowed GenSymEntry? = st.lookup(name);
+        if (gEnt_ == nil) {return unknownSymbolError("set",name);}
+        var gEnt = gEnt_!;
 
         select (gEnt.dtype, dtype) {
             when (DType.Int64, DType.Int64) {

--- a/src/MultiTypeSymbolTable.chpl
+++ b/src/MultiTypeSymbolTable.chpl
@@ -18,7 +18,7 @@ module MultiTypeSymbolTable
         /*
         Associative array indexed by strings
         */
-        var tab: [tD] shared GenSymEntry; 
+        var tab: [tD] shared GenSymEntry?;
 
         var nid = 0;
         /*
@@ -56,7 +56,7 @@ module MultiTypeSymbolTable
 
             ref tableEntry = tab[name];
             tableEntry = entry;
-            return tableEntry.borrow().toSymEntry(t);
+            return tableEntry!.borrow().toSymEntry(t);
         }
 
         /*
@@ -80,7 +80,7 @@ module MultiTypeSymbolTable
 
             ref tableEntry = tab[name];
             tableEntry = entry;
-            return tableEntry.borrow();
+            return tableEntry!.borrow();
         }
 
         /*
@@ -129,7 +129,7 @@ module MultiTypeSymbolTable
 
         :returns: sym entry or nil
         */
-        proc lookup(name: string): shared GenSymEntry {
+        proc lookup(name: string): borrowed GenSymEntry? {
             if (!tD.contains(name))
             {
                 if (v) {writeln("undefined symbol ",name);try! stdout.flush();}
@@ -180,15 +180,18 @@ module MultiTypeSymbolTable
             var s: string;
             if name == "__AllSymbols__" {
                 for n in tD {
-                    if (tab[n] != nil) {
-                        try! s += "name:%t dtype:%t size:%t ndim:%t shape:%t itemsize:%t\n".format(n, dtype2str(tab[n].dtype), tab[n].size, tab[n].ndim, tab[n].shape, tab[n].itemsize);
+                    var entry_ = tab[n];
+                    if (entry_ != nil) {
+                        var entry = entry_!;
+                        try! s += "name:%t dtype:%t size:%t ndim:%t shape:%t itemsize:%t\n".format(n, dtype2str(entry.dtype), entry.size, entry.ndim, entry.shape, entry.itemsize);
                     }
                 }
             }
             else
             {
                 if (tD.contains(name)) {
-                    try! s = "name:%t dtype:%t size:%t ndim:%t shape:%t itemsize:%t\n".format(name, dtype2str(tab[name].dtype), tab[name].size, tab[name].ndim, tab[name].shape, tab[name].itemsize);
+                    var entry = tab[name]!;
+                    try! s = "name:%t dtype:%t size:%t ndim:%t shape:%t itemsize:%t\n".format(name, dtype2str(entry.dtype), entry.size, entry.ndim, entry.shape, entry.itemsize);
                 }
                 else {s = unknownSymbolError("info",name);}
             }
@@ -207,7 +210,9 @@ module MultiTypeSymbolTable
         proc attrib(name:string):string {
             var s:string;
             if (tD.contains(name)) {
-                try! s = "%s %s %t %t %t %t".format(name, dtype2str(tab[name].dtype), tab[name].size, tab[name].ndim, tab[name].shape, tab[name].itemsize);
+                // TODO: Use a serializer.
+                var entry = tab[name]!;
+                try! s = "%s %s %t %t %t %t".format(name, dtype2str(entry.dtype), entry.size, entry.ndim, entry.shape, entry.itemsize);
             }
             else {s = unknownSymbolError("attrib",name);}
             return s;
@@ -230,7 +235,7 @@ module MultiTypeSymbolTable
         proc datastr(name: string, thresh:int): string {
             var s:string;
             if (tD.contains(name)) {
-                var u: borrowed GenSymEntry = tab[name];
+                var u: borrowed GenSymEntry = tab[name]!;
                 select u.dtype
                 {
                     when DType.Int64
@@ -307,7 +312,7 @@ module MultiTypeSymbolTable
         proc datarepr(name: string, thresh:int): string {
             var s:string;
             if (tD.contains(name)) {
-                var u: borrowed GenSymEntry = tab[name];
+                var u: borrowed GenSymEntry = tab[name]!;
                 select u.dtype
                 {
                     when DType.Int64

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -32,10 +32,13 @@ module OperatorMsg
         var rname = st.nextName();
         if v {try! writeln("%s %s %s %s : %s".format(cmd,op,aname,bname,rname));try! stdout.flush();}
 
-        var left: borrowed GenSymEntry = st.lookup(aname);
-        if (left == nil) {return try! "Error: binopvv: unkown symbol %s".format(aname);}
-        var right: borrowed GenSymEntry = st.lookup(bname);
-        if (right == nil) {return try! "Error: binopvv: unkown symbol %s".format(bname);}
+        var left_: borrowed GenSymEntry? = st.lookup(aname);
+        if (left_ == nil) {return try! "Error: binopvv: unkown symbol %s".format(aname);}
+        var left = left_!;
+
+        var right_: borrowed GenSymEntry? = st.lookup(bname);
+        if (right_ == nil) {return try! "Error: binopvv: unkown symbol %s".format(bname);}
+        var right = right_!;
 
         select (left.dtype, right.dtype) {
             when (DType.Int64, DType.Int64) {
@@ -453,8 +456,10 @@ module OperatorMsg
         var rname = st.nextName();
         if v {try! writeln("%s %s %s %s %s : %s".format(cmd,op,aname,dtype2str(dtype),value,rname));try! stdout.flush();}
 
-        var left: borrowed GenSymEntry = st.lookup(aname);
-        if (left == nil) {return try! "Error: binopvs: unkown symbol %s".format(aname);}
+        var left_: borrowed GenSymEntry? = st.lookup(aname);
+        if (left_ == nil) {return try! "Error: binopvs: unkown symbol %s".format(aname);}
+        var left = left_!;
+
         select (left.dtype, dtype) {
             when (DType.Int64, DType.Int64) {
                 var l = toSymEntry(left,int);
@@ -867,8 +872,10 @@ module OperatorMsg
         var rname = st.nextName();
         if v {try! writeln("%s %s %s %s %s : %s".format(cmd,op,dtype2str(dtype),value,aname,rname));try! stdout.flush();}
 
-        var right: borrowed GenSymEntry = st.lookup(aname);
-        if (right == nil) {return try! "Error: binopsv: unkown symbol %s".format(aname);}
+        var right_: borrowed GenSymEntry? = st.lookup(aname);
+        if (right_ == nil) {return try! "Error: binopsv: unkown symbol %s".format(aname);}
+        var right = right_!;
+
         select (dtype, right.dtype) {
             when (DType.Int64, DType.Int64) {
                 var val = try! value:int;
@@ -1275,10 +1282,14 @@ module OperatorMsg
         var bname = fields[4];
         if v {try! writeln("%s %s %s %s".format(cmd,op,aname,bname));try! stdout.flush();}
         
-        var left: borrowed GenSymEntry = st.lookup(aname);
-        if (left == nil) {return unknownSymbolError("opeqvv",aname);}
-        var right: borrowed GenSymEntry = st.lookup(bname);
-        if (right == nil) {return unknownSymbolError("opeqvv",bname);}
+        var left_: borrowed GenSymEntry? = st.lookup(aname);
+        if (left_ == nil) {return unknownSymbolError("opeqvv",aname);}
+        var left = left_!;
+
+        var right_: borrowed GenSymEntry? = st.lookup(bname);
+        if (right_ == nil) {return unknownSymbolError("opeqvv",bname);}
+        var right = right_!;
+
         select (left.dtype, right.dtype) {
             when (DType.Int64, DType.Int64) {
                 var l = toSymEntry(left,int);
@@ -1413,8 +1424,9 @@ module OperatorMsg
         var value = fields[5];
         if v {try! writeln("%s %s %s %s %s".format(cmd,op,aname,dtype2str(dtype),value));try! stdout.flush();}
 
-        var left: borrowed GenSymEntry = st.lookup(aname);
-        if (left == nil) {return unknownSymbolError("opeqvs",aname);}
+        var left_: borrowed GenSymEntry? = st.lookup(aname);
+        if (left_ == nil) {return unknownSymbolError("opeqvs",aname);}
+        var left = left_!;
 
         select (left.dtype, dtype) {
             when (DType.Int64, DType.Int64) {

--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -31,9 +31,10 @@ module ReductionMsg
         var name = fields[3];
         if v {try! writeln("%s %s %s".format(cmd,reductionop,name));try! stdout.flush();}
 
-        var gEnt: borrowed GenSymEntry = st.lookup(name);
-        if (gEnt == nil) {return unknownSymbolError("reduction",name);}
-       
+        var gEnt_: borrowed GenSymEntry? = st.lookup(name);
+        if (gEnt_ == nil) {return unknownSymbolError("reduction",name);}
+        var gEnt = gEnt_!;
+
         select (gEnt.dtype) {
             when (DType.Int64) {
                 var e = toSymEntry(gEnt,int);
@@ -210,10 +211,12 @@ module ReductionMsg
       var rname = st.nextName();
       if v {try! writeln("%s %s %s".format(cmd,segments_name, size));try! stdout.flush();}
 
-      var gSeg: borrowed GenSymEntry = st.lookup(segments_name);
-      if (gSeg == nil) {return unknownSymbolError("segmentedReduction",segments_name);}
+      var gSeg_: borrowed GenSymEntry? = st.lookup(segments_name);
+      if (gSeg_ == nil) {return unknownSymbolError("segmentedReduction",segments_name);}
+      var gSeg = gSeg_!;
+
       var segments = toSymEntry(gSeg, int);
-      if (segments == nil) {return "Error: array of segment offsets must be int dtype";}
+
       var counts = segCount(segments.a, size);
       st.addEntry(rname, new shared SymEntry(counts));
       return try! "created " + st.attrib(rname);
@@ -243,10 +246,12 @@ module ReductionMsg
       var rname = st.nextName();
       if v {try! writeln("%s %s %s".format(cmd,segments_name, size));try! stdout.flush();}
 
-      var gSeg: borrowed GenSymEntry = st.lookup(segments_name);
-      if (gSeg == nil) {return unknownSymbolError("segmentedReduction",segments_name);}
+      var gSeg_: borrowed GenSymEntry? = st.lookup(segments_name);
+      if (gSeg_ == nil) {return unknownSymbolError("segmentedReduction",segments_name);}
+      var gSeg = gSeg_!;
+
       var segments = toSymEntry(gSeg, int);
-      if (segments == nil) {return "Error: array of segment offsets must be int dtype";}
+
       var counts = perLocCount(segments.a, size);
       st.addEntry(rname, new shared SymEntry(counts));
       return try! "created " + st.attrib(rname);
@@ -278,16 +283,24 @@ module ReductionMsg
       var operator = fields[5];      // reduction operator
       var rname = st.nextName();
       if v {try! writeln("%s %s %s %s %s".format(cmd,keys_name,values_name,segments_name,operator));try! stdout.flush();}
-      var gKey: borrowed GenSymEntry = st.lookup(keys_name);
-      if (gKey == nil) {return unknownSymbolError("segmentedReduction", keys_name);}
+
+      var gKey_: borrowed GenSymEntry? = st.lookup(keys_name);
+      if (gKey_ == nil) {return unknownSymbolError("segmentedReduction", keys_name);}
+      var gKey = gKey_!;
+
       if (gKey.dtype != DType.Int64) {return unrecognizedTypeError("segmentedLocalRdx", dtype2str(gKey.dtype));}
       var keys = toSymEntry(gKey, int);
-      var gVal: borrowed GenSymEntry = st.lookup(values_name);
-      if (gVal == nil) {return unknownSymbolError("segmentedReduction",values_name);}
-      var gSeg: borrowed GenSymEntry = st.lookup(segments_name);
-      if (gSeg == nil) {return unknownSymbolError("segmentedReduction",segments_name);}
+
+      var gVal_: borrowed GenSymEntry? = st.lookup(values_name);
+      if (gVal_ == nil) {return unknownSymbolError("segmentedReduction",values_name);}
+      var gVal = gVal_!;
+
+      var gSeg_: borrowed GenSymEntry? = st.lookup(segments_name);
+      if (gSeg_ == nil) {return unknownSymbolError("segmentedReduction",segments_name);}
+      var gSeg = gSeg_!;
+
       var segments = toSymEntry(gSeg, int);
-      if (segments == nil) {return "Error: array of segment offsets must be int dtype";}
+
       select (gVal.dtype) {
       when (DType.Int64) {
 	var values = toSymEntry(gVal, int);
@@ -399,16 +412,23 @@ module ReductionMsg
       var rname = st.nextName();
       if v {try! writeln("%s %s %s %s %s".format(cmd,keys_name,values_name,segments_name,operator));try! stdout.flush();}
 
-      var gKey: borrowed GenSymEntry = st.lookup(keys_name);
-      if (gKey == nil) {return unknownSymbolError("segmentedLocalRdx",keys_name);}
+      var gKey_: borrowed GenSymEntry? = st.lookup(keys_name);
+      if (gKey_ == nil) {return unknownSymbolError("segmentedLocalRdx",keys_name);}
+      var gKey = gKey_!;
+
       if (gKey.dtype != DType.Int64) {return unrecognizedTypeError("segmentedLocalRdx", dtype2str(gKey.dtype));}
       var keys = toSymEntry(gKey, int);
-      var gVal: borrowed GenSymEntry = st.lookup(values_name);
-      if (gVal == nil) {return unknownSymbolError("segmentedLocalRdx",values_name);}
-      var gSeg: borrowed GenSymEntry = st.lookup(segments_name);
-      if (gSeg == nil) {return unknownSymbolError("segmentedLocalRdx",segments_name);}
+
+      var gVal_: borrowed GenSymEntry? = st.lookup(values_name);
+      if (gVal_ == nil) {return unknownSymbolError("segmentedLocalRdx",values_name);}
+      var gVal = gVal_!;
+
+      var gSeg_: borrowed GenSymEntry? = st.lookup(segments_name);
+      if (gSeg_ == nil) {return unknownSymbolError("segmentedLocalRdx",segments_name);}
+      var gSeg = gSeg_!;
+
       var segments = toSymEntry(gSeg, int);
-      if (segments == nil) {return "Error: array of segment offsets must be int dtype";}
+
       select (gVal.dtype) {
       when (DType.Int64) {
 	var values = toSymEntry(gVal, int);

--- a/src/UniqueMsg.chpl
+++ b/src/UniqueMsg.chpl
@@ -41,8 +41,9 @@ module UniqueMsg
         var cname = st.nextName();
         if v {try! writeln("%s %s %t: %s %s".format(cmd, name, returnCounts, vname, cname));try! stdout.flush();}
         
-        var gEnt: borrowed GenSymEntry = st.lookup(name);
-        if (gEnt == nil) {return unknownSymbolError(pn,name);}
+        var gEnt_: borrowed GenSymEntry? = st.lookup(name);
+        if (gEnt_ == nil) {return unknownSymbolError(pn,name);}
+        var gEnt = gEnt_!;
         
         select (gEnt.dtype) {
             when (DType.Int64) {
@@ -95,8 +96,9 @@ module UniqueMsg
         var cname = st.nextName();
         if v {try! writeln("%s %s : %s %s".format(cmd, name, vname, cname));try! stdout.flush();}
 
-        var gEnt: borrowed GenSymEntry = st.lookup(name);
-        if (gEnt == nil) {return unknownSymbolError(pn,name);}
+        var gEnt_: borrowed GenSymEntry? = st.lookup(name);
+        if (gEnt_ == nil) {return unknownSymbolError(pn,name);}
+        var gEnt = gEnt_!;
 
         select (gEnt.dtype) {
             when (DType.Int64) {


### PR DESCRIPTION
**Do not merge this PR if #93 is merged. This PR is mutually exclusive from #93!**
**Do not merge this PR until Chapel 1.20.0 is released.**

**This PR is based on top of branch `ref-from-addEntry` #107 .** I thought I'd be able to redirect the PR to master, but I probably can't (I suppose it's a GitHub constraint). In any case, I can create another PR to merge against master once #107 is merged. I just didn't want the diff of this PR to be polluted with the required changes from #107.

This PR introduces the alternative way of converting the codebase to use Chapel 1.20.0's nilability feature. In a few words, nilability is represented as "can this class be nil" (syntax: `MyClass?`). If it can be nil, the user has to do some extra steps to check that the stored object is not nil before using it.

The primary change is deciding the return value of `SymTab.lookup()`. There's a few other places that nilability affects the code, but this one function decides the bulk of the changes. This function's behavior is "look up the name in the SymTab and either succeed or fail". The failure case can be handled by two approaches. Both approaches are valid and it is a matter of preference for how to handle errors.

- This commit takes the approach of returning a borrowed nilable. The
  borrow is nil if the lookup failed. The caller must check for nil.
  This behavior is similar to what the current code already does.
  The majority of the changes is simply calling the lookup function as
  usual, then converting it to a non-nilable if lookup succeeded (via
  another variable declaration). There are a few points in the code,
  notably GenSymIO.chpl, where the variable declaration cannot be split
  from the variable assignment/initialization because that variable's
  type is non-nilable (thus requiring initialization). So the lines
  of code moved around a bit to avoid the non-nil variable declaration.

- The other approach #93 is to do the nil-check within the `lookup`
  function and return a borrowed non-nilable (and throw if the lookup
  failed). In my opinion, this solution is cleaner to follow and
  requires less explicit handling of the failed lookups because they are
  instead handled as exceptions. The code is then able to assume that
  lookups succeed, and if they instead fail, will just be handled by the
  exception catcher.

Regardless of the decision, the introduction of nilability affects the entire codebase wherever the `lookup` function is called. The difference is simply which way you prefer to handle the failed lookup.

In doing this conversion, I found a few places where the lookup was assumed to always succeed. I preserved this behavior by simply decorating the call with e.g., `st.lookup(...)!` (using postfix `!`).