### PR TITLE
Make Arkouda's `use` statements work if `use` => `private use`

### DIFF
--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -1,5 +1,6 @@
 module GenSymIO {
   use HDF5;
+  use ServerConfig;
   use MultiTypeSymbolTable;
   use MultiTypeSymEntry;
   use ServerErrorStrings;

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -1,6 +1,7 @@
 module IndexingMsg
 {
     use ServerConfig;
+    use ServerErrorStrings;
 
     use Reflection only;
 

--- a/src/MsgProcessing.chpl
+++ b/src/MsgProcessing.chpl
@@ -13,17 +13,17 @@ module MsgProcessing
 
     use AryUtil;
     
-    use OperatorMsg;
-    use RandMsg;
-    use IndexingMsg;
-    use UniqueMsg;
-    use In1dMsg;
-    use HistogramMsg;
-    use ArgSortMsg;
-    use ReductionMsg;
-    use FindSegmentsMsg;
-    use EfuncMsg;
-    use ConcatenateMsg;
+    public use OperatorMsg;
+    public use RandMsg;
+    public use IndexingMsg;
+    public use UniqueMsg;
+    public use In1dMsg;
+    public use HistogramMsg;
+    public use ArgSortMsg;
+    public use ReductionMsg;
+    public use FindSegmentsMsg;
+    public use EfuncMsg;
+    public use ConcatenateMsg;
     
     /* 
     Parse, execute, and respond to a create message 

--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -3,9 +3,9 @@ module MultiTypeSymEntry
 {
     use ServerConfig;
 
-    use NumPyDType;
+    public use NumPyDType;
 
-    use SymArrayDmap;
+    public use SymArrayDmap;
 
     use AryUtil;
     

--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -5,6 +5,7 @@ module ReductionMsg
     use Time only;
     use Math only;
     use Reflection only;
+    use UnorderedCopy;
 
     use MultiTypeSymbolTable;
     use MultiTypeSymEntry;

--- a/src/SymArrayDmap.chpl
+++ b/src/SymArrayDmap.chpl
@@ -3,8 +3,8 @@ module SymArrayDmap
 {
     use ServerConfig;
 
-    use CyclicDist;
-    use BlockDist;
+    public use CyclicDist;
+    public use BlockDist;
 
     /* 
     Uses the MyDmap config param in ServerConfig.chpl::

--- a/src/Unique.chpl
+++ b/src/Unique.chpl
@@ -22,6 +22,7 @@ module Unique
     use SymArrayDmap;
 
     use RadixSortLSD;
+    use AryUtil;
 
     /* // thresholds for different unique counting algorithms */
     /* var sBins = 2**10; // small-range maybe for using reduce intents on forall loops */

--- a/src/UniqueMsg.chpl
+++ b/src/UniqueMsg.chpl
@@ -15,6 +15,7 @@ module UniqueMsg
     use Time only;
     use Math only;
     use Reflection only;
+    use UnorderedCopy;
     
     use MultiTypeSymbolTable;
     use MultiTypeSymEntry;

--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -11,6 +11,7 @@ use MultiTypeSymbolTable;
 use MultiTypeSymEntry;
 use MsgProcessing;
 use GenSymIO;
+use SymArrayDmap;
 
 proc main() {
     writeln("arkouda server version = ",arkoudaVersion); try! stdout.flush();


### PR DESCRIPTION
Background: Chapel is considering changing an undecorated `use` from
meaning `public use` ("anyone who uses me can also use this module's
contents") to `private use` ("I can use this module's symbols, but those
who use me won't be the wiser") in order to support better code
encapsulation and clarity between dependencies (https://github.com/chapel-lang/chapel/issues/14183)

Here, I've massaged Arkouda's `use` statements such that they work
with the above interpretation.  In some cases, I added new `use` statements
to a given module to satisfy a dependency; in others, I made an existing `use`
into a `public use` such that a module could serve as a shorthand for a number
of other `use`s.  I don't feel expert in understanding the organization of the Arkouda
code yet, so am not confident that I've made the best choices in all cases, and
am very open to feedback.

That said, this compiles and runs in a "private use by default" world, so could
be considered a step forward.