### PR TITLE
Change get hostname technique from spawn() to locale query

### DIFF
--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -29,7 +29,15 @@ module ServerConfig
     var serverHostname: string = try! get_hostname();
 
     proc get_hostname(): string {
-      return here.name;
+      // Want:
+      //   return here.hostname;
+      // but this isn't implemented yet; could use:
+      //   return here.name;
+      // but this munges the hostname when using local spawning with GASNet
+      // so the following is used as a temporary workaround:
+      extern proc chpl_nodeName(): c_string;
+      var hostname = chpl_nodeName(): string;
+      return hostname;
     }
 
     proc getConfig(): string {

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -29,30 +29,7 @@ module ServerConfig
     var serverHostname: string = try! get_hostname();
 
     proc get_hostname(): string {
-        /* The right way to do this is by reading the hostname from stdout, but that 
-           causes a segfault in a multilocale setting. So we have to use a temp file, 
-           but we can't use opentmp, because we need the name and the .path attribute 
-           is not the true name. */
-        use Spawn;
-        use IO;
-        use FileSystem;
-        const tmpfile = '/tmp/arkouda.hostname';
-        try! {
-            if exists(tmpfile) {
-                remove(tmpfile);
-            }
-            var cmd =  "hostname > \"%s\"".format(tmpfile);
-            var sub =  spawnshell(cmd);
-            sub.wait();
-            var hostname: string;
-            var f = open(tmpfile, iomode.r);
-            var r = f.reader();
-            r.readstring(hostname);
-            r.close();
-            f.close();
-            remove(tmpfile);
-            return hostname.strip();
-        }
+      return here.name;
     }
 
     proc getConfig(): string {


### PR DESCRIPTION
This converts the spawn-based approach used to get the hostname
of the current locale into a ~query on the locale value, which is far
more Chapeltastic~.  Elliot points out that `locale.name` is not always
a valid hostname (specifically when using local spawning with GASNet
in some configurations), so I've changed this PR to use a workaround
as well.  Separately, I have a change intended for 1.21 in which locale
supports a `.hostname` query, so we can change to that at that time.

Even though this workaround uses a non-public interface, I think it
remains preferable to the previous approach.

Resolves #164.