### PR TITLE
adding == operator for ak.bool pdarrays

### DIFF
--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -347,6 +347,10 @@ module OperatorMsg
                         var e = st.addEntry(rname, l.size, bool);
 		        e.a = l.a ^ r.a;
 		    }
+                    when "==" {
+                        var e = st.addEntry(rname, l.size, bool);
+                        e.a = l.a == r.a;
+                    }
 		    otherwise {return notImplementedError(pn,left.dtype,op,right.dtype);}
 		}
 	    }


### PR DESCRIPTION
#174 
output of:
```
a1 = ak.array(np.array([0,0,1,1], dtype=ak.bool))
a2 = ak.array(np.array([0,1,0,1], dtype=ak.bool))
print('a1 type: ', a1.dtype)
print('a2 type: ', a2.dtype)
print('a1 == a2: ', a1 == a2)
```
is the following:
```
a1 type:  bool
a2 type:  bool
a1 == a2:  [True False False True]
```