### PR TITLE
Convert arkouda to nilable (one option for making Arkouda Chapel 1.20-ready)

### DIFF
--- a/src/ConcatenateMsg.chpl
+++ b/src/ConcatenateMsg.chpl
@@ -28,9 +28,9 @@ module ConcatenateMsg
         var dtype: DType;
         // Check that all arrays exist in the symbol table and have the same size
         for (name, i) in zip(names, 1..) {
+          try {
             // arrays[i] = st.lookup(name): borrowed GenSymEntry;
             var g: borrowed GenSymEntry = st.lookup(name);
-            if (g == nil) { return unknownSymbolError(pn, name); }
             if (i == 1) {dtype = g.dtype;}
             else {
                 if (dtype != g.dtype) {
@@ -39,6 +39,11 @@ module ConcatenateMsg
             }
             // accumulate size from each array size
             size += g.size;
+          } catch e: UndefinedSymbolError {
+            return unknownSymbolError(pn,name);
+          } catch {
+            return unknownError(pn);
+          }
         }
         // allocate a new array in the symboltable
         // and copy in arrays
@@ -51,6 +56,7 @@ module ConcatenateMsg
                 var end: int;
                 start = 0;
                 for (name, i) in zip(names, 1..) {
+                  try {
                     // lookup and cast operand to copy from
                     var o = toSymEntry(st.lookup(name), int);
                     // calculate end which is inclusive
@@ -59,6 +65,11 @@ module ConcatenateMsg
                     e.a[{start..end}] = o.a;
                     // update new start for next array copy
                     start += o.size;
+                  } catch e: UndefinedSymbolError {
+                    return unknownSymbolError(pn,name);
+                  } catch {
+                    return unknownError(pn);
+                  }
                 }
             }
             when DType.Float64 {
@@ -68,6 +79,7 @@ module ConcatenateMsg
                 var end: int;
                 start = 0;
                 for (name, i) in zip(names, 1..) {
+                  try {
                     // lookup and cast operand to copy from
                     var o = toSymEntry(st.lookup(name), real);
                     // calculate end which is inclusive
@@ -76,6 +88,11 @@ module ConcatenateMsg
                     e.a[{start..end}] = o.a;
                     // update new start for next array copy
                     start += o.size;
+                  } catch e: UndefinedSymbolError {
+                    return unknownSymbolError(pn,name);
+                  } catch {
+                    return unknownError(pn);
+                  }
                 }
             }
             when DType.Bool {
@@ -85,6 +102,7 @@ module ConcatenateMsg
                 var end: int;
                 start = 0;
                 for (name, i) in zip(names, 1..) {
+                  try {
                     // lookup and cast operand to copy from
                     var o = toSymEntry(st.lookup(name), bool);
                     // calculate end which is inclusive
@@ -93,6 +111,11 @@ module ConcatenateMsg
                     e.a[{start..end}] = o.a;
                     // update new start for next array copy
                     start += o.size;
+                  } catch e: UndefinedSymbolError {
+                    return unknownSymbolError(pn,name);
+                  } catch {
+                    return unknownError(pn);
+                  }
                 }
             }
             otherwise {return notImplementedError("concatenate",dtype);}

--- a/src/EfuncMsg.chpl
+++ b/src/EfuncMsg.chpl
@@ -36,8 +36,8 @@ module EfuncMsg
         var rname = st.nextName();
         if v {try! writeln("%s %s %s : %s".format(cmd,efunc,name,rname));try! stdout.flush();}
 
