### PR TITLE
turn off printing of symbol table entry array domains

### DIFF
--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -101,7 +101,7 @@ module MultiTypeSymEntry
         Verbose flag utility method
         */
         proc postinit() {
-            if v {write("aD = "); printOwnership(this.a);}
+            //if v {write("aD = "); printOwnership(this.a);}
         }
         /*
         Verbose flag utility method


### PR DESCRIPTION
printing symbol table array domains really clutters up the trace/log from the arkouda server when running on 100+ locales. so this PR turns it off. it is still in the code just commented out.