### PR TITLE
Another `private use` by default update

### DIFF
--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -12,6 +12,7 @@ use MultiTypeSymEntry;
 use MsgProcessing;
 use GenSymIO;
 use SymArrayDmap;
+use ServerErrorStrings;
 
 proc main() {
     writeln("arkouda server version = ",arkoudaVersion); try! stdout.flush();


### PR DESCRIPTION
Chapel is moving toward having `use` statements be private (i.e.,
non-transitive) by default.  This is a case that needs a `use` which I
missed in my previous PR #173 (or perhaps the world changed since
then).