### PR TITLE
Fix more array copies

### DIFF
--- a/src/EfuncMsg.chpl
+++ b/src/EfuncMsg.chpl
@@ -47,32 +47,33 @@ module EfuncMsg
                 select efunc
                 {
                     when "abs" {
-                        var a = Math.abs(e.a);
-                        st.addEntry(rname, new shared SymEntry(a));
+                        var a = st.addEntry(rname, e.size, real);
+                        a.a = Math.abs(e.a);
+                        
                     }
                     when "log" {
-                        var a = Math.log(e.a);
-                        st.addEntry(rname, new shared SymEntry(a));
+                        var a = st.addEntry(rname, e.size, real);
+                        a.a = Math.log(e.a);
                     }
                     when "exp" {
-                        var a = Math.exp(e.a);
-                        st.addEntry(rname, new shared SymEntry(a));
+                        var a = st.addEntry(rname, e.size, real);
+                        a.a = Math.exp(e.a);
                     }
                     when "cumsum" {
-                        var a: [e.aD] int = + scan e.a; //try! writeln((a.type):string,(a.domain.type):string); try! stdout.flush();
-                        st.addEntry(rname, new shared SymEntry(a));
+                        var a = st.addEntry(rname, e.size, int);
+                        a.a = + scan e.a;
                     }
                     when "cumprod" {
-                        var a: [e.aD] int = * scan e.a; //try! writeln((a.type):string,(a.domain.type):string); try! stdout.flush();
-                        st.addEntry(rname, new shared SymEntry(a));
+                        var a= st.addEntry(rname, e.size, int);
+                        a.a = * scan e.a;
                     }
                     when "sin" {
-                        var a = Math.sin(e.a);
-                        st.addEntry(rname,new shared SymEntry(a));
+                        var a = st.addEntry(rname, e.size, real);
+                        a.a = Math.sin(e.a);
                     }
                     when "cos" {
-                        var a = Math.cos(e.a);
-                        st.addEntry(rname,new shared SymEntry(a));
+                        var a = st.addEntry(rname, e.size, real);
+                        a.a = Math.cos(e.a);
                     }
                     otherwise {return notImplementedError(pn,efunc,gEnt.dtype);}
                 }
@@ -82,32 +83,32 @@ module EfuncMsg
                 select efunc
                 {
                     when "abs" {
-                        var a = Math.abs(e.a);
-                        st.addEntry(rname, new shared SymEntry(a));
+                        var a = st.addEntry(rname, e.size, real);
+                        a.a = Math.abs(e.a);
                     }
                     when "log" {
-                        var a = Math.log(e.a);
-                        st.addEntry(rname, new shared SymEntry(a));
+                        var a = st.addEntry(rname, e.size, real);
+                        a.a = Math.log(e.a);
                     }
                     when "exp" {
-                        var a = Math.exp(e.a);
-                        st.addEntry(rname, new shared SymEntry(a));
+                        var a = st.addEntry(rname, e.size, real);
+                        a.a = Math.exp(e.a);
                     }
                     when "cumsum" {
-                        var a: [e.aD] real = + scan e.a;
-                        st.addEntry(rname, new shared SymEntry(a));
+                        var a = st.addEntry(rname, e.size, real);
+                        a.a = + scan e.a;
                     }
                     when "cumprod" {
-                        var a: [e.aD] real = * scan e.a;
-                        st.addEntry(rname, new shared SymEntry(a));
+                        var a = st.addEntry(rname, e.size, real);
+                        a.a = * scan e.a;
                     }
                     when "sin" {
-                        var a = Math.sin(e.a);
-                        st.addEntry(rname,new shared SymEntry(a));
+                        var a = st.addEntry(rname, e.size, real);
+                        a.a = Math.sin(e.a);
                     }
                     when "cos" {
-                        var a = Math.cos(e.a);
-                        st.addEntry(rname,new shared SymEntry(a));
+                        var a = st.addEntry(rname, e.size, real);
+                        a.a = Math.cos(e.a);
                     }
                     otherwise {return notImplementedError(pn,efunc,gEnt.dtype);}
                 }
@@ -118,13 +119,13 @@ module EfuncMsg
                 {
                     when "cumsum" {
                         var ia: [e.aD] int = (e.a:int); // make a copy of bools as ints blah!
-                        var a: [e.aD] int = + scan ia;
-                        st.addEntry(rname, new shared SymEntry(a));
+                        var a = st.addEntry(rname, e.size, int);
+                        a.a = + scan ia;
                     }
                     when "cumprod" {
                         var ia: [e.aD] int = (e.a:int); // make a copy of bools as ints blah!
-                        var a: [e.aD] int = * scan ia;
-                        st.addEntry(rname, new shared SymEntry(a));
+                        var a = st.addEntry(rname, e.size, int);
+                        a.a = * scan ia;
                     }
                     otherwise {return notImplementedError(pn,efunc,gEnt.dtype);}
                 }

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -75,7 +75,7 @@ module IndexingMsg
             ref ea = e.a;
             ref aa = a.a;
             [(elt,j) in zip(aa, slice)] elt = ea[j];
-            //[(elt,j) in zip(a, slice)] unorderedCopy(elt,ea[j]);
+            //[(elt,j) in zip(a.a, slice)] unorderedCopy(elt,ea[j]);
             return try! "created " + st.attrib(rname);
         }
         
@@ -136,7 +136,7 @@ module IndexingMsg
             var pop = iv[iv.size-1];
             if v {writeln("pop = ",pop,"last-scan = ",iv[iv.size-1]);try! stdout.flush();}
             var a = st.addEntry(rname, pop, XType);
-            //[i in e.aD] if (truth.a[i] == true) {a[iv[i]-1] = e.a[i];}// iv[i]-1 for zero base index
+            //[i in e.aD] if (truth.a[i] == true) {a.a[iv[i]-1] = e.a[i];}// iv[i]-1 for zero base index
             ref ead = e.aD;
             ref ea = e.a;
             ref trutha = truth.a;

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -71,11 +71,11 @@ module IndexingMsg
 
         proc sliceHelper(type t) {
             var e = toSymEntry(gEnt,t);
-            var a = makeDistArray(slice.size, t);
+            var a = st.addEntry(rname, slice.size, t);
             ref ea = e.a;
-            [(elt,j) in zip(a, slice)] elt = ea[j];
+            ref aa = a.a;
+            [(elt,j) in zip(aa, slice)] elt = ea[j];
             //[(elt,j) in zip(a, slice)] unorderedCopy(elt,ea[j]);
-            st.addEntry(rname, new shared SymEntry(a));
             return try! "created " + st.attrib(rname);
         }
         
@@ -118,12 +118,13 @@ module IndexingMsg
             var ivMax = max reduce iv.a;
             if ivMin < 0 {return try! "Error: %s: OOBindex %i < 0".format(pn,ivMin);}
             if ivMax >= e.size {return try! "Error: %s: OOBindex %i > %i".format(pn,ivMin,e.size-1);}
-            var a: [iv.aD] XType;
-            //[i in iv.aD] a[i] = e.a[iv.a[i]]; // bounds check iv[i] against e.aD?
+            var a = st.addEntry(rname, iv.size, XType);
+            //[i in iv.aD] a.a[i] = e.a[iv.a[i]]; // bounds check iv[i] against e.aD?
             ref a2 = e.a;
             ref iva = iv.a;
-            [(a1,idx) in zip(a,iva)] unorderedCopy(a1,a2[idx]); // bounds check iv[i] against e.aD?
-            st.addEntry(rname, new shared SymEntry(a));
+            ref aa = a.a;
+            [(a1,idx) in zip(aa,iva)] unorderedCopy(a1,a2[idx]); // bounds check iv[i] against e.aD?
+            
             return try! "created " + st.attrib(rname);
         }
 
@@ -134,13 +135,13 @@ module IndexingMsg
             var iv: [truth.aD] int = (+ scan truth.a);
             var pop = iv[iv.size-1];
             if v {writeln("pop = ",pop,"last-scan = ",iv[iv.size-1]);try! stdout.flush();}
-            var a = makeDistArray(pop, XType);
+            var a = st.addEntry(rname, pop, XType);
             //[i in e.aD] if (truth.a[i] == true) {a[iv[i]-1] = e.a[i];}// iv[i]-1 for zero base index
             ref ead = e.aD;
             ref ea = e.a;
             ref trutha = truth.a;
-            [i in ead] if (trutha[i] == true) {unorderedCopy(a[iv[i]-1], ea[i]);}// iv[i]-1 for zero base index
-            st.addEntry(rname, new shared SymEntry(a));
+            ref aa = a.a;
+            [i in ead] if (trutha[i] == true) {unorderedCopy(aa[iv[i]-1], ea[i]);}// iv[i]-1 for zero base index
             return try! "created " + st.attrib(rname);
         }
         

--- a/src/MsgProcessing.chpl
+++ b/src/MsgProcessing.chpl
@@ -205,17 +205,17 @@ module MsgProcessing
         if v {try! writeln("%s %i %i %i : %i , %s".format(cmd, start, stop, stride, len, rname));try! stdout.flush();}
         
         var t1 = Time.getCurrentTime();
-        var aD = makeDistDom(len);
-        var a = makeDistArray(len, int);
+        var e = st.addEntry(rname, len, int);
         writeln("alloc time = ",Time.getCurrentTime() - t1,"sec"); try! stdout.flush();
 
         t1 = Time.getCurrentTime();
-        forall i in aD {
-            a[i] = start + (i * stride);
+        ref ea = e.a;
+        ref ead = e.aD;
+        forall (ei, i) in zip(ea,ead) {
+            ei = start + (i * stride);
         }
         writeln("compute time = ",Time.getCurrentTime() - t1,"sec"); try! stdout.flush();
 
-        st.addEntry(rname, new shared SymEntry(a));
         return try! "created " + st.attrib(rname);
     }            
 
@@ -244,19 +244,19 @@ module MsgProcessing
         if v {try! writeln("%s %r %r %i : %r , %s".format(cmd, start, stop, len, stride, rname));try! stdout.flush();}
 
         var t1 = Time.getCurrentTime();
-        var aD = makeDistDom(len);
-        var a = makeDistArray(len, real);
+        var e = st.addEntry(rname, len, real);
         writeln("alloc time = ",Time.getCurrentTime() - t1,"sec"); try! stdout.flush();
 
         t1 = Time.getCurrentTime();
-        forall i in aD {
-            a[i] = start + (i * stride);
+        ref ea = e.a;
+        ref ead = e.aD;
+        forall (ei, i) in zip(ea,ead) {
+            ei = start + (i * stride);
         }
-        a[0] = start;
-        a[len-1] = stop;
+        ea[0] = start;
+        ea[len-1] = stop;
         writeln("compute time = ",Time.getCurrentTime() - t1,"sec"); try! stdout.flush();
 
-        st.addEntry(rname, new shared SymEntry(a));
         return try! "created " + st.attrib(rname);
     }
 

--- a/src/RandMsg.chpl
+++ b/src/RandMsg.chpl
@@ -35,14 +35,15 @@ module RandMsg
         select (dtype) {
             when (DType.Int64) {                
                 var t1 = Time.getCurrentTime();
-                var aD = makeDistDom(len);
-                var a = makeDistArray(len, int);
+                var e = st.addEntry(rname, len, int);
                 writeln("alloc time = ",Time.getCurrentTime() - t1,"sec"); try! stdout.flush();
                 
                 t1 = Time.getCurrentTime();
+                ref ea = e.a;
+                ref ead = e.aD;
                 coforall loc in Locales {
                     on loc {
-		      ref myA = a.localSlice[a.localSubdomain()];
+		      ref myA = ea.localSlice[ea.localSubdomain()];
 		      fillRandom(myA);
 		      [ai in myA] if (ai < 0) { ai = -ai; }
 		      const modulus = aMax - aMin;
@@ -50,46 +51,42 @@ module RandMsg
                     }
                 }
                 writeln("compute time = ",Time.getCurrentTime() - t1,"sec"); try! stdout.flush();
-                
-                st.addEntry(rname, new shared SymEntry(a));
             }
             when (DType.Float64) {
                 var t1 = Time.getCurrentTime();
-                var aD = makeDistDom(len);
-                var a = makeDistArray(len, real);
+                var e = st.addEntry(rname, len, real);
                 writeln("alloc time = ",Time.getCurrentTime() - t1,"sec"); try! stdout.flush();
                 
                 t1 = Time.getCurrentTime();
+                ref ea = e.a;
+                ref ead = e.aD;
                 coforall loc in Locales {
                     on loc {
-		      ref myA = a.localSlice[a.localSubdomain()];
+		      ref myA = ea.localSlice[ea.localSubdomain()];
 		      fillRandom(myA);
 		      const scale = aMax - aMin;
 		      myA = scale*myA + aMin;
                     }
                 }
                 writeln("compute time = ",Time.getCurrentTime() - t1,"sec"); try! stdout.flush();
-                
-                st.addEntry(rname, new shared SymEntry(a));                
             }
             when (DType.Bool) {
                 var t1 = Time.getCurrentTime();
-                var aD = makeDistDom(len);
-                var a = makeDistArray(len, bool);
+                var e = st.addEntry(rname, len, bool);
                 writeln("alloc time = ",Time.getCurrentTime() - t1,"sec"); try! stdout.flush();
                 
                 t1 = Time.getCurrentTime();
+                ref ea = e.a;
+                ref ead = e.aD;
                 coforall loc in Locales {
                     on loc {
-		      ref myA = a.localSlice[a.localSubdomain()];
+		      ref myA = ea.localSlice[ea.localSubdomain()];
 		      fillRandom(myA);
                         /* var R = new owned RandomStream(real); R.getNext(); */
                         /* [i in a.localSubdomain()] a[i] = (R.getNext() >= 0.5); */
                     }
                 }
                         writeln("compute time = ",Time.getCurrentTime() - t1,"sec"); try! stdout.flush();
-                
-                st.addEntry(rname, new shared SymEntry(a));
             }            
             otherwise {return notImplementedError(pn,dtype);}
         }


### PR DESCRIPTION
fixed all the easy cases of making extra array copies.
changed from using
```chapel
st.addEntry(rname, new shared SymEntry(a));
```
to using 
```chapel
var a = st.addEntry(rname, size, type);
```
and writing directly into the array associated with the symbol table entry.
