### PR TITLE
Fix compilation for Chapel 1.20.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 # Makefile for Arkouda
+THISDIR := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 PROJECT_NAME := arkouda
 ARKOUDA_SOURCE_DIR := src
 ARKOUDA_MAIN_MODULE := arkouda_server
@@ -12,6 +13,9 @@ CHPL := chpl
 CHPL_FLAGS += --print-passes
 CHPL_FLAGS += --ccflags="-Wno-incompatible-pointer-types" --cache-remote --instantiate-max 1024 --fast
 CHPL_FLAGS += -lhdf5 -lhdf5_hl -lzmq
+
+# Run script to get more compiler flags for broader version compatibility.
+CHPL_FLAGS += $(shell $(THISDIR)/chpl-compat.bash)
 
 # add-path: Append custom paths for non-system software.
 define add-path

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ CHPL_FLAGS += --ccflags="-Wno-incompatible-pointer-types" --cache-remote --insta
 CHPL_FLAGS += -lhdf5 -lhdf5_hl -lzmq
 
 # Run script to get more compiler flags for broader version compatibility.
-CHPL_FLAGS += $(shell $(THISDIR)/chpl-compat.bash)
+CHPL_FLAGS += $(shell $(THISDIR)/chpl-compat.bash $(CHPL))
 
 # add-path: Append custom paths for non-system software.
 define add-path

--- a/chpl-compat.bash
+++ b/chpl-compat.bash
@@ -1,9 +1,15 @@
 #!/bin/bash
 # Generate `chpl` compiler flags for broader version compatibility.
+# This script optionally accepts the path to a `chpl` compiler.
 set -o errexit -o pipefail -o noclobber -o nounset
 
+CHPL=chpl
+if (( $# >= 1 )); then
+    CHPL="$1"
+fi
+
 re='(([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+))'
-[[ "$(chpl --version | head -n 1)" =~ $re ]]
+[[ "$($CHPL --version | head -n 1)" =~ $re ]]
 CHPL_VERSION="${BASH_REMATCH[1]}"
 CHPL_MAJOR_VERSION="${BASH_REMATCH[2]}"
 CHPL_MINOR_VERSION="${BASH_REMATCH[3]}"

--- a/chpl-compat.bash
+++ b/chpl-compat.bash
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Generate `chpl` compiler flags for broader version compatibility.
+set -o errexit -o pipefail -o noclobber -o nounset
+
+re='(([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+))'
+[[ "$(chpl --version | head -n 1)" =~ $re ]]
+CHPL_VERSION="${BASH_REMATCH[1]}"
+CHPL_MAJOR_VERSION="${BASH_REMATCH[2]}"
+CHPL_MINOR_VERSION="${BASH_REMATCH[3]}"
+CHPL_PATCH_VERSION="${BASH_REMATCH[4]}"
+
+if (( CHPL_MAJOR_VERSION == 1 )) && (( CHPL_MINOR_VERSION >= 20 )); then
+    echo "--legacy-classes"
+fi

--- a/chpl-compat.bash
+++ b/chpl-compat.bash
@@ -9,6 +9,10 @@ CHPL_MAJOR_VERSION="${BASH_REMATCH[2]}"
 CHPL_MINOR_VERSION="${BASH_REMATCH[3]}"
 CHPL_PATCH_VERSION="${BASH_REMATCH[4]}"
 
-if (( CHPL_MAJOR_VERSION == 1 )) && (( CHPL_MINOR_VERSION >= 20 )); then
-    echo "--legacy-classes"
+FLAGS=
+
+if (( CHPL_MAJOR_VERSION >= 1 )) && (( CHPL_MINOR_VERSION >= 20 )); then
+    FLAGS+=" --legacy-classes "
 fi
+
+echo $FLAGS


### PR DESCRIPTION
I added a compatibility script `chpl-compat.bash` that will generate compiler flags depending on what version of `chpl` you are using. Right now, it only generates `--legacy-classes` for version 1.20 and higher. Once nilability support is merged in, this script should be deactivated because nilability is a breaking change so compatibility with 1.19.0 won't make any sense at that point.