### PR TITLE
Add a qualified reference to Time.Timer

### DIFF
--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -35,7 +35,7 @@ proc main() {
 
     var reqCount: int = 0;
     var repCount: int = 0;
-    var t1 = new Timer();
+    var t1 = new Time.Timer();
     t1.clear();
     t1.start();
     while !shutdownServer {


### PR DESCRIPTION
On the master branch of Chapel, we're getting much better about
reducing the number of symbols that are inadvertently made available
in user code.  This PR updates a reference to `Timer` to be the
fully-qualified `Time.Timer` since the use statement referring to Time
is `use Time only;` (alternatively, one could presumably change it to
just `use Time;` or `use Time only Timer;` but I didn't try either of
those for the sake of expediency).