### PR TITLE
Fixed socket behavior on interrupt

### DIFF
--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1,7 +1,7 @@
 import json, struct
 import numpy as np
 
-from arkouda.client import generic_msg, connected, verbose, maxTransferBytes, pdarrayIterThresh
+from arkouda.client import generic_msg, verbose, maxTransferBytes, pdarrayIterThresh
 from arkouda.dtypes import *
 from arkouda.dtypes import structDtypeCodes, NUMBER_FORMAT_STRINGS
 
@@ -65,9 +65,10 @@ class pdarray:
         self.itemsize = itemsize
 
     def __del__(self):
-        global connected
-        if connected:
+        try:
             generic_msg("delete {}".format(self.name))
+        except:
+            pass
 
     def __len__(self):
         return self.shape[0]


### PR DESCRIPTION
I updated `arkouda/client.py` to handle connections a bit more cleanly:
* The biggest thing is that now, when a user hits Ctrl+C during execution of a server command, the connection to the server is automatically re-established (by resetting the socket)
* The other major change is that, if the client is not connected to a server, `generic_msg` will raise an exception instead of hanging.
* The `connect()` function now forces re-connection, even when the `connected` flag is set. Before, it would just do a no-op, which was confusing in situations when the connection was lost but the `connected` flag remained set. There does not appear to be any issue with re-connecting an active socket.
* Connection-related functions now print the server-generated messages, instead of messages hard-coded into the client

I have tested the interrupt behavior in an interactive python session. I have also tested this change with the following scripts:
* `tests/check.py`
* `tests/operator_tests.py`
* `tests/groupby_test.py
* `tests/setops_test.py`
* `tests/where_test.py`
* `benchmarks/stream.py`
* `benchmarks/gather.py`