+        try {
         var gEnt: borrowed GenSymEntry = st.lookup(name);
-        if (gEnt == nil) {return unknownSymbolError("efunc",name);}
        
         select (gEnt.dtype) {
             when (DType.Int64) {
@@ -130,6 +130,12 @@ module EfuncMsg
             otherwise {return unrecognizedTypeError("efunc", dtype2str(gEnt.dtype));}
         }
         return try! "created " + st.attrib(rname);
+        } catch e: UndefinedSymbolError {
+          return unknownSymbolError("efunc",e.name);
+        } catch {
+          return unknownError("efunc");
+        }
+
     }
 
     /*
@@ -155,12 +161,10 @@ module EfuncMsg
         var rname = st.nextName();
 	if v {try! writeln("%s %s %s %s %s %s : %s".format(cmd,efunc,name1,name2,name3,rname));try! stdout.flush();}
 
+        try {
         var g1: borrowed GenSymEntry = st.lookup(name1);
-        if (g1 == nil) {return unknownSymbolError("efunc",name1);}
 	var g2: borrowed GenSymEntry = st.lookup(name2);
-	if (g2 == nil) {return unknownSymbolError("efunc",name2);}
 	var g3: borrowed GenSymEntry = st.lookup(name3);
-	if (g3 == nil) {return unknownSymbolError("efunc",name3);}
 	if !((g1.size == g2.size) && (g2.size == g3.size)) {
 	  return "Error: size mismatch in arguments to efunc3vv";
 	}
@@ -204,6 +208,11 @@ module EfuncMsg
 	otherwise {return notImplementedError("efunc3vv",efunc,g1.dtype,g2.dtype,g3.dtype);}
 	}
 	return try! "created " + st.attrib(rname);
+        } catch e: UndefinedSymbolError {
+          return unknownSymbolError("efunc3vv",e.name);
+        } catch {
+          return unknownError("efunc3vv");
+        }
     }
 
     /*
@@ -229,10 +238,9 @@ module EfuncMsg
         var rname = st.nextName();
 	if v {try! writeln("%s %s %s %s %s %s %s : %s".format(cmd,efunc,name1,name2,dtype,value,rname));try! stdout.flush();}
 
+        try {
         var g1: borrowed GenSymEntry = st.lookup(name1);
-        if (g1 == nil) {return unknownSymbolError("efunc",name1);}
 	var g2: borrowed GenSymEntry = st.lookup(name2);
-	if (g2 == nil) {return unknownSymbolError("efunc",name2);}
 	if !(g1.size == g2.size) {
 	  return "Error: size mismatch in arguments to efunc3vs";
 	}
@@ -276,6 +284,11 @@ module EfuncMsg
 	otherwise {return notImplementedError("efunc3vs",efunc,g1.dtype,g2.dtype,dtype);}
 	}
 	return try! "created " + st.attrib(rname);
+        } catch e: UndefinedSymbolError {
+          return unknownSymbolError("efunc3vs",e.name);
+        } catch {
+          return unknownError("efunc3vs");
+        }
     }
 
     /*
@@ -301,10 +314,9 @@ module EfuncMsg
         var rname = st.nextName();
 	if v {try! writeln("%s %s %s %s %s %s %s : %s".format(cmd,efunc,name1,dtype,value,name2,rname));try! stdout.flush();}
 
+        try {
         var g1: borrowed GenSymEntry = st.lookup(name1);
-        if (g1 == nil) {return unknownSymbolError("efunc",name1);}
 	var g2: borrowed GenSymEntry = st.lookup(name2);
-	if (g2 == nil) {return unknownSymbolError("efunc",name2);}
 	if !(g1.size == g2.size) {
 	  return "Error: size mismatch in arguments to efunc3sv";
 	}
@@ -348,6 +360,11 @@ module EfuncMsg
 	otherwise {return notImplementedError("efunc3sv",efunc,g1.dtype,dtype,g2.dtype);}
 	}
 	return try! "created " + st.attrib(rname);
+        } catch e: UndefinedSymbolError {
+          return unknownSymbolError("efunc3sv",e.name);
+        } catch {
+          return unknownError("efunc3sv");
+        }
     }
 
     /*
@@ -374,8 +391,8 @@ module EfuncMsg
         var rname = st.nextName();
 	if v {try! writeln("%s %s %s %s %s %s %s %s : %s".format(cmd,efunc,name1,dtype1,value1,dtype2,value2,rname));try! stdout.flush();}
 
+        try {
         var g1: borrowed GenSymEntry = st.lookup(name1);
-        if (g1 == nil) {return unknownSymbolError("efunc",name1);}
         select (g1.dtype, dtype1, dtype1) {
 	when (DType.Bool, DType.Int64, DType.Int64) {
 	  var e1 = toSymEntry(g1, bool);
@@ -416,6 +433,11 @@ module EfuncMsg
 	otherwise {return notImplementedError("efunc3sv",efunc,g1.dtype,dtype1,dtype2);}
 	}
 	return try! "created " + st.attrib(rname);
+        } catch e: UndefinedSymbolError {
+          return unknownSymbolError("efunc3ss",e.name);
+        } catch {
+          return unknownError("efunc3ss");
+        }
     }
 
     /* The 'where' function takes a boolean array and two other arguments A and B, and 

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -23,45 +23,54 @@ module GenSymIO {
     } catch {
       return "Error: Could not write to memory buffer";
     }
-    var entry: shared GenSymEntry;
     try {
+      const entry: shared GenSymEntry = readEntry();
+      const rname = st.nextName();
+      st.addEntry(rname, entry);
+      return try! "created " + st.attrib(rname);
+    } catch err: UnhandledDataTypeError {
+      return try! "Error: Unhandled data type %s".format(err.dtype);
+    } catch {
+      return "Error: Could not read from memory buffer into SymEntry";
+    }
+
+    class UnhandledDataTypeError: Error {
+      var dtype: DType;
+    }
+
+    proc readEntry(): shared GenSymEntry throws {
       var tmpr = tmpf.reader(kind=iobig, start=0);
       if dtype == DType.Int64 {
 	var entryInt = new shared SymEntry(size, int);
 	tmpr.read(entryInt.a);
 	tmpr.close(); tmpf.close();
-	entry = entryInt;
+	return entryInt;
       } else if dtype == DType.Float64 {
 	var entryReal = new shared SymEntry(size, real);
 	tmpr.read(entryReal.a);
 	tmpr.close(); tmpf.close();
-	entry = entryReal;
+	return entryReal;
       } else if dtype == DType.Bool {
 	var entryBool = new shared SymEntry(size, bool);
 	tmpr.read(entryBool.a);
 	tmpr.close(); tmpf.close();
-	entry = entryBool;
+	return entryBool;
       } else {
 	tmpr.close();
 	tmpf.close();
-	return try! "Error: Unhandled data type %s".format(fields[2]);
+	throw new owned UnhandledDataTypeError(dtype);
       }
       tmpr.close();
       tmpf.close();
-    } catch {
-      return "Error: Could not read from memory buffer into SymEntry";
     }
-    var rname = st.nextName();
-    st.addEntry(rname, entry);
-    return try! "created " + st.attrib(rname);
   }
 
   proc tondarrayMsg(reqMsg: string, st: borrowed SymTab): string {
     var arraystr: string;
     var fields = reqMsg.split();
-    var entry = st.lookup(fields[2]);
     var tmpf: file;
     try {
+    var entry = st.lookup(fields[2]);
       tmpf = openmem();
       var tmpw = tmpf.writer(kind=iobig);
       if entry.dtype == DType.Int64 {
@@ -74,6 +83,8 @@ module GenSymIO {
 	return try! "Error: Unhandled dtype %s".format(entry.dtype);
       }
       tmpw.close();
+    } catch e: UndefinedSymbolError {
+      return unknownSymbolError("tondarrayMsg",e.name);
     } catch {
       try! tmpf.close();
       return "Error: Unable to write SymEntry to memory buffer";
@@ -206,6 +217,7 @@ module GenSymIO {
       }
     }
     const dataclass = dclasses[dclasses.domain.first];
+
     for (i, dc) in zip(dclasses.domain, dclasses) {
       if dc != dataclass {
 	return try! "Error: inconsistent dtype in dataset %s of file %s".format(dsetName, filenames[i]);
@@ -226,27 +238,42 @@ module GenSymIO {
     if GenSymIO_DEBUG {
       writeln("Got subdomains and total length");
     }
-    var entry: shared GenSymEntry;
+    try {
+    var entry: shared GenSymEntry = computeEntry(dataclass);
+    var rname = st.nextName();
+    st.addEntry(rname, entry);
+    return try! "created " + st.attrib(rname);
+    } catch e: UnhandledHDFSDataTypeError {
+      return try! "Error: detected unhandled datatype code %i".format(dataclass);
+    } catch {
+      return "Unexpected error";
+    }
+
+    class UnhandledHDFSDataTypeError: Error {
+    }
+
+    // This assumes that dataclass has already been validated above in
+    // validateDataClass() and that only expected dataclass values
+    // will be sent in.  If this is not the case, a halt occurs.
+    proc computeEntry(dataclass: C_HDF5.hid_t): shared GenSymEntry throws {
     if dataclass == C_HDF5.H5T_INTEGER {
       var entryInt = new shared SymEntry(len, int);
       if GenSymIO_DEBUG {
 	writeln("Initialized int entry"); try! stdout.flush();
       }
       read_files_into_distributed_array(entryInt.a, subdoms, filenames, dsetName);
-      entry = entryInt;
+      return entryInt;
     } else if dataclass == C_HDF5.H5T_FLOAT {
       var entryReal = new shared SymEntry(len, real);
       if GenSymIO_DEBUG {
 	writeln("Initialized float entry"); try! stdout.flush();
       }
       read_files_into_distributed_array(entryReal.a, subdoms, filenames, dsetName);
-      entry = entryReal;
+      return entryReal;
     } else {
-      return try! "Error: detected unhandled datatype code %i".format(dataclass);
+      throw new owned UnhandledHDFSDataTypeError();
     }
-    var rname = st.nextName();
-    st.addEntry(rname, entry);
-    return try! "created " + st.attrib(rname);
+  }
   }
   
   /* Get the class of the HDF5 datatype for the dataset. */
@@ -409,9 +436,9 @@ module GenSymIO {
     } catch {
       return try! "Error: could not decode json filenames via tempfile (%i files: %s)".format(1, jsonfile);
     }
-    var entry = st.lookup(arrayName);
     var warnFlag: bool;
     try {
+    var entry = st.lookup(arrayName);
     select entry.dtype {
       when DType.Int64 {
 	var e = toSymEntry(entry, int);
@@ -434,6 +461,8 @@ module GenSymIO {
       return try! "Error: unable to open file for writing: %s".format(filename);
     } catch e: MismatchedAppendError {
       return "Error: appending to existing files must be done with the same number of locales. Try saving with a different directory or filename prefix?";
+    } catch e: UndefinedSymbolError {
+      return try! "Error: lookup failed for %s".format(arrayName);
     } catch {
       return "Error: problem writing to file";
     }

--- a/src/HistogramMsg.chpl
+++ b/src/HistogramMsg.chpl
@@ -23,8 +23,8 @@ module HistogramMsg
         var rname = st.nextName();
         if v {try! writeln("%s %s %i : %s".format(cmd, name, bins, rname));try! stdout.flush();}
 
+        try {
         var gEnt: borrowed GenSymEntry = st.lookup(name);
-        if (gEnt == nil) {return unknownSymbolError("histogram",name);}
 
         // helper nested procedure
         proc histogramHelper(type t) {
@@ -58,6 +58,11 @@ module HistogramMsg
         }
         
         return try! "created " + st.attrib(rname);
+        } catch e: UndefinedSymbolError {
+          return unknownSymbolError("histogram",e.name);
+        } catch {
+          return unknownError("histogram");
+        }
     }
 
 

--- a/src/In1dMsg.chpl
+++ b/src/In1dMsg.chpl
@@ -41,10 +41,9 @@ module In1dMsg
         var rname = st.nextName();
         if v {try! writeln("%s %s %s %s : %s".format(cmd, name, sname, invert, rname));try! stdout.flush();}
 
+        try {
         var gAr1: borrowed GenSymEntry = st.lookup(name);
-        if (gAr1 == nil) {return unknownSymbolError("in1d",name);}
         var gAr2: borrowed GenSymEntry = st.lookup(sname);
-        if (gAr2 == nil) {return unknownSymbolError("in1d",sname);}
 
         select (gAr1.dtype, gAr2.dtype) {
             when (DType.Int64, DType.Int64) {
@@ -80,6 +79,11 @@ module In1dMsg
         }
         
         return try! "created " + st.attrib(rname);
+        } catch e: UndefinedSymbolError {
+          return unknownSymbolError("in1d",e.name);
+        } catch {
+          return unknownError("in1d");
+        }
     }
 
     

--- a/src/MsgProcessing.chpl
+++ b/src/MsgProcessing.chpl
@@ -277,8 +277,8 @@ module MsgProcessing
         var dtype = str2dtype(fields[3]);
         var value = fields[4];
 
+        try {
         var gEnt: borrowed GenSymEntry = st.lookup(name);
-        if (gEnt == nil) {return unknownSymbolError("set",name);}
 
         select (gEnt.dtype, dtype) {
             when (DType.Int64, DType.Int64) {
@@ -353,7 +353,11 @@ module MsgProcessing
             otherwise {return unrecognizedTypeError("set",fields[3]);}
         }
         return repMsg;
-    }
-    
+        } catch e: UndefinedSymbolError {
+          return unknownSymbolError("set",name);
+        } catch {
+          return unknownError("set");
+        }
 
+    }
 }

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -32,10 +32,9 @@ module OperatorMsg
         var rname = st.nextName();
         if v {try! writeln("%s %s %s %s : %s".format(cmd,op,aname,bname,rname));try! stdout.flush();}
 
+        try {
         var left: borrowed GenSymEntry = st.lookup(aname);
-        if (left == nil) {return try! "Error: binopvv: unkown symbol %s".format(aname);}
         var right: borrowed GenSymEntry = st.lookup(bname);
-        if (right == nil) {return try! "Error: binopvv: unkown symbol %s".format(bname);}
 
         select (left.dtype, right.dtype) {
             when (DType.Int64, DType.Int64) {
@@ -428,6 +427,12 @@ module OperatorMsg
             otherwise {return unrecognizedTypeError("binopvv",
                                                     "("+dtype2str(left.dtype)+","+dtype2str(right.dtype)+")");}
         }
+        } catch e: UndefinedSymbolError {
+          return try! "Error: binopvv: unknown symbol %s".format(e.name);
+        } catch {
+          return unknownError("binopvv");
+        }
+
         return try! "created " + st.attrib(rname);
     }
     /*
@@ -453,8 +458,8 @@ module OperatorMsg
         var rname = st.nextName();
         if v {try! writeln("%s %s %s %s %s : %s".format(cmd,op,aname,dtype2str(dtype),value,rname));try! stdout.flush();}
 
+        try {
         var left: borrowed GenSymEntry = st.lookup(aname);
-        if (left == nil) {return try! "Error: binopvs: unkown symbol %s".format(aname);}
         select (left.dtype, dtype) {
             when (DType.Int64, DType.Int64) {
                 var l = toSymEntry(left,int);
@@ -842,6 +847,11 @@ module OperatorMsg
                                                     "("+dtype2str(left.dtype)+","+dtype2str(dtype)+")");}
         }
         return try! "created " + st.attrib(rname);
+        } catch e: UndefinedSymbolError {
+          return try! "Error: binopvs: unkown symbol %s".format(aname);
+        } catch {
+          return unknownError("binopvs");
+        }
     }
 
     /*
@@ -867,6 +877,7 @@ module OperatorMsg
         var rname = st.nextName();
         if v {try! writeln("%s %s %s %s %s : %s".format(cmd,op,dtype2str(dtype),value,aname,rname));try! stdout.flush();}
 
+        try {
         var right: borrowed GenSymEntry = st.lookup(aname);
         if (right == nil) {return try! "Error: binopsv: unkown symbol %s".format(aname);}
         select (dtype, right.dtype) {
@@ -1252,6 +1263,12 @@ module OperatorMsg
                                                     "("+dtype2str(dtype)+","+dtype2str(right.dtype)+")");}
         }
         return try! "created " + st.attrib(rname);
+        } catch e: UndefinedSymbolError {
+          return try! "Error: binopsv: unkown symbol %s".format(aname);
+        } catch {
+          return unknownError("binopsv");
+        }
+
     }
 
     /*
@@ -1274,11 +1291,10 @@ module OperatorMsg
         var aname = fields[3];
         var bname = fields[4];
         if v {try! writeln("%s %s %s %s".format(cmd,op,aname,bname));try! stdout.flush();}
-        
+
+        try {
         var left: borrowed GenSymEntry = st.lookup(aname);
-        if (left == nil) {return unknownSymbolError("opeqvv",aname);}
         var right: borrowed GenSymEntry = st.lookup(bname);
-        if (right == nil) {return unknownSymbolError("opeqvv",bname);}
         select (left.dtype, right.dtype) {
             when (DType.Int64, DType.Int64) {
                 var l = toSymEntry(left,int);
@@ -1387,6 +1403,11 @@ module OperatorMsg
             otherwise {return unrecognizedTypeError("opeqvv",
                                                     "("+dtype2str(left.dtype)+","+dtype2str(right.dtype)+")");}
         }
+        } catch e: UndefinedSymbolError {
+          return try! "Error: opeqvv: unkown symbol %s".format(aname);
+        } catch {
+          return unknownError("opeqvv");
+        }
         return "opeqvv success";
     }
 
@@ -1413,8 +1434,8 @@ module OperatorMsg
         var value = fields[5];
         if v {try! writeln("%s %s %s %s %s".format(cmd,op,aname,dtype2str(dtype),value));try! stdout.flush();}
 
+        try {
         var left: borrowed GenSymEntry = st.lookup(aname);
-        if (left == nil) {return unknownSymbolError("opeqvs",aname);}
 
         select (left.dtype, dtype) {
             when (DType.Int64, DType.Int64) {
@@ -1516,6 +1537,11 @@ module OperatorMsg
 	    }
             otherwise {return unrecognizedTypeError("opeqvs",
                                                     "("+dtype2str(left.dtype)+","+dtype2str(dtype)+")");}
+        }
+        } catch e: UndefinedSymbolError {
+          return try! "Error: opeqvs: unkown symbol %s".format(aname);
+        } catch {
+          return unknownError("opeqvs");
         }
         return "opeqvs success";
     }

--- a/src/ServerErrorStrings.chpl
+++ b/src/ServerErrorStrings.chpl
@@ -45,6 +45,10 @@ module ServerErrorStrings
         return try! "Error: %s: unkown symbol: %s".format(pname, sname);
     }
 
+    proc unknownError(pname: string): string {
+      return try! "Error: %s: unexpected error".format(pname);
+    }
+
     /* incompatible arguments */
     proc incompatibleArgumentsError(pname: string, reason: string) {
       return try! "Error: %s: Incompatible arguments: %s".format(pname, reason);

--- a/src/UniqueMsg.chpl
+++ b/src/UniqueMsg.chpl
@@ -40,9 +40,9 @@ module UniqueMsg
         // get next symbol anme for counts
         var cname = st.nextName();
         if v {try! writeln("%s %s %t: %s %s".format(cmd, name, returnCounts, vname, cname));try! stdout.flush();}
-        
+
+        try {
         var gEnt: borrowed GenSymEntry = st.lookup(name);
-        if (gEnt == nil) {return unknownSymbolError(pn,name);}
         
         select (gEnt.dtype) {
             when (DType.Int64) {
@@ -80,6 +80,12 @@ module UniqueMsg
         if returnCounts {s += " +created " + st.attrib(cname);}
 
         return s;
+        } catch e: UndefinedSymbolError {
+          return unknownSymbolError(pn,e.name);
+        } catch {
+          return unknownError(pn);
+        }
+
     }
     
     /* value_counts takes a pdarray and returns two pdarrays unique values and counts for each value */
@@ -95,8 +101,8 @@ module UniqueMsg
         var cname = st.nextName();
         if v {try! writeln("%s %s : %s %s".format(cmd, name, vname, cname));try! stdout.flush();}
 
+        try {
         var gEnt: borrowed GenSymEntry = st.lookup(name);
-        if (gEnt == nil) {return unknownSymbolError(pn,name);}
 
         select (gEnt.dtype) {
             when (DType.Int64) {
@@ -135,6 +141,12 @@ module UniqueMsg
         }
         
         return try! "created " + st.attrib(vname) + " +created " + st.attrib(cname);
+        } catch e: UndefinedSymbolError {
+          return unknownSymbolError(pn,e.name);
+        } catch {
+          return unknownError(pn);
+        }
+
     }
 
 }


### PR DESCRIPTION
This is a first stab at converting Arkouda over to using nilable
vs. non-nilable classes.  Generally speaking, the approach I took was
to use non-nilable classes for the most part and to rely on throwing
and catching errors to handle failed lookups or conversions.  This
had the upside of living primarily in the non-nilable world of features,
but the downside of requiring catches to be put throughout the
code (and, being a bit paranoid, I always did this with a very specific
catch block for the error I anticipated and a catch-all "just in case"
which made things messier...  I'm definitely open to different ideas
here).

Note that I didn't worry much about getting indenting "right" in order to
try and minimize the diff against master for the sake of comparison by
human reviewers of this PR. If we go forward with this PR, I can update the
indentation either before or after merging.

At this point, I'm opening this PR to get feedback on the approach
taken and whether the arkouda keepers would like to see a different
approach or any other minor changes.
