### PR TITLE
Restore `use IO` statements and make ServerConfig's `public`

### DIFF
--- a/src/RadixSortLSD.chpl
+++ b/src/RadixSortLSD.chpl
@@ -27,7 +27,7 @@ module RadixSortLSD
     use AryUtil;
     use UnorderedCopy;
     use CommAggregation;
-    //use IO;
+    use IO;
 
     inline proc getBitWidth(a: [?aD] int): int {
       var aMin = min reduce a;

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -7,7 +7,7 @@ module ServerConfig
     use HDF5.C_HDF5 only H5get_libversion;
     use SymArrayDmap only makeDistDom;
 
-    //use IO;
+    public use IO;
 
     use ServerErrorStrings;
     

--- a/src/ServerErrorStrings.chpl
+++ b/src/ServerErrorStrings.chpl
@@ -2,6 +2,7 @@
 module ServerErrorStrings
 {
     use NumPyDType;
+    use IO;
     
     class ErrorWithMsg: Error {
       var msg: string;


### PR DESCRIPTION
This re-instates the `use IO` statements introduced in PR #189
and commented out in PR #196 (I believe while debugging a
separate issue which turned out to be unrelated to these uses. 
Though they are not required with Chapel 1.20, they are with the
master branch of Chapel as we tighten up the set of symbols
that are provided by default to exclude channels and files.

In addition, I made the use statement in ServerConfig public
such that it would be transitively available to modules that
`use ServerConfig` as we make `use` statements private by
default.

Finally, I added one new `use IO` statement to ServerErrorStrings
which was necessary for it to get the string.format function.