### PR TITLE
Add `use IO` to get stdout, stderr, etc.

### DIFF
--- a/src/RadixSortLSD.chpl
+++ b/src/RadixSortLSD.chpl
@@ -27,6 +27,7 @@ module RadixSortLSD
     use AryUtil;
     use UnorderedCopy;
     use CommAggregation;
+    use IO;
 
     inline proc getBitWidth(a: [?aD] int): int {
       var aMin = min reduce a;

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -4,6 +4,8 @@ module ServerConfig
     use ZMQ only;
     use HDF5.C_HDF5 only H5get_libversion;
     use SymArrayDmap only makeDistDom;
+    public use IO;
+
     /*
     Verbose flag
     */


### PR DESCRIPTION
Chapel is teasing IO into two categories:

* things that are supported by default (e.g., default, channel-less
  writeln(), writef()), and

* things that require `use IO` to get at (channels, files, errors,
  etc.)

This adds `use IO` in a few key places to keep Arkouda working under
these assumptions for consideration.