### PR TITLE
Stop running the server/client in travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,4 @@ jobs:
         docker run -it -v ${TRAVIS_BUILD_DIR}:/repo.git -w /repo.git chapel/chapel:1.20.0 /bin/bash -c '
         apt-get update && apt-get install -y libhdf5-dev libzmq3-dev python3-pip &&
         echo "\$(eval \$(call add-path,/usr/lib/x86_64-linux-gnu/hdf5/serial/))" > Makefile.paths &&
-        ARKOUDA_DEVELOPER=true make &&
-        pip3 install --ignore-requires-python . &&
-        { ./arkouda_server &>server.log & } && ./tests/check.py; ./tests/shutdown.py'
+        ARKOUDA_DEVELOPER=true make'


### PR DESCRIPTION
It almost always hangs right now, which IMO makes the travis results
useless. For now, just build the server until we resolve #191.