### PR TITLE
Add `use SysCTypes` where needed

### DIFF
--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -307,6 +307,8 @@ module GenSymIO {
   
   /* Get the subdomains of the distributed array represented by each file, as well as the total length of the array. */
   proc get_subdoms(filenames: [?FD] string, dsetName: string) throws {
+    use SysCTypes;
+
     var lengths: [FD] int;
     for (i, filename) in zip(FD, filenames) {
       var file_id = C_HDF5.H5Fopen(filename.c_str(), C_HDF5.H5F_ACC_RDONLY, C_HDF5.H5P_DEFAULT);

--- a/src/RadixSortLSD.chpl
+++ b/src/RadixSortLSD.chpl
@@ -64,6 +64,8 @@ module RadixSortLSD
     */
     
     inline proc getDigit(key: real, rshift: int): int {
+      use SysCTypes;
+
       var shiftedKey: uint = shiftDouble(key: c_double, rshift: c_longlong): uint;
       return (shiftedKey & maskDigit):int;
     }

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -49,6 +49,7 @@ module ServerConfig
     }
 
     proc getConfig(): string {
+        use SysCTypes;
         
         class LocaleConfig {
             var id: int;


### PR DESCRIPTION
Traditionally, symbols in SysCTypes have been automatically available to
Chapel code, but as part of our effort to be more precise about
namespaces, we have changed that so that an explicit `use SysCTypes;`
is now required.  This PR adds such a statement to the places in
Arkouda that currently rely on such types (e.g., `c_int`) and don't already
have them available.  It is backwards compatible with Chapel 1.20.