### PR TITLE
Cleanup local build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,20 +71,13 @@ pip3 install jupyter
 ### If you need to build Chapel from scratch here is what I use
 ```bash
 # on my mac build chapel in my home directory with these settings...
-# I don't understand them all but they seem to work
 export CHPL_HOME=~/chapel/chapel-1.20.0
 source $CHPL_HOME/util/setchplenv.bash
 export CHPL_COMM=gasnet
 export CHPL_COMM_SUBSTRATE=smp
-export CHPL_GASNET_CFG_OPTIONS=--disable-ibv
 export CHPL_TARGET_CPU=native
-export GASNET_SPAWNFN=L
-export GASNET_ROUTE_OUTPUT=0
 export GASNET_QUIET=Y
-export GASNET_MASTERIP=127.0.0.1
-# Set these to help with oversubscription...
-export QT_AFFINITY=no
-export CHPL_QTHREAD_ENABLE_OVERSUBSCRIPTION=1
+export CHPL_RT_OVERSUBSCRIBED=yes
 cd $CHPL_HOME
 make
 ```


### PR DESCRIPTION
Cleanup local build instructions

The old options work and shouldn't cause any problems, but most of them
aren't needed or have better alternatives in in 1.20:

- `QT_AFFINITY=no CHPL_QTHREAD_ENABLE_OVERSUBSCRIPTION=1` -- used to
   limit interference from concurrent Chapel runtimes when running
   oversubscribed. Replaced with `CHPL_RT_OVERSUBSCRIBED=yes` in 1.20

* `CHPL_GASNET_CFG_OPTIONS=--disable-ibv` -- the Chapel team sets this
   internally when we want to test gasnet-udp on a system with
   InfiniBand, but generally speaking this isn't needed
* `GASNET_SPAWNFN=L` -- this is only needed for gasnet-udp. It spawns
   locales locally instead of via ssh. This is not needed for
   gasnet-smp, which will always spawn locally.
* `GASNET_ROUTE_OUTPUT=0` -- also gasnet-udp only, deals with routing
   stdout/stderr from locales back to the console.
* `GASNET_MASTERIP=127.0.0.1` -- also udp only. Usually, you have to set
   this if you're on a VPN and are having problems with local spawning.