### PR TITLE
Make Arkouda nilable-ready

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ VERBOSE ?= 0
 
 CHPL := chpl
 CHPL_DEBUG_FLAGS += --print-passes
-CHPL_FLAGS += --fast --legacy-classes
+CHPL_FLAGS += --fast
 CHPL_FLAGS += -lhdf5 -lhdf5_hl -lzmq
 
 # --cache-remote does not work with ugni in Chapel 1.20

--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -448,7 +448,6 @@ module ArgSortMsg
 	  return try! "Error: %s unknown cause".format(pn);
 	}
       }
-
       return try! "created " + st.attrib(rname);
     }
     
@@ -491,7 +490,6 @@ module ArgSortMsg
         }
         
         return try! "created " + st.attrib(ivname);
-
     }
 
     /* localArgsort takes a pdarray and returns an index vector which sorts the array on a per-locale basis */
@@ -517,7 +515,6 @@ module ArgSortMsg
 	    otherwise {return notImplementedError(pn,gEnt.dtype);}
 	}
 	return try! "created " + st.attrib(ivname);
-
     }
     
     proc perLocaleArgSort(a:[?aD] int):[aD] int {

--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -409,7 +409,7 @@ module ArgSortMsg
     /* Find the permutation that sorts multiple arrays, treating each array as a
        new level of the sorting key.
      */
-    proc coargsortMsg(reqMsg: string, st: borrowed SymTab) {
+    proc coargsortMsg(reqMsg: string, st: borrowed SymTab) throws {
       param pn = Reflection.getRoutineName();
       var repMsg: string;
       var fields = reqMsg.split();
@@ -422,7 +422,6 @@ module ArgSortMsg
       var size: int;
       // Check that all arrays exist in the symbol table and have the same size
       for (name, i) in zip(names, 1..) {
-        try {
 	// arrays[i] = st.lookup(name): borrowed GenSymEntry;
 	var g: borrowed GenSymEntry = st.lookup(name);
 	if (i == 1) {
@@ -430,16 +429,10 @@ module ArgSortMsg
 	} else {
 	  if (g.size != size) { return incompatibleArgumentsError(pn, "Arrays must all be same size"); }
 	}
-        } catch (e: UndefinedSymbolError) {
-          return unknownSymbolError(pn, name);
-        } catch {
-          return unknownError(pn);
-        }
       }
       // Initialize the permutation vector in the symbol table with the identity perm
       var rname = st.nextName();
       st.addEntry(rname, size, int);
-      try {
       var iv = toSymEntry(st.lookup(rname), int);
       iv.a = 0..#size;
       // Starting with the last array, incrementally permute the IV by sorting each array
@@ -454,11 +447,6 @@ module ArgSortMsg
 	} catch {
 	  return try! "Error: %s unknown cause".format(pn);
 	}
-      }
-      } catch e: UndefinedSymbolError {
-        return unknownSymbolError(pn, rname);
-      } catch {
-        return unknownError(pn);
       }
 
       return try! "created " + st.attrib(rname);
@@ -475,7 +463,7 @@ module ArgSortMsg
     }
     
     /* argsort takes pdarray and returns an index vector iv which sorts the array */
-    proc argsortMsg(reqMsg: string, st: borrowed SymTab): string {
+    proc argsortMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
         var fields = reqMsg.split(); // split request into fields
@@ -486,7 +474,6 @@ module ArgSortMsg
         var ivname = st.nextName();
         if v {try! writeln("%s %s : %s %s".format(cmd, name, ivname));try! stdout.flush();}
 
-        try {
         var gEnt: borrowed GenSymEntry = st.lookup(name);
 
         select (gEnt.dtype) {
@@ -504,16 +491,11 @@ module ArgSortMsg
         }
         
         return try! "created " + st.attrib(ivname);
-        } catch e: UndefinedSymbolError {
-          return unknownSymbolError(pn,e.name);
-        } catch {
-          return unknownError(pn);
-        }
 
     }
 
     /* localArgsort takes a pdarray and returns an index vector which sorts the array on a per-locale basis */
-    proc localArgsortMsg(reqMsg: string, st: borrowed SymTab): string {
+    proc localArgsortMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
         var fields = reqMsg.split(); // split request into fields
@@ -524,7 +506,6 @@ module ArgSortMsg
         var ivname = st.nextName();
         if v {try! writeln("%s %s : %s %s".format(cmd, name, ivname));try! stdout.flush();}
 
-        try {
         var gEnt: borrowed GenSymEntry = st.lookup(name);
 
         select (gEnt.dtype) {
@@ -536,11 +517,6 @@ module ArgSortMsg
 	    otherwise {return notImplementedError(pn,gEnt.dtype);}
 	}
 	return try! "created " + st.attrib(ivname);
-        } catch e: UndefinedSymbolError {
-          return unknownSymbolError(pn,name);
-        } catch {
-          return unknownError(pn);
-        }
 
     }
     

--- a/src/ConcatenateMsg.chpl
+++ b/src/ConcatenateMsg.chpl
@@ -15,7 +15,7 @@ module ConcatenateMsg
     /* Concatenate a list of arrays together
        to form one array
      */
-    proc concatenateMsg(reqMsg: string, st: borrowed SymTab) {
+    proc concatenateMsg(reqMsg: string, st: borrowed SymTab) throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string;
         var fields = reqMsg.split();
@@ -29,7 +29,6 @@ module ConcatenateMsg
         var dtype: DType;
         // Check that all arrays exist in the symbol table and have the same size
         for (name, i) in zip(names, 1..) {
-          try {
             // arrays[i] = st.lookup(name): borrowed GenSymEntry;
             var g: borrowed GenSymEntry = st.lookup(name);
             if (i == 1) {dtype = g.dtype;}
@@ -40,11 +39,6 @@ module ConcatenateMsg
             }
             // accumulate size from each array size
             size += g.size;
-          } catch e: UndefinedSymbolError {
-            return unknownSymbolError(pn,name);
-          } catch {
-            return unknownError(pn);
-          }
         }
         // allocate a new array in the symboltable
         // and copy in arrays
@@ -57,7 +51,6 @@ module ConcatenateMsg
                 var end: int;
                 start = 0;
                 for (name, i) in zip(names, 1..) {
-                  try {
                     // lookup and cast operand to copy from
                     var o = toSymEntry(st.lookup(name), int);
                     // calculate end which is inclusive
@@ -66,11 +59,6 @@ module ConcatenateMsg
                     e.a[{start..end}] = o.a;
                     // update new start for next array copy
                     start += o.size;
-                  } catch e: UndefinedSymbolError {
-                    return unknownSymbolError(pn,name);
-                  } catch {
-                    return unknownError(pn);
-                  }
                 }
             }
             when DType.Float64 {
@@ -80,7 +68,6 @@ module ConcatenateMsg
                 var end: int;
                 start = 0;
                 for (name, i) in zip(names, 1..) {
-                  try {
                     // lookup and cast operand to copy from
                     var o = toSymEntry(st.lookup(name), real);
                     // calculate end which is inclusive
@@ -89,11 +76,6 @@ module ConcatenateMsg
                     e.a[{start..end}] = o.a;
                     // update new start for next array copy
                     start += o.size;
-                  } catch e: UndefinedSymbolError {
-                    return unknownSymbolError(pn,name);
-                  } catch {
-                    return unknownError(pn);
-                  }
                 }
             }
             when DType.Bool {
@@ -103,7 +85,6 @@ module ConcatenateMsg
                 var end: int;
                 start = 0;
                 for (name, i) in zip(names, 1..) {
-                  try {
                     // lookup and cast operand to copy from
                     var o = toSymEntry(st.lookup(name), bool);
                     // calculate end which is inclusive
@@ -112,11 +93,6 @@ module ConcatenateMsg
                     e.a[{start..end}] = o.a;
                     // update new start for next array copy
                     start += o.size;
-                  } catch e: UndefinedSymbolError {
-                    return unknownSymbolError(pn,name);
-                  } catch {
-                    return unknownError(pn);
-                  }
                 }
             }
             otherwise {return notImplementedError("concatenate",dtype);}

--- a/src/ConcatenateMsg.chpl
+++ b/src/ConcatenateMsg.chpl
@@ -28,9 +28,9 @@ module ConcatenateMsg
         var dtype: DType;
         // Check that all arrays exist in the symbol table and have the same size
         for (name, i) in zip(names, 1..) {
+          try {
             // arrays[i] = st.lookup(name): borrowed GenSymEntry;
             var g: borrowed GenSymEntry = st.lookup(name);
-            if (g == nil) { return unknownSymbolError(pn, name); }
             if (i == 1) {dtype = g.dtype;}
             else {
                 if (dtype != g.dtype) {
@@ -39,6 +39,11 @@ module ConcatenateMsg
             }
             // accumulate size from each array size
             size += g.size;
+          } catch e: UndefinedSymbolError {
+            return unknownSymbolError(pn,name);
+          } catch {
+            return unknownError(pn);
+          }
         }
         // allocate a new array in the symboltable
         // and copy in arrays
@@ -51,6 +56,7 @@ module ConcatenateMsg
                 var end: int;
                 start = 0;
                 for (name, i) in zip(names, 1..) {
+                  try {
                     // lookup and cast operand to copy from
                     var o = toSymEntry(st.lookup(name), int);
                     // calculate end which is inclusive
@@ -59,6 +65,11 @@ module ConcatenateMsg
                     e.a[{start..end}] = o.a;
                     // update new start for next array copy
                     start += o.size;
+                  } catch e: UndefinedSymbolError {
+                    return unknownSymbolError(pn,name);
+                  } catch {
+                    return unknownError(pn);
+                  }
                 }
             }
             when DType.Float64 {
@@ -68,6 +79,7 @@ module ConcatenateMsg
                 var end: int;
                 start = 0;
                 for (name, i) in zip(names, 1..) {
+                  try {
                     // lookup and cast operand to copy from
                     var o = toSymEntry(st.lookup(name), real);
                     // calculate end which is inclusive
@@ -76,6 +88,11 @@ module ConcatenateMsg
                     e.a[{start..end}] = o.a;
                     // update new start for next array copy
                     start += o.size;
+                  } catch e: UndefinedSymbolError {
+                    return unknownSymbolError(pn,name);
+                  } catch {
+                    return unknownError(pn);
+                  }
                 }
             }
             when DType.Bool {
@@ -85,6 +102,7 @@ module ConcatenateMsg
                 var end: int;
                 start = 0;
                 for (name, i) in zip(names, 1..) {
+                  try {
                     // lookup and cast operand to copy from
                     var o = toSymEntry(st.lookup(name), bool);
                     // calculate end which is inclusive
@@ -93,6 +111,11 @@ module ConcatenateMsg
                     e.a[{start..end}] = o.a;
                     // update new start for next array copy
                     start += o.size;
+                  } catch e: UndefinedSymbolError {
+                    return unknownSymbolError(pn,name);
+                  } catch {
+                    return unknownError(pn);
+                  }
                 }
             }
             otherwise {return notImplementedError("concatenate",dtype);}

--- a/src/EfuncMsg.chpl
+++ b/src/EfuncMsg.chpl
@@ -36,8 +36,8 @@ module EfuncMsg
         var rname = st.nextName();
         if v {try! writeln("%s %s %s : %s".format(cmd,efunc,name,rname));try! stdout.flush();}
 
+        try {
         var gEnt: borrowed GenSymEntry = st.lookup(name);
-        if (gEnt == nil) {return unknownSymbolError("efunc",name);}
        
         select (gEnt.dtype) {
             when (DType.Int64) {
@@ -130,6 +130,12 @@ module EfuncMsg
             otherwise {return unrecognizedTypeError("efunc", dtype2str(gEnt.dtype));}
         }
         return try! "created " + st.attrib(rname);
+        } catch e: UndefinedSymbolError {
+          return unknownSymbolError("efunc",e.name);
+        } catch {
+          return unknownError("efunc");
+        }
+
     }
 
     /*
@@ -155,12 +161,10 @@ module EfuncMsg
         var rname = st.nextName();
 	if v {try! writeln("%s %s %s %s %s %s : %s".format(cmd,efunc,name1,name2,name3,rname));try! stdout.flush();}
 
+        try {
         var g1: borrowed GenSymEntry = st.lookup(name1);
-        if (g1 == nil) {return unknownSymbolError("efunc",name1);}
 	var g2: borrowed GenSymEntry = st.lookup(name2);
-	if (g2 == nil) {return unknownSymbolError("efunc",name2);}
 	var g3: borrowed GenSymEntry = st.lookup(name3);
-	if (g3 == nil) {return unknownSymbolError("efunc",name3);}
 	if !((g1.size == g2.size) && (g2.size == g3.size)) {
 	  return "Error: size mismatch in arguments to efunc3vv";
 	}
@@ -204,6 +208,11 @@ module EfuncMsg
 	otherwise {return notImplementedError("efunc3vv",efunc,g1.dtype,g2.dtype,g3.dtype);}
 	}
 	return try! "created " + st.attrib(rname);
+        } catch e: UndefinedSymbolError {
+          return unknownSymbolError("efunc3vv",e.name);
+        } catch {
+          return unknownError("efunc3vv");
+        }
     }
 
     /*
@@ -229,10 +238,9 @@ module EfuncMsg
         var rname = st.nextName();
 	if v {try! writeln("%s %s %s %s %s %s %s : %s".format(cmd,efunc,name1,name2,dtype,value,rname));try! stdout.flush();}
 
+        try {
         var g1: borrowed GenSymEntry = st.lookup(name1);
-        if (g1 == nil) {return unknownSymbolError("efunc",name1);}
 	var g2: borrowed GenSymEntry = st.lookup(name2);
-	if (g2 == nil) {return unknownSymbolError("efunc",name2);}
 	if !(g1.size == g2.size) {
 	  return "Error: size mismatch in arguments to efunc3vs";
 	}
@@ -276,6 +284,11 @@ module EfuncMsg
 	otherwise {return notImplementedError("efunc3vs",efunc,g1.dtype,g2.dtype,dtype);}
 	}
 	return try! "created " + st.attrib(rname);
+        } catch e: UndefinedSymbolError {
+          return unknownSymbolError("efunc3vs",e.name);
+        } catch {
+          return unknownError("efunc3vs");
+        }
     }
 
     /*
@@ -301,10 +314,9 @@ module EfuncMsg
         var rname = st.nextName();
 	if v {try! writeln("%s %s %s %s %s %s %s : %s".format(cmd,efunc,name1,dtype,value,name2,rname));try! stdout.flush();}
 
+        try {
         var g1: borrowed GenSymEntry = st.lookup(name1);
-        if (g1 == nil) {return unknownSymbolError("efunc",name1);}
 	var g2: borrowed GenSymEntry = st.lookup(name2);
-	if (g2 == nil) {return unknownSymbolError("efunc",name2);}
 	if !(g1.size == g2.size) {
 	  return "Error: size mismatch in arguments to efunc3sv";
 	}
@@ -348,6 +360,11 @@ module EfuncMsg
 	otherwise {return notImplementedError("efunc3sv",efunc,g1.dtype,dtype,g2.dtype);}
 	}
 	return try! "created " + st.attrib(rname);
+        } catch e: UndefinedSymbolError {
+          return unknownSymbolError("efunc3sv",e.name);
+        } catch {
+          return unknownError("efunc3sv");
+        }
     }
 
     /*
@@ -374,8 +391,8 @@ module EfuncMsg
         var rname = st.nextName();
 	if v {try! writeln("%s %s %s %s %s %s %s %s : %s".format(cmd,efunc,name1,dtype1,value1,dtype2,value2,rname));try! stdout.flush();}
 
+        try {
         var g1: borrowed GenSymEntry = st.lookup(name1);
-        if (g1 == nil) {return unknownSymbolError("efunc",name1);}
         select (g1.dtype, dtype1, dtype1) {
 	when (DType.Bool, DType.Int64, DType.Int64) {
 	  var e1 = toSymEntry(g1, bool);
@@ -416,6 +433,11 @@ module EfuncMsg
 	otherwise {return notImplementedError("efunc3sv",efunc,g1.dtype,dtype1,dtype2);}
 	}
 	return try! "created " + st.attrib(rname);
+        } catch e: UndefinedSymbolError {
+          return unknownSymbolError("efunc3ss",e.name);
+        } catch {
+          return unknownError("efunc3ss");
+        }
     }
 
     /* The 'where' function takes a boolean array and two other arguments A and B, and 

--- a/src/EfuncMsg.chpl
+++ b/src/EfuncMsg.chpl
@@ -26,9 +26,10 @@ module EfuncMsg
       :type st: borrowed SymTab 
 
       :returns: (string)
+      :throws: `UndefinedSymbolError(name)`
       */
 
-    proc efuncMsg(reqMsg: string, st: borrowed SymTab): string {
+    proc efuncMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
         var fields = reqMsg.split(); // split request into fields
@@ -38,7 +39,6 @@ module EfuncMsg
         var rname = st.nextName();
         if v {try! writeln("%s %s %s : %s".format(cmd,efunc,name,rname));try! stdout.flush();}
 
-        try {
         var gEnt: borrowed GenSymEntry = st.lookup(name);
        
         select (gEnt.dtype) {
@@ -132,12 +132,6 @@ module EfuncMsg
             otherwise {return unrecognizedTypeError(pn, dtype2str(gEnt.dtype));}
         }
         return try! "created " + st.attrib(rname);
-        } catch e: UndefinedSymbolError {
-          return unknownSymbolError("efunc",e.name);
-        } catch {
-          return unknownError("efunc");
-        }
-
     }
 
     /*
@@ -151,8 +145,9 @@ module EfuncMsg
     :type st: borrowed SymTab 
 
     :returns: (string)
+    :throws: `UndefinedSymbolError(name)`
     */
-    proc efunc3vvMsg(reqMsg: string, st: borrowed SymTab): string {
+    proc efunc3vvMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
         var fields = reqMsg.split(); // split request into fields
@@ -164,7 +159,6 @@ module EfuncMsg
         var rname = st.nextName();
 	if v {try! writeln("%s %s %s %s %s %s : %s".format(cmd,efunc,name1,name2,name3,rname));try! stdout.flush();}
 
-        try {
         var g1: borrowed GenSymEntry = st.lookup(name1);
 	var g2: borrowed GenSymEntry = st.lookup(name2);
 	var g3: borrowed GenSymEntry = st.lookup(name3);
@@ -211,11 +205,6 @@ module EfuncMsg
 	otherwise {return notImplementedError(pn,efunc,g1.dtype,g2.dtype,g3.dtype);}
 	}
 	return try! "created " + st.attrib(rname);
-        } catch e: UndefinedSymbolError {
-          return unknownSymbolError("efunc3vv",e.name);
-        } catch {
-          return unknownError("efunc3vv");
-        }
     }
 
     /*
@@ -228,8 +217,9 @@ module EfuncMsg
     :type st: borrowed SymTab 
 
     :returns: (string)
+    :throws: `UndefinedSymbolError(name)`
     */
-    proc efunc3vsMsg(reqMsg: string, st: borrowed SymTab): string {
+    proc efunc3vsMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
         var fields = reqMsg.split(); // split request into fields
@@ -242,7 +232,6 @@ module EfuncMsg
         var rname = st.nextName();
 	if v {try! writeln("%s %s %s %s %s %s %s : %s".format(cmd,efunc,name1,name2,dtype,value,rname));try! stdout.flush();}
 
-        try {
         var g1: borrowed GenSymEntry = st.lookup(name1);
 	var g2: borrowed GenSymEntry = st.lookup(name2);
 	if !(g1.size == g2.size) {
@@ -288,11 +277,6 @@ module EfuncMsg
 	otherwise {return notImplementedError(pn,efunc,g1.dtype,g2.dtype,dtype);}
 	}
 	return try! "created " + st.attrib(rname);
-        } catch e: UndefinedSymbolError {
-          return unknownSymbolError("efunc3vs",e.name);
-        } catch {
-          return unknownError("efunc3vs");
-        }
     }
 
     /*
@@ -305,8 +289,9 @@ module EfuncMsg
     :type st: borrowed SymTab 
 
     :returns: (string)
+    :throws: `UndefinedSymbolError(name)`
     */
-    proc efunc3svMsg(reqMsg: string, st: borrowed SymTab): string {
+    proc efunc3svMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
         var fields = reqMsg.split(); // split request into fields
@@ -319,7 +304,6 @@ module EfuncMsg
         var rname = st.nextName();
 	if v {try! writeln("%s %s %s %s %s %s %s : %s".format(cmd,efunc,name1,dtype,value,name2,rname));try! stdout.flush();}
 
-        try {
         var g1: borrowed GenSymEntry = st.lookup(name1);
 	var g2: borrowed GenSymEntry = st.lookup(name2);
 	if !(g1.size == g2.size) {
@@ -365,11 +349,6 @@ module EfuncMsg
 	otherwise {return notImplementedError(pn,efunc,g1.dtype,dtype,g2.dtype);}
 	}
 	return try! "created " + st.attrib(rname);
-        } catch e: UndefinedSymbolError {
-          return unknownSymbolError("efunc3sv",e.name);
-        } catch {
-          return unknownError("efunc3sv");
-        }
     }
 
     /*
@@ -382,8 +361,9 @@ module EfuncMsg
     :type st: borrowed SymTab 
 
     :returns: (string)
+    :throws: `UndefinedSymbolError(name)`
     */
-    proc efunc3ssMsg(reqMsg: string, st: borrowed SymTab): string {
+    proc efunc3ssMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
         var fields = reqMsg.split(); // split request into fields
@@ -397,7 +377,6 @@ module EfuncMsg
         var rname = st.nextName();
 	if v {try! writeln("%s %s %s %s %s %s %s %s : %s".format(cmd,efunc,name1,dtype1,value1,dtype2,value2,rname));try! stdout.flush();}
 
-        try {
         var g1: borrowed GenSymEntry = st.lookup(name1);
         select (g1.dtype, dtype1, dtype1) {
 	when (DType.Bool, DType.Int64, DType.Int64) {
@@ -439,11 +418,6 @@ module EfuncMsg
 	otherwise {return notImplementedError(pn,efunc,g1.dtype,dtype1,dtype2);}
 	}
 	return try! "created " + st.attrib(rname);
-        } catch e: UndefinedSymbolError {
-          return unknownSymbolError("efunc3ss",e.name);
-        } catch {
-          return unknownError("efunc3ss");
-        }
     }
 
     /* The 'where' function takes a boolean array and two other arguments A and B, and 

--- a/src/FindSegmentsMsg.chpl
+++ b/src/FindSegmentsMsg.chpl
@@ -40,7 +40,6 @@ module FindSegmentsMsg
 	}
 	// Check all the argument arrays before doing anything
 	var gPerm = st.lookup(pname);
-
 	if (gPerm.dtype != DType.Int64) { return notImplementedError(pn,"(permutation dtype "+dtype2str(gPerm.dtype)+")"); }	
 	// var keyEntries: [0..#nkeys] borrowed GenSymEntry;
 	for (name, i) in zip(knames, 0..) {
@@ -95,7 +94,6 @@ module FindSegmentsMsg
 	ref uka = ukeyinds.a;
 	// Segment boundaries are in terms of permuted arrays, so invert the permutation to get back to original index
 	[(s, i) in zip(sa, saD)] { unorderedCopy(uka[i], pa[s]); }
-
 	// Return entry names of segments and unique key indices
 	return try! "created " + st.attrib(sname) + " +created " + st.attrib(uname);
     }

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -215,7 +215,6 @@ module GenSymIO {
       }
     }
     const dataclass = dclasses[dclasses.domain.first];
-
     for (i, dc) in zip(dclasses.domain, dclasses) {
       if dc != dataclass {
 	return try! "Error: inconsistent dtype in dataset %s of file %s".format(dsetName, filenames[i]);

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -23,45 +23,54 @@ module GenSymIO {
     } catch {
       return "Error: Could not write to memory buffer";
     }
-    var entry: shared GenSymEntry;
     try {
+      const entry: shared GenSymEntry = readEntry();
+      const rname = st.nextName();
+      st.addEntry(rname, entry);
+      return try! "created " + st.attrib(rname);
+    } catch err: UnhandledDataTypeError {
+      return try! "Error: Unhandled data type %s".format(err.dtype);
+    } catch {
+      return "Error: Could not read from memory buffer into SymEntry";
+    }
+
+    class UnhandledDataTypeError: Error {
+      var dtype: DType;
+    }
+
+    proc readEntry(): shared GenSymEntry throws {
       var tmpr = tmpf.reader(kind=iobig, start=0);
       if dtype == DType.Int64 {
 	var entryInt = new shared SymEntry(size, int);
 	tmpr.read(entryInt.a);
 	tmpr.close(); tmpf.close();
-	entry = entryInt;
+	return entryInt;
       } else if dtype == DType.Float64 {
 	var entryReal = new shared SymEntry(size, real);
 	tmpr.read(entryReal.a);
 	tmpr.close(); tmpf.close();
-	entry = entryReal;
+	return entryReal;
       } else if dtype == DType.Bool {
 	var entryBool = new shared SymEntry(size, bool);
 	tmpr.read(entryBool.a);
 	tmpr.close(); tmpf.close();
-	entry = entryBool;
+	return entryBool;
       } else {
 	tmpr.close();
 	tmpf.close();
-	return try! "Error: Unhandled data type %s".format(fields[2]);
+	throw new owned UnhandledDataTypeError(dtype);
       }
       tmpr.close();
       tmpf.close();
-    } catch {
-      return "Error: Could not read from memory buffer into SymEntry";
     }
-    var rname = st.nextName();
-    st.addEntry(rname, entry);
-    return try! "created " + st.attrib(rname);
   }
 
   proc tondarrayMsg(reqMsg: string, st: borrowed SymTab): string {
     var arraystr: string;
     var fields = reqMsg.split();
-    var entry = st.lookup(fields[2]);
     var tmpf: file;
     try {
+    var entry = st.lookup(fields[2]);
       tmpf = openmem();
       var tmpw = tmpf.writer(kind=iobig);
       if entry.dtype == DType.Int64 {
@@ -74,6 +83,8 @@ module GenSymIO {
 	return try! "Error: Unhandled dtype %s".format(entry.dtype);
       }
       tmpw.close();
+    } catch e: UndefinedSymbolError {
+      return unknownSymbolError("tondarrayMsg",e.name);
     } catch {
       try! tmpf.close();
       return "Error: Unable to write SymEntry to memory buffer";
@@ -206,6 +217,7 @@ module GenSymIO {
       }
     }
     const dataclass = dclasses[dclasses.domain.first];
+
     for (i, dc) in zip(dclasses.domain, dclasses) {
       if dc != dataclass {
 	return try! "Error: inconsistent dtype in dataset %s of file %s".format(dsetName, filenames[i]);
@@ -226,27 +238,42 @@ module GenSymIO {
     if GenSymIO_DEBUG {
       writeln("Got subdomains and total length");
     }
-    var entry: shared GenSymEntry;
+    try {
+    var entry: shared GenSymEntry = computeEntry(dataclass);
+    var rname = st.nextName();
+    st.addEntry(rname, entry);
+    return try! "created " + st.attrib(rname);
+    } catch e: UnhandledHDFSDataTypeError {
+      return try! "Error: detected unhandled datatype code %i".format(dataclass);
+    } catch {
+      return "Unexpected error";
+    }
+
+    class UnhandledHDFSDataTypeError: Error {
+    }
+
+    // This assumes that dataclass has already been validated above in
+    // validateDataClass() and that only expected dataclass values
+    // will be sent in.  If this is not the case, a halt occurs.
+    proc computeEntry(dataclass: C_HDF5.hid_t): shared GenSymEntry throws {
     if dataclass == C_HDF5.H5T_INTEGER {
       var entryInt = new shared SymEntry(len, int);
       if GenSymIO_DEBUG {
 	writeln("Initialized int entry"); try! stdout.flush();
       }
       read_files_into_distributed_array(entryInt.a, subdoms, filenames, dsetName);
-      entry = entryInt;
+      return entryInt;
     } else if dataclass == C_HDF5.H5T_FLOAT {
       var entryReal = new shared SymEntry(len, real);
       if GenSymIO_DEBUG {
 	writeln("Initialized float entry"); try! stdout.flush();
       }
       read_files_into_distributed_array(entryReal.a, subdoms, filenames, dsetName);
-      entry = entryReal;
+      return entryReal;
     } else {
-      return try! "Error: detected unhandled datatype code %i".format(dataclass);
+      throw new owned UnhandledHDFSDataTypeError();
     }
-    var rname = st.nextName();
-    st.addEntry(rname, entry);
-    return try! "created " + st.attrib(rname);
+  }
   }
   
   /* Get the class of the HDF5 datatype for the dataset. */
@@ -409,9 +436,9 @@ module GenSymIO {
     } catch {
       return try! "Error: could not decode json filenames via tempfile (%i files: %s)".format(1, jsonfile);
     }
-    var entry = st.lookup(arrayName);
     var warnFlag: bool;
     try {
+    var entry = st.lookup(arrayName);
     select entry.dtype {
       when DType.Int64 {
 	var e = toSymEntry(entry, int);
@@ -434,6 +461,8 @@ module GenSymIO {
       return try! "Error: unable to open file for writing: %s".format(filename);
     } catch e: MismatchedAppendError {
       return "Error: appending to existing files must be done with the same number of locales. Try saving with a different directory or filename prefix?";
+    } catch e: UndefinedSymbolError {
+      return try! "Error: lookup failed for %s".format(arrayName);
     } catch {
       return "Error: problem writing to file";
     }

--- a/src/HistogramMsg.chpl
+++ b/src/HistogramMsg.chpl
@@ -14,7 +14,7 @@ module HistogramMsg
     private config const mBound = 2**25;
 
     /* histogram takes a pdarray and returns a pdarray with the histogram in it */
-    proc histogramMsg(reqMsg: string, st: borrowed SymTab): string {
+    proc histogramMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
         var fields = reqMsg.split(); // split request into fields
@@ -26,7 +26,6 @@ module HistogramMsg
         var rname = st.nextName();
         if v {try! writeln("%s %s %i : %s".format(cmd, name, bins, rname));try! stdout.flush();}
 
-        try {
         var gEnt: borrowed GenSymEntry = st.lookup(name);
 
         // helper nested procedure
@@ -61,11 +60,6 @@ module HistogramMsg
         }
         
         return try! "created " + st.attrib(rname);
-        } catch e: UndefinedSymbolError {
-          return unknownSymbolError("histogram",e.name);
-        } catch {
-          return unknownError("histogram");
-        }
     }
 
 

--- a/src/HistogramMsg.chpl
+++ b/src/HistogramMsg.chpl
@@ -23,8 +23,8 @@ module HistogramMsg
         var rname = st.nextName();
         if v {try! writeln("%s %s %i : %s".format(cmd, name, bins, rname));try! stdout.flush();}
 
+        try {
         var gEnt: borrowed GenSymEntry = st.lookup(name);
-        if (gEnt == nil) {return unknownSymbolError("histogram",name);}
 
         // helper nested procedure
         proc histogramHelper(type t) {
@@ -58,6 +58,11 @@ module HistogramMsg
         }
         
         return try! "created " + st.attrib(rname);
+        } catch e: UndefinedSymbolError {
+          return unknownSymbolError("histogram",e.name);
+        } catch {
+          return unknownError("histogram");
+        }
     }
 
 

--- a/src/In1dMsg.chpl
+++ b/src/In1dMsg.chpl
@@ -41,10 +41,9 @@ module In1dMsg
         var rname = st.nextName();
         if v {try! writeln("%s %s %s %s : %s".format(cmd, name, sname, invert, rname));try! stdout.flush();}
 
+        try {
         var gAr1: borrowed GenSymEntry = st.lookup(name);
-        if (gAr1 == nil) {return unknownSymbolError("in1d",name);}
         var gAr2: borrowed GenSymEntry = st.lookup(sname);
-        if (gAr2 == nil) {return unknownSymbolError("in1d",sname);}
 
         select (gAr1.dtype, gAr2.dtype) {
             when (DType.Int64, DType.Int64) {
@@ -80,6 +79,11 @@ module In1dMsg
         }
         
         return try! "created " + st.attrib(rname);
+        } catch e: UndefinedSymbolError {
+          return unknownSymbolError("in1d",e.name);
+        } catch {
+          return unknownError("in1d");
+        }
     }
 
     

--- a/src/In1dMsg.chpl
+++ b/src/In1dMsg.chpl
@@ -27,7 +27,7 @@ module In1dMsg
        in1dMsg processes the request, considers the size of the arguements, and decides which implementation
        of in1d to utilize.
     */
-    proc in1dMsg(reqMsg: string, st: borrowed SymTab): string {
+    proc in1dMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
         var fields = reqMsg.split(); // split request into fields
@@ -43,7 +43,6 @@ module In1dMsg
         var rname = st.nextName();
         if v {try! writeln("%s %s %s %s : %s".format(cmd, name, sname, invert, rname));try! stdout.flush();}
 
-        try {
         var gAr1: borrowed GenSymEntry = st.lookup(name);
         var gAr2: borrowed GenSymEntry = st.lookup(sname);
 
@@ -81,11 +80,6 @@ module In1dMsg
         }
         
         return try! "created " + st.attrib(rname);
-        } catch e: UndefinedSymbolError {
-          return unknownSymbolError("in1d",e.name);
-        } catch {
-          return unknownError("in1d");
-        }
     }
 
     

--- a/src/MsgProcessing.chpl
+++ b/src/MsgProcessing.chpl
@@ -277,8 +277,8 @@ module MsgProcessing
         var dtype = str2dtype(fields[3]);
         var value = fields[4];
 
+        try {
         var gEnt: borrowed GenSymEntry = st.lookup(name);
-        if (gEnt == nil) {return unknownSymbolError("set",name);}
 
         select (gEnt.dtype, dtype) {
             when (DType.Int64, DType.Int64) {
@@ -353,7 +353,11 @@ module MsgProcessing
             otherwise {return unrecognizedTypeError("set",fields[3]);}
         }
         return repMsg;
-    }
-    
+        } catch e: UndefinedSymbolError {
+          return unknownSymbolError("set",name);
+        } catch {
+          return unknownError("set");
+        }
 
+    }
 }

--- a/src/MsgProcessing.chpl
+++ b/src/MsgProcessing.chpl
@@ -269,8 +269,9 @@ module MsgProcessing
     :type st: borrowed SymTab 
 
     :returns: (string)
+    :throws: `UndefinedSymbolError(name)`
     */
-    proc setMsg(reqMsg: string, st: borrowed SymTab): string {
+    proc setMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
         var fields = reqMsg.split(); // split request into fields
@@ -279,7 +280,6 @@ module MsgProcessing
         var dtype = str2dtype(fields[3]);
         var value = fields[4];
 
-        try {
         var gEnt: borrowed GenSymEntry = st.lookup(name);
 
         select (gEnt.dtype, dtype) {
@@ -355,11 +355,7 @@ module MsgProcessing
             otherwise {return unrecognizedTypeError(pn,fields[3]);}
         }
         return repMsg;
-        } catch e: UndefinedSymbolError {
-          return unknownSymbolError("set",name);
-        } catch {
-          return unknownError("set");
-        }
-
     }
+    
+
 }

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -32,10 +32,9 @@ module OperatorMsg
         var rname = st.nextName();
         if v {try! writeln("%s %s %s %s : %s".format(cmd,op,aname,bname,rname));try! stdout.flush();}
 
+        try {
         var left: borrowed GenSymEntry = st.lookup(aname);
-        if (left == nil) {return try! "Error: binopvv: unkown symbol %s".format(aname);}
         var right: borrowed GenSymEntry = st.lookup(bname);
-        if (right == nil) {return try! "Error: binopvv: unkown symbol %s".format(bname);}
 
         select (left.dtype, right.dtype) {
             when (DType.Int64, DType.Int64) {
@@ -428,6 +427,12 @@ module OperatorMsg
             otherwise {return unrecognizedTypeError("binopvv",
                                                     "("+dtype2str(left.dtype)+","+dtype2str(right.dtype)+")");}
         }
+        } catch e: UndefinedSymbolError {
+          return try! "Error: binopvv: unknown symbol %s".format(e.name);
+        } catch {
+          return unknownError("binopvv");
+        }
+
         return try! "created " + st.attrib(rname);
     }
     /*
@@ -453,8 +458,8 @@ module OperatorMsg
         var rname = st.nextName();
         if v {try! writeln("%s %s %s %s %s : %s".format(cmd,op,aname,dtype2str(dtype),value,rname));try! stdout.flush();}
 
+        try {
         var left: borrowed GenSymEntry = st.lookup(aname);
-        if (left == nil) {return try! "Error: binopvs: unkown symbol %s".format(aname);}
         select (left.dtype, dtype) {
             when (DType.Int64, DType.Int64) {
                 var l = toSymEntry(left,int);
@@ -842,6 +847,11 @@ module OperatorMsg
                                                     "("+dtype2str(left.dtype)+","+dtype2str(dtype)+")");}
         }
         return try! "created " + st.attrib(rname);
+        } catch e: UndefinedSymbolError {
+          return try! "Error: binopvs: unkown symbol %s".format(aname);
+        } catch {
+          return unknownError("binopvs");
+        }
     }
 
     /*
@@ -867,6 +877,7 @@ module OperatorMsg
         var rname = st.nextName();
         if v {try! writeln("%s %s %s %s %s : %s".format(cmd,op,dtype2str(dtype),value,aname,rname));try! stdout.flush();}
 
+        try {
         var right: borrowed GenSymEntry = st.lookup(aname);
         if (right == nil) {return try! "Error: binopsv: unkown symbol %s".format(aname);}
         select (dtype, right.dtype) {
@@ -1252,6 +1263,12 @@ module OperatorMsg
                                                     "("+dtype2str(dtype)+","+dtype2str(right.dtype)+")");}
         }
         return try! "created " + st.attrib(rname);
+        } catch e: UndefinedSymbolError {
+          return try! "Error: binopsv: unkown symbol %s".format(aname);
+        } catch {
+          return unknownError("binopsv");
+        }
+
     }
 
     /*
@@ -1274,11 +1291,10 @@ module OperatorMsg
         var aname = fields[3];
         var bname = fields[4];
         if v {try! writeln("%s %s %s %s".format(cmd,op,aname,bname));try! stdout.flush();}
-        
+
+        try {
         var left: borrowed GenSymEntry = st.lookup(aname);
-        if (left == nil) {return unknownSymbolError("opeqvv",aname);}
         var right: borrowed GenSymEntry = st.lookup(bname);
-        if (right == nil) {return unknownSymbolError("opeqvv",bname);}
         select (left.dtype, right.dtype) {
             when (DType.Int64, DType.Int64) {
                 var l = toSymEntry(left,int);
@@ -1387,6 +1403,11 @@ module OperatorMsg
             otherwise {return unrecognizedTypeError("opeqvv",
                                                     "("+dtype2str(left.dtype)+","+dtype2str(right.dtype)+")");}
         }
+        } catch e: UndefinedSymbolError {
+          return try! "Error: opeqvv: unkown symbol %s".format(aname);
+        } catch {
+          return unknownError("opeqvv");
+        }
         return "opeqvv success";
     }
 
@@ -1413,8 +1434,8 @@ module OperatorMsg
         var value = fields[5];
         if v {try! writeln("%s %s %s %s %s".format(cmd,op,aname,dtype2str(dtype),value));try! stdout.flush();}
 
+        try {
         var left: borrowed GenSymEntry = st.lookup(aname);
-        if (left == nil) {return unknownSymbolError("opeqvs",aname);}
 
         select (left.dtype, dtype) {
             when (DType.Int64, DType.Int64) {
@@ -1516,6 +1537,11 @@ module OperatorMsg
 	    }
             otherwise {return unrecognizedTypeError("opeqvs",
                                                     "("+dtype2str(left.dtype)+","+dtype2str(dtype)+")");}
+        }
+        } catch e: UndefinedSymbolError {
+          return try! "Error: opeqvs: unkown symbol %s".format(aname);
+        } catch {
+          return unknownError("opeqvs");
         }
         return "opeqvs success";
     }

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -22,8 +22,9 @@ module OperatorMsg
     :type st: borrowed SymTab 
 
     :returns: (string) 
+    :throws: `UndefinedSymbolError(name)`
     */
-    proc binopvvMsg(reqMsg: string, st: borrowed SymTab): string {
+    proc binopvvMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
         var fields = reqMsg.split(); // split request into fields
@@ -34,7 +35,6 @@ module OperatorMsg
         var rname = st.nextName();
         if v {try! writeln("%s %s %s %s : %s".format(cmd,op,aname,bname,rname));try! stdout.flush();}
 
-        try {
         var left: borrowed GenSymEntry = st.lookup(aname);
         var right: borrowed GenSymEntry = st.lookup(bname);
 
@@ -429,12 +429,6 @@ module OperatorMsg
             otherwise {return unrecognizedTypeError(pn,
                                                     "("+dtype2str(left.dtype)+","+dtype2str(right.dtype)+")");}
         }
-        } catch e: UndefinedSymbolError {
-          return try! "Error: binopvv: unknown symbol %s".format(e.name);
-        } catch {
-          return unknownError("binopvv");
-        }
-
         return try! "created " + st.attrib(rname);
     }
     /*
@@ -448,8 +442,9 @@ module OperatorMsg
     :type st: borrowed SymTab 
 
     :returns: (string) 
+    :throws: `UndefinedSymbolError(name)`
     */
-    proc binopvsMsg(reqMsg: string, st: borrowed SymTab): string {
+    proc binopvsMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string = ""; // response message
         var fields = reqMsg.split(); // split request into fields
@@ -461,7 +456,6 @@ module OperatorMsg
         var rname = st.nextName();
         if v {try! writeln("%s %s %s %s %s : %s".format(cmd,op,aname,dtype2str(dtype),value,rname));try! stdout.flush();}
 
-        try {
         var left: borrowed GenSymEntry = st.lookup(aname);
         select (left.dtype, dtype) {
             when (DType.Int64, DType.Int64) {
@@ -850,11 +844,6 @@ module OperatorMsg
                                                     "("+dtype2str(left.dtype)+","+dtype2str(dtype)+")");}
         }
         return try! "created " + st.attrib(rname);
-        } catch e: UndefinedSymbolError {
-          return try! "Error: binopvs: unkown symbol %s".format(aname);
-        } catch {
-          return unknownError("binopvs");
-        }
     }
 
     /*
@@ -868,8 +857,9 @@ module OperatorMsg
     :type st: borrowed SymTab 
 
     :returns: (string) 
+    :throws: `UndefinedSymbolError(name)`
     */
-    proc binopsvMsg(reqMsg: string, st: borrowed SymTab): string {
+    proc binopsvMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string = ""; // response message
         var fields = reqMsg.split(); // split request into fields
@@ -881,7 +871,6 @@ module OperatorMsg
         var rname = st.nextName();
         if v {try! writeln("%s %s %s %s %s : %s".format(cmd,op,dtype2str(dtype),value,aname,rname));try! stdout.flush();}
 
-        try {
         var right: borrowed GenSymEntry = st.lookup(aname);
         if (right == nil) {return unknownSymbolError(pn, aname);}
         select (dtype, right.dtype) {
@@ -1267,12 +1256,6 @@ module OperatorMsg
                                                     "("+dtype2str(dtype)+","+dtype2str(right.dtype)+")");}
         }
         return try! "created " + st.attrib(rname);
-        } catch e: UndefinedSymbolError {
-          return try! "Error: binopsv: unkown symbol %s".format(aname);
-        } catch {
-          return unknownError("binopsv");
-        }
-
     }
 
     /*
@@ -1286,8 +1269,9 @@ module OperatorMsg
     :type st: borrowed SymTab 
 
     :returns: (string) 
+    :throws: `UndefinedSymbolError(name)`
     */
-    proc opeqvvMsg(reqMsg: string, st: borrowed SymTab): string {
+    proc opeqvvMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
         var fields = reqMsg.split(); // split request into fields
@@ -1296,8 +1280,7 @@ module OperatorMsg
         var aname = fields[3];
         var bname = fields[4];
         if v {try! writeln("%s %s %s %s".format(cmd,op,aname,bname));try! stdout.flush();}
-
-        try {
+        
         var left: borrowed GenSymEntry = st.lookup(aname);
         var right: borrowed GenSymEntry = st.lookup(bname);
         select (left.dtype, right.dtype) {
@@ -1408,11 +1391,6 @@ module OperatorMsg
             otherwise {return unrecognizedTypeError(pn,
                                                     "("+dtype2str(left.dtype)+","+dtype2str(right.dtype)+")");}
         }
-        } catch e: UndefinedSymbolError {
-          return try! "Error: opeqvv: unkown symbol %s".format(aname);
-        } catch {
-          return unknownError("opeqvv");
-        }
         return "opeqvv success";
     }
 
@@ -1427,9 +1405,10 @@ module OperatorMsg
     :type st: borrowed SymTab 
 
     :returns: (string) 
+    :throws: `UndefinedSymbolError(name)`
 
     */
-    proc opeqvsMsg(reqMsg: string, st: borrowed SymTab): string {
+    proc opeqvsMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
         var fields = reqMsg.split(); // split request into fields
@@ -1440,7 +1419,6 @@ module OperatorMsg
         var value = fields[5];
         if v {try! writeln("%s %s %s %s %s".format(cmd,op,aname,dtype2str(dtype),value));try! stdout.flush();}
 
-        try {
         var left: borrowed GenSymEntry = st.lookup(aname);
 
         select (left.dtype, dtype) {
@@ -1543,11 +1521,6 @@ module OperatorMsg
 	    }
             otherwise {return unrecognizedTypeError(pn,
                                                     "("+dtype2str(left.dtype)+","+dtype2str(dtype)+")");}
-        }
-        } catch e: UndefinedSymbolError {
-          return try! "Error: opeqvs: unkown symbol %s".format(aname);
-        } catch {
-          return unknownError("opeqvs");
         }
         return "opeqvs success";
     }

--- a/src/ServerErrorStrings.chpl
+++ b/src/ServerErrorStrings.chpl
@@ -42,7 +42,10 @@ module ServerErrorStrings
 
     /* name not found in the symbol table */
     proc unknownSymbolError(pname: string, sname: string):string {
-        return try! "Error: %s: unkown symbol: %s".format(pname, sname);
+      if pname != "" then
+        return try! "Error: %s: unknown symbol: %s".format(pname, sname);
+      else
+        return try! "Error: unknown symbol: %s".format(sname);
     }
 
     proc unknownError(pname: string): string {

--- a/src/ServerErrorStrings.chpl
+++ b/src/ServerErrorStrings.chpl
@@ -45,6 +45,10 @@ module ServerErrorStrings
         return try! "Error: %s: unkown symbol: %s".format(pname, sname);
     }
 
+    proc unknownError(pname: string): string {
+      return try! "Error: %s: unexpected error".format(pname);
+    }
+
     /* incompatible arguments */
     proc incompatibleArgumentsError(pname: string, reason: string) {
       return try! "Error: %s: Incompatible arguments: %s".format(pname, reason);

--- a/src/UniqueMsg.chpl
+++ b/src/UniqueMsg.chpl
@@ -40,9 +40,9 @@ module UniqueMsg
         // get next symbol anme for counts
         var cname = st.nextName();
         if v {try! writeln("%s %s %t: %s %s".format(cmd, name, returnCounts, vname, cname));try! stdout.flush();}
-        
+
+        try {
         var gEnt: borrowed GenSymEntry = st.lookup(name);
-        if (gEnt == nil) {return unknownSymbolError(pn,name);}
         
         select (gEnt.dtype) {
             when (DType.Int64) {
@@ -80,6 +80,12 @@ module UniqueMsg
         if returnCounts {s += " +created " + st.attrib(cname);}
 
         return s;
+        } catch e: UndefinedSymbolError {
+          return unknownSymbolError(pn,e.name);
+        } catch {
+          return unknownError(pn);
+        }
+
     }
     
     /* value_counts takes a pdarray and returns two pdarrays unique values and counts for each value */
@@ -95,8 +101,8 @@ module UniqueMsg
         var cname = st.nextName();
         if v {try! writeln("%s %s : %s %s".format(cmd, name, vname, cname));try! stdout.flush();}
 
+        try {
         var gEnt: borrowed GenSymEntry = st.lookup(name);
-        if (gEnt == nil) {return unknownSymbolError(pn,name);}
 
         select (gEnt.dtype) {
             when (DType.Int64) {
@@ -135,6 +141,12 @@ module UniqueMsg
         }
         
         return try! "created " + st.attrib(vname) + " +created " + st.attrib(cname);
+        } catch e: UndefinedSymbolError {
+          return unknownSymbolError(pn,e.name);
+        } catch {
+          return unknownError(pn);
+        }
+
     }
 
 }

--- a/src/UniqueMsg.chpl
+++ b/src/UniqueMsg.chpl
@@ -23,7 +23,7 @@ module UniqueMsg
     use Unique;
     
     /* unique take a pdarray and returns a pdarray with the unique values */
-    proc uniqueMsg(reqMsg: string, st: borrowed SymTab): string {
+    proc uniqueMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
         var fields = reqMsg.split(); // split request into fields
@@ -41,8 +41,7 @@ module UniqueMsg
         // get next symbol anme for counts
         var cname = st.nextName();
         if v {try! writeln("%s %s %t: %s %s".format(cmd, name, returnCounts, vname, cname));try! stdout.flush();}
-
-        try {
+        
         var gEnt: borrowed GenSymEntry = st.lookup(name);
         
         select (gEnt.dtype) {
@@ -81,16 +80,10 @@ module UniqueMsg
         if returnCounts {s += " +created " + st.attrib(cname);}
 
         return s;
-        } catch e: UndefinedSymbolError {
-          return unknownSymbolError(pn,e.name);
-        } catch {
-          return unknownError(pn);
-        }
-
     }
     
     /* value_counts takes a pdarray and returns two pdarrays unique values and counts for each value */
-    proc value_countsMsg(reqMsg: string, st: borrowed SymTab): string {
+    proc value_countsMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
         var fields = reqMsg.split(); // split request into fields
@@ -102,7 +95,6 @@ module UniqueMsg
         var cname = st.nextName();
         if v {try! writeln("%s %s : %s %s".format(cmd, name, vname, cname));try! stdout.flush();}
 
-        try {
         var gEnt: borrowed GenSymEntry = st.lookup(name);
 
         select (gEnt.dtype) {
@@ -142,12 +134,6 @@ module UniqueMsg
         }
         
         return try! "created " + st.attrib(vname) + " +created " + st.attrib(cname);
-        } catch e: UndefinedSymbolError {
-          return unknownSymbolError(pn,e.name);
-        } catch {
-          return unknownError(pn);
-        }
-
     }
 
 }

--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -64,6 +64,8 @@ proc main() {
             try! stdout.flush();
         }
 
+        try {
+        
         // parse requests, execute requests, format responses
         select cmd
         {
@@ -126,6 +128,13 @@ proc main() {
                 if v {writeln("Error: unrecognized command: %s".format(reqMsg)); try! stdout.flush();}
             }
         }
+
+        } catch (e: UndefinedSymbolError) {
+          repMsg = unknownSymbolError("", e.name);
+        } catch {
+          repMsg = unknownError("");
+        }
+        
         
         // send responses
         // send count for now


### PR DESCRIPTION
This PR updates Arkouda to work in the nilable vs. non-nilable class world introduced by Chapel 1.20 and retires the need for the `--legacy-classes` flag (removing it from the Makefile).  It extends and replaces PR #152 which was an earlier approach for doing this.

To sanity check this, I ran `tests/check.py` against it, which passed.

The main effort here relates to the MultiTypeSymbolTable and its lookup() routine since lookup() used to return `nil` as a sentinel value when a lookup() failed, which would require propagating nilable classes throughout the code.  Instead of doing that, I converted lookup() to throw upon failure and changed routines that call lookup() to throw the error further upwards.  As a result, `arkouda_server.chpl` now does the main `select` statement in a `try` block so that these errors can be handled after the message has been processed.

One impact of this refactoring is that the procedure name which made the failing lookup() call is no longer captured, so does not get put into the error string.  That said, the result is much simpler in the code than a previous approach (PR #152) in which `try...catch` blocks were inserted around the lookup() calls to handle the errors closer to the failure.  That approach could, itself, be improved by support for deferred initialization as proposed in https://github.com/chapel-lang/chapel/issues/14271, so in the future, if we wanted to re-introduce the procedure names into the error message, this would be a way to do so a bit more cleanly, by catching the errors locally, or rethrowing them, incorporating the failing routine name.

Other than that change, the modification generally cleans up the code nicely, replacing a number of nil checks to guard against failed lookups into `throws` annotations and a `catch` block at the top level.  Moreover, some cases that were not guarded against by nil checks generated compiler errors with this new structure.  Changing them to `throw` results in safer code than what was on master before.

The other main changes here include:

* In arrayMsg(), I pushed most of the logic relating to reading an entry into a helper routine in order to be able to store it directly into `entry` as a non-nilable object.  This is a case that, in the future, could benefit from deferred initialization to keep the code closer to how it was originally written.

* Similarly, in readhdfMsg(), I pushed the logic related to computing an entry into a nested `computeEntry()` procedure in order to store it directly into `entry` as a non-nilable.

* Three new error classes are introduced:
  - `UndefinedSymbolError` which is thrown by lookup() on failure
  - `UnhandledDataTypeError` which is thrown by the helper in the first bullet above
  - `UnhandledHDFSDataTypeError` which is thrown by the helper in the second bullet above

* One new error string-generating routine is added: unknownError() which I use for the catch-all case in the outer try statement "just in case."  It's not particularly helpful, but better than halting...

In each of these cases, I'm not fully convinced that I've taken the best approach, though I think it's acceptable.  I'm definitely open to feedback.

I've generally tried not to change the indentation of the original code in order to keep the diff easy to read for the sake of review.  But once we have a PR that the team is relatively happy with, the code should be re-indented (either as part of this PR or a follow-on one).