### PR TITLE
Update python examples

### DIFF
--- a/benchmarks/argsort.py
+++ b/benchmarks/argsort.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     if args.dtype not in ('int64', 'float64'):
         raise ValueError("Dtype must be either int64 or float64, not {}".format(args.dtype))
-    ak.v = False
+    ak.verbose = False
     ak.connect(args.hostname, args.port)
     
     print("array size = {:,}".format(args.size))

--- a/benchmarks/gather.py
+++ b/benchmarks/gather.py
@@ -92,7 +92,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     if args.dtype not in ('int64', 'float64'):
         raise ValueError("Dtype must be either int64 or float64, not {}".format(args.dtype))
-    ak.v = False
+    ak.verbose = False
     ak.connect(args.hostname, args.port)
     
     print("size of index array = {:,}".format(args.index_size))

--- a/benchmarks/reduce.py
+++ b/benchmarks/reduce.py
@@ -85,7 +85,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     if args.dtype not in ('int64', 'float64'):
         raise ValueError("Dtype must be either int64 or float64, not {}".format(args.dtype))
-    ak.v = False
+    ak.verbose = False
     ak.connect(args.hostname, args.port)
     
     print("array size = {:,}".format(args.size))

--- a/benchmarks/scan.py
+++ b/benchmarks/scan.py
@@ -85,7 +85,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     if args.dtype not in ('int64', 'float64'):
         raise ValueError("Dtype must be either int64 or float64, not {}".format(args.dtype))
-    ak.v = False
+    ak.verbose = False
     ak.connect(args.hostname, args.port)
     
     print("array size = {:,}".format(args.size))

--- a/benchmarks/scatter.py
+++ b/benchmarks/scatter.py
@@ -99,7 +99,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     if args.dtype not in ('int64', 'float64'):
         raise ValueError("Dtype must be either int64 or float64, not {}".format(args.dtype))
-    ak.v = False
+    ak.verbose = False
     ak.connect(args.hostname, args.port)
     
     print("size of index array = {:,}".format(args.index_size))

--- a/benchmarks/stream.py
+++ b/benchmarks/stream.py
@@ -92,7 +92,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     if args.dtype not in ('int64', 'float64'):
         raise ValueError("Dtype must be either int64 or float64, not {}".format(args.dtype))
-    ak.v = False
+    ak.verbose = False
     ak.connect(args.hostname, args.port)
     
     print("array size = {:,}".format(args.size))

--- a/tests/check.py
+++ b/tests/check.py
@@ -10,7 +10,7 @@ import arkouda as ak
 
 print(">>> Sanity checks on the arkouda_server")
 
-ak.v = False
+ak.verbose = False
 if len(sys.argv) > 1:
     ak.connect(server=sys.argv[1], port=sys.argv[2])
 else:

--- a/tests/deprecated/IOtest.py
+++ b/tests/deprecated/IOtest.py
@@ -4,7 +4,7 @@ import sys, time, argparse
 import arkouda as ak
 
 if __name__ == '__main__':
-    ak.v = False
+    ak.verbose = False
     parser = argparse.ArgumentParser()
     parser.add_argument('--server', default=None)
     parser.add_argument('--port', default=None)

--- a/tests/deprecated/ak_add_sub.py
+++ b/tests/deprecated/ak_add_sub.py
@@ -8,7 +8,7 @@ import sys
 
 import arkouda as ak
 
-ak.v = False
+ak.verbose = False
 if len(sys.argv) > 1:
     ak.connect(server=sys.argv[1], port=sys.argv[2])
 else:

--- a/tests/deprecated/ak_test.py
+++ b/tests/deprecated/ak_test.py
@@ -8,7 +8,7 @@ import sys
 
 import arkouda as ak
 
-ak.v = False
+ak.verbose = False
 if len(sys.argv) > 1:
     ak.connect(server=sys.argv[1], port=sys.argv[2])
 else:
@@ -69,13 +69,13 @@ b = ak.zeros(iv.size,dtype=ak.int64)
 a[iv] = b
 print(a)
 
-ak.v = False
+ak.verbose = False
 a = ak.randint(10,30,40)
 vc = ak.value_counts(a)
 print(vc[0].size,vc[0])
 print(vc[1].size,vc[1])
 
-ak.v = False
+ak.verbose = False
 
 a = ak.arange(0,10,1)
 b = a[a<5]
@@ -83,12 +83,12 @@ a = ak.linspace(0,9,10)
 b = a[a<5]
 print(b)
 
-ak.v = True
+ak.verbose = True
 ak.pdarrayIterThresh = 1000
 a = ak.arange(0,10,1)
 print(list(a))
 
-ak.v = False
+ak.verbose = False
 a = ak.randint(10,30,40)
 u = ak.unique(a)
 h = ak.histogram(a,bins=20)
@@ -96,28 +96,28 @@ print(a)
 print(h.size,h)
 print(u.size,u)
 
-ak.v = False
+ak.verbose = False
 a = ak.randint(10,30,50)
 h = ak.histogram(a,bins=20)
 print(a)
 print(h)
 
-ak.v = False
+ak.verbose = False
 a = ak.randint(0,2,50,dtype=ak.bool)
 print(a)
 print(a.sum())
 
-ak.v = False
+ak.verbose = False
 a = ak.linspace(101,102,100)
 h = ak.histogram(a,bins=50)
 print(h)
 
-ak.v = False
+ak.verbose = False
 a = ak.arange(0,100,1)
 h = ak.histogram(a,bins=10)
 print(h)
 
-ak.v = False
+ak.verbose = False
 a = ak.arange(0,99,1)
 b = a[::10] # take every tenth one
 b = b[::-1] # reverse b
@@ -127,13 +127,13 @@ c = ak.in1d(a,b) # put out truth vector
 print(c)
 print(a[c]) # compress out false values
 
-ak.v = False
+ak.verbose = False
 a = np.ones(10,dtype=np.bool)
 b = np.arange(0,10,1)
 
 np.sum(a),np.cumsum(a),np.sum(b<4),b[b<4],b<5
 
-ak.v = False
+ak.verbose = False
 # currently... ak pdarray to np array
 a = ak.linspace(0,9,10)
 b = np.array(list(a))
@@ -147,39 +147,39 @@ a = ak.ones(10,dtype=ak.bool)
 b = np.array(list(a))
 print(a,a.dtype,b,b.dtype)
 
-ak.v = False
+ak.verbose = False
 
 b = np.linspace(1,10,10)
 a = np.arange(1,11,1)
 print(b/a)
 
-ak.v = False
+ak.verbose = False
 
 #a = np.ones(10000,dtype=np.int64)
 a = np.linspace(0,99,100)
 #a = np.arange(0,100,1)
 print(a)
 
-ak.v = False
+ak.verbose = False
 print(a.__repr__())
 print(a.__str__())
 
-ak.v = False
+ak.verbose = False
 print(a)
 print(type(a), a.dtype, a.size, a.ndim, a.shape, a.itemsize)
 
-ak.v = False
+ak.verbose = False
 a = ak.arange(0,100,1)
 
-ak.v = False
+ak.verbose = False
 print(a)
 
-ak.v = False
+ak.verbose = False
 
 b = ak.linspace(0,99,100)
 print(b.__repr__())
 
-ak.v = False
+ak.verbose = False
 b = ak.linspace(0,9,10)
 a = ak.arange(0,10,1)
 print(a.name, a.size, a.dtype, a)
@@ -187,14 +187,14 @@ print(b.name, b.size, b.dtype, b)
 print(ak.info(a+b))
 
 
-ak.v = False
+ak.verbose = False
 
 c = ak.arange(0,10,1)
 print(ak.info(c))
 print(c.name, c.dtype, c.size, c.ndim, c.shape, c.itemsize)
 print(c)
 
-ak.v = False
+ak.verbose = False
 
 print(5+c + 5)
 
@@ -202,7 +202,7 @@ c = np.array([10, 11, 12, 13, 14, 15, 16, 17, 18, 19])
 c = np.array([10, 11, 12, 13, 14, 15, 16, 17, 18, 19.1])
 print(c.__repr__(), c.dtype.__str__(), c.dtype.__repr__())
 
-ak.v = False
+ak.verbose = False
 a = np.ones(9)
 b = np.arange(1,10,1)
 print(a.dtype,b.dtype)
@@ -218,7 +218,7 @@ z = c//d
 print("floordiv \nnp out:",y,"\nak out:",z)
 print(y[5],z[5],y[5] ==z[5])
 
-ak.v = False
+ak.verbose = False
 
 c = ak.arange(1,10,1)
 c //= c
@@ -228,26 +228,26 @@ print(c)
 c *= c
 print(c)
 
-ak.v = False
+ak.verbose = False
 
 a = np.ones(9,dtype=np.int64)
 b = np.ones_like(a)
 print(b)
 
-ak.v = False
+ak.verbose = False
 
 a = ak.ones(9,dtype=ak.int64)
 b = ak.ones_like(a)
 print(b)
 
-ak.v = False
+ak.verbose = False
 
 a = ak.arange(0,10,1)
 b = np.arange(0,10,1)
 
 print(a[5] == b[5])
 
-ak.v = False
+ak.verbose = False
 
 a = ak.arange(0,10,1)
 b = np.arange(0,10,1)
@@ -255,7 +255,7 @@ b = np.arange(0,10,1)
 a[5] = 10.2
 print(a[5])
 
-ak.v = False
+ak.verbose = False
 
 a = ak.arange(0,10,1)
 b = np.arange(0,10,1)
@@ -265,23 +265,23 @@ b = np.arange(0,10,1)
 print(a[4:20:-1],b[4:20:-1])
 print(a[:1:-1],b[:1:-1])
 
-ak.v = False
+ak.verbose = False
 d = ak.arange(1,10,1)
 #d.type.__class__,d.name,d.isnative,np.int64.__class__,bool
 ak.info(d)
 #dir(d)
 
-ak.v = False
+ak.verbose = False
 
 a = ak.ones(10,dtype=ak.bool)
 print(a[1])
 
-ak.v = False
+ak.verbose = False
 
 a = ak.zeros(10,dtype=ak.bool)
 print(a[1])
 
-ak.v = False
+ak.verbose = False
 a = ak.ones(10,dtype=ak.bool)
 a[4] = False
 a[1] = False
@@ -301,7 +301,7 @@ print(a)
 print(a[::2])
 print(a[1])
 
-ak.v = False
+ak.verbose = False
 
 a = ak.arange(0,10,1)
 b = list(a)
@@ -311,7 +311,7 @@ a = a<5
 b = list(a)
 print(b)
 
-ak.v = False
+ak.verbose = False
 a = ak.linspace(1,10,10)
 print(ak.abs(a))
 print(ak.log(a))
@@ -321,7 +321,7 @@ print(ak.log(a))
 
 type(bool),type(np.bool),type(ak.bool),type(True)
 
-ak.v = False
+ak.verbose = False
 a = ak.linspace(0,9,10)
 print(a,ak.any(a),ak.all(a),ak.all(ak.ones(10,dtype=ak.float64)))
 b = a<5
@@ -330,18 +330,18 @@ c = ak.arange(0,10,1)
 print(c,ak.any(c),ak.all(c),ak.all(ak.ones(10,dtype=ak.int64)))
 print(a.any(),a.all(),b.any(),b.all())
 
-ak.v = False
+ak.verbose = False
 a = ak.linspace(0,9,10)
 ak.sum(a)
 b = np.linspace(0,9,10)
 print(ak.sum(a) == np.sum(b),ak.sum(a),np.sum(b),a.sum(),b.sum())
 
-ak.v = False
+ak.verbose = False
 a = ak.linspace(1,10,10)
 b = np.linspace(1,10,10)
 print(ak.prod(a) == np.prod(b),ak.prod(a),np.prod(b),a.prod(),b.prod())
 
-ak.v = False
+ak.verbose = False
 
 a = np.arange(0,20,1)
 b = a<10
@@ -356,48 +356,48 @@ print(b,ak.sum(b),b.sum(),ak.prod(b),b.prod(),ak.cumsum(b),ak.cumprod(b))
 b = a<5
 print(b,ak.sum(b),b.sum(),ak.prod(b),b.prod(),ak.cumsum(b),ak.cumprod(b))
 
-ak.v = False
+ak.verbose = False
 a = ak.arange(0,10,1)
 iv = a[::-1]
 print(a,iv,a[iv])
 
-ak.v = False
+ak.verbose = False
 a = ak.arange(0,10,1)
 iv = a[::-1]
 print(a,iv,a[iv])
 
-ak.v = False
+ak.verbose = False
 a = ak.linspace(0,9,10)
 iv = ak.arange(0,10,1)
 iv = iv[::-1]
 print(a,iv,a[iv])
 
-ak.v = False
+ak.verbose = False
 a = np.arange(0,10,1)
 iv = a[::-1]
 print(a,iv,a[iv])
 
-ak.v = False
+ak.verbose = False
 a = ak.arange(0,10,1)
 b = a<20
 print(a,b,a[b])
 
-ak.v = False
+ak.verbose = False
 a = ak.arange(0,10,1)
 b = a<5
 print(a,b,a[b])
 
-ak.v = False
+ak.verbose = False
 a = ak.arange(0,10,1)
 b = a<0
 print(a,b,a[b])
 
-ak.v = False
+ak.verbose = False
 a = ak.linspace(0,9,10)
 b = a<5
 print(a,b,a[b])
 
-ak.v = False
+ak.verbose = False
 N = 2**23 # 2**23 * 8 == 64MiB
 A = ak.linspace(0,N-1,N)
 B = ak.linspace(0,N-1,N)
@@ -406,7 +406,7 @@ C = A+B
 print(ak.info(C),C)
 
 # turn off verbose messages from arkouda package
-ak.v = False
+ak.verbose = False
 # set pdarrayIterThresh to 0 to only print the first 3 and last 3 of pdarray
 ak.pdarrayIterThresh = 0
 a = ak.linspace(0,9,10)
@@ -423,7 +423,7 @@ print(b)
 print(a[b])
 print(a)
 
-ak.v = False
+ak.verbose = False
 ak.pdarrayIterThresh = 0
 
 a = ak.ones(10,ak.int64)

--- a/tests/deprecated/lanl_io_test.py
+++ b/tests/deprecated/lanl_io_test.py
@@ -4,7 +4,7 @@ import sys, time, argparse
 import arkouda as ak
 
 if __name__ == '__main__':
-    ak.v = False
+    ak.verbose = False
     parser = argparse.ArgumentParser()
     parser.add_argument('--server', default=None)
     parser.add_argument('--port', default=None)
@@ -13,7 +13,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     ak.set_defaults()
-    ak.v = False
+    ak.verbose = False
     if args.server is not None:
         if args.port is not None:
             ak.connect(server=args.server, port=args.port)

--- a/tests/setops_test.py
+++ b/tests/setops_test.py
@@ -12,7 +12,7 @@ if __name__ == "__main__":
     parser.add_argument('-n', '--size', type=int, default=10**6, help='Problem size: length of array to argsort')
 
     args = parser.parse_args()
-    ak.v = False
+    ak.verbose = False
     ak.connect(args.hostname, args.port)
     print("size = ",args.size)
     SIZE = args.size

--- a/toys/ak_bfs_conn_comp.py
+++ b/toys/ak_bfs_conn_comp.py
@@ -109,7 +109,7 @@ if __name__ == "__main__":
     
     args = parser.parse_args()
 
-    ak.v = False
+    ak.verbose = False
     ak.connect(args.hostname, args.port)
 
     print((args.lgNv, args.Ne_per_v, args.prob, args.perm, args.pl))


### PR DESCRIPTION
changes `ak.v` to `ak.verbose` in python benchmarks, tests, and examples
I think I got them all but if there are more call them out and I will add them to this PR 