### PR TITLE
added --ccflags="-Wno-incompatible-pointer-types" to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ CHPL_DEBUG_FLAGS += --print-passes
 ifndef ARKOUDA_DEVELOPER
 CHPL_FLAGS += --fast
 endif
+CHPL_FLAGS += --ccflags="-Wno-incompatible-pointer-types"
 CHPL_FLAGS += -lhdf5 -lhdf5_hl -lzmq
 
 # --cache-remote does not work with ugni in Chapel 1.20

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ CHPL_DEBUG_FLAGS += --print-passes
 ifndef ARKOUDA_DEVELOPER
 CHPL_FLAGS += --fast
 endif
+# need this to avoid a slew of warnings from HDF5 on some platforms
+# --ccflags="-Wno-incompatible-pointer-types"
 CHPL_FLAGS += --ccflags="-Wno-incompatible-pointer-types"
 CHPL_FLAGS += -lhdf5 -lhdf5_hl -lzmq
 


### PR DESCRIPTION
incompatible-pointer-type warning started showing up again with HDF5 on our IB cluster so I added it back to the makefile.