### PR TITLE
Don't use --cache-remote with ugni

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,14 @@ VERBOSE ?= 0
 
 CHPL := chpl
 CHPL_DEBUG_FLAGS += --print-passes
-CHPL_FLAGS += --cache-remote --fast --legacy-classes
+CHPL_FLAGS += --fast --legacy-classes
 CHPL_FLAGS += -lhdf5 -lhdf5_hl -lzmq
+
+# --cache-remote does not work with ugni in Chapel 1.20
+COMM = $(shell $(CHPL_HOME)/util/chplenv/chpl_comm.py 2>/dev/null)
+ifneq ($(COMM),ugni)
+CHPL_FLAGS += --cache-remote
+endif
 
 # add-path: Append custom paths for non-system software.
 # Note: Darwin `ld` only supports `-rpath <path>`, not `-rpath=<paths>`.


### PR DESCRIPTION
`--cache-remote` does not work with `CHPL_COMM=ugni` in Chapel 1.20.
This was fixed in chapel-lang/chapel#14329 and should be included in the
next Chapel release, but until then avoid using it.