### PR TITLE
Add a sorting test and fix some bugs

### DIFF
--- a/src/RadixSortLSD.chpl
+++ b/src/RadixSortLSD.chpl
@@ -46,29 +46,15 @@ module RadixSortLSD
         return ((key >> rshift) & maskDigit);
     }
 
-    proc shiftDouble(in key: real(64), rshift: int(64)) {
-      const ptrToReal = c_ptrTo(key);
-      const ptrToULL = ptrToReal: c_ptr(int(64));
-      const intkey = ptrToULL.deref();
-      return (intkey >> rshift);
+    inline proc realToUint(in r: real): uint {
+        var u: uint;
+        c_memcpy(c_ptrTo(u), c_ptrTo(r), numBytes(r.type));
+        return u;
     }
-    pragma "no doc" // Bug: chapel-lang/chapel#14250
-    /*
-    extern {
-      static inline unsigned long long shiftDouble(double key, long long rshift) {
-	// Reinterpret the bits of key as an unsigned 64-bit int (u long long)
-	// Unsigned because we want to left-extend with zeros
-	unsigned long long intkey = * (unsigned long long *) &key;
-	return (intkey >> rshift);
-      }
-    }
-    */
-    
-    inline proc getDigit(key: real, rshift: int): int {
-      use SysCTypes;
 
-      var shiftedKey: uint = shiftDouble(key: c_double, rshift: c_longlong): uint;
-      return (shiftedKey & maskDigit):int;
+    inline proc getDigit(key: real, rshift: int): int {
+        var keyu = realToUint(key);
+        return ((keyu >> rshift) & maskDigit):int;
     }
 
     inline proc isNeg(key) {

--- a/src/RadixSortLSD.chpl
+++ b/src/RadixSortLSD.chpl
@@ -34,6 +34,7 @@ module RadixSortLSD
       var aMax = max reduce a;
       var wPos = if aMax >= 0 then numBits(int) - clz(aMax) else 0;
       var wNeg = if aMin < 0 then numBits(int) - clz(-aMin) + 1 else 0;
+      wNeg = min(wNeg, numBits(int));
       return max(wPos, wNeg);
     }
 
@@ -68,6 +69,14 @@ module RadixSortLSD
 
       var shiftedKey: uint = shiftDouble(key: c_double, rshift: c_longlong): uint;
       return (shiftedKey & maskDigit):int;
+    }
+
+    inline proc isNeg(key) {
+      if isReal(key) {
+        return signbit(key);
+      } else {
+        return key < 0;
+      }
     }
 
     // calculate sub-domain for task
@@ -232,7 +241,7 @@ module RadixSortLSD
 	// if there are no negative keys then firstNegative will be aD.low
         var hasNegatives: bool , firstNegative: int;
         // maxloc on bools returns the first index where condition is true
-        (hasNegatives, firstNegative) = maxloc reduce zip([(key,rank) in kr1] (key < 0), aD);
+        (hasNegatives, firstNegative) = maxloc reduce zip([(key,rank) in kr1] (isNeg(key)), aD);
         // Swap the ranks of the positive and negative keys, so that negatives come first
         // If real type, then negative keys will appear in descending order and
         // must be reversed
@@ -390,7 +399,7 @@ module RadixSortLSD
         // if there are no negative keys then firstNegative will be aD.low
         var hasNegatives: bool , firstNegative: int;
         // maxloc on bools returns the first index where condition is true
-        (hasNegatives, firstNegative) = maxloc reduce zip([key in k1] (key < 0), aD);
+        (hasNegatives, firstNegative) = maxloc reduce zip([key in k1] (isNeg(key)), aD);
         // Swap the ranks of the positive and negative keys, so that negatives come first
         // If real type, then negative keys will appear in descending order and
         // must be reversed

--- a/test/UnitTestSort.chpl
+++ b/test/UnitTestSort.chpl
@@ -1,0 +1,215 @@
+module UnitTestSort
+{
+  use CommDiagnostics;
+  use IO;
+  use Memory;
+  use Random;
+  use Time;
+
+  use BlockDist;
+
+  use RadixSortLSD;
+  use AryUtil;
+
+  enum testMode { correctness, correctnessFast, performance, commDiags };
+  config const mode = testMode.correctness;
+
+  config const elemsPerLocale = -1;
+  const numElems = numLocales * elemsPerLocale;
+  config const printArrays = false;
+
+  /* Timing and Comm diagnostic reporting helpers */
+
+  var t: Timer;
+  inline proc startDiag() {
+    select mode {
+      when testMode.performance { t.start(); }
+      when testMode.commDiags   { startCommDiagnostics(); }
+    }
+  }
+  inline proc endDiag(name, type elemType, nElems, sortDesc) {
+    select mode {
+      when testMode.performance { t.stop(); }
+      when testMode.commDiags { stopCommDiagnostics(); }
+    }
+
+    var sortType = try! "%s(A:[] %s)".format(name, elemType:string);
+    writef("%33s -- (%s)", sortType, sortDesc);
+    select mode {
+      when testMode.performance {
+        const sec = t.elapsed();
+        const mbPerNode = (nElems * numBytes(elemType)):real / (1024.0*1024.0) / numLocales:real;
+        writef(" -- %.2dr MB/s per node (%.2drs)", mbPerNode/sec, sec);
+        t.clear();
+      }
+      when testMode.commDiags {
+        const d = getCommDiagnostics();
+        const GETS = +reduce (d.get + d.get_nb);
+        const PUTS = +reduce (d.put + d.put_nb);
+        const ONS = +reduce (d.execute_on + d.execute_on_fast + d.execute_on_nb);
+        writef(" -- GETS: %i, PUTS: %i, ONS: %i", GETS, PUTS, ONS);
+        resetCommDiagnostics();
+      }
+    }
+    writef("\n");
+  }
+
+
+  /* Main sort testing routine */
+
+  proc testSort(A:[?D], type elemType, nElems, sortDesc) {
+    {
+      startDiag();
+      var sortedA = radixSortLSD_keys(A, checkSorted=false);
+      endDiag("radixSortLSD_keys", elemType, nElems, sortDesc);
+      if printArrays { writeln(A); writeln(sortedA); }
+      assert(isSorted(sortedA));
+    }
+
+    {
+      startDiag();
+      var rankSortedA = radixSortLSD_ranks(A, checkSorted=false);
+      endDiag("radixSortLSD_ranks", elemType, nElems, sortDesc);
+      var sortedA: [D] elemType = forall i in rankSortedA do A[i];
+      if printArrays { writeln(A); writeln(rankSortedA); writeln(sortedA); }
+      assert(isSorted(sortedA));
+    }
+  }
+ 
+ 
+  /* Correctness Testing */
+
+  inline proc negateEven(val) {
+    if val % 2 == 0 then return -val;
+                    else return val;
+  }
+
+  // Sort permutations of the indices
+  proc testSortIndexPerm(type elemType, nElems) {
+    const D = newBlockDom({0..#nElems});
+    var A: [D] elemType;
+
+    forall i in D { A[i] = i:elemType; }
+    testSort(A, elemType, nElems, "indices");
+
+    forall i in D { A[i] = (nElems - 1 - i):elemType; }
+    testSort(A, elemType, nElems, "rev indices");
+
+    forall i in D { A[i] = (nElems/2 - i):elemType; }
+    testSort(A, elemType, nElems, "rev shifted indices");
+
+    forall i in D { A[i] = max(elemType) - i:elemType; }
+    testSort(A, elemType, nElems, "rev max-indices");
+
+    forall i in D { A[i] = negateEven(i):elemType; }
+    testSort(A, elemType, nElems, "negate even indices");
+  }
+
+
+  // Fill an array with random values between min(T) and max(T) and sort it
+  proc testSortRandVals(A:[?D], type T, nElems) {
+    type elemType = A.eltType;
+
+    var B: [D] T;
+    fillRandom(B);
+    A = B:A.eltType;
+
+    testSort(A, elemType, nElems, "rand "+T:string+" vals");
+  }
+
+  // Sort arrays that contain random values between various int/uint sizes
+  // (e.g. sort random values that fit in int(32) and uint(32))
+  proc testSortMultRandVals(type elemType, nElems) {
+    const D = newBlockDom({0..#nElems});
+    var A: [D] elemType;
+
+    testSortRandVals(A, int(8),  nElems);
+    testSortRandVals(A, int(16), nElems);
+    testSortRandVals(A, int(32), nElems);
+    testSortRandVals(A, int(64), nElems);
+
+    testSortRandVals(A, uint(8),  nElems);
+    testSortRandVals(A, uint(16), nElems);
+    testSortRandVals(A, uint(32), nElems);
+    testSortRandVals(A, uint(64), nElems);
+  }
+
+
+  proc testSortActiveBitRange(A, type elemType, nElems, activeBits) {
+    var mask: int;
+    for bit in activeBits {
+      if bit < numBits(int) then mask |= (1:uint<<bit):int;
+    }
+
+    fillRandom(A);
+    A &= mask;
+
+    testSort(A, elemType, nElems, "activeBits="+activeBits:string);
+  }
+
+  // Sort random values where various bit pattens are active. Radix sorting
+  // treats values as "bags of bits", so here we mask different bit ranges and
+  // bit clusters, which can trigger some interesting corner cases
+  proc testSortActiveBitRanges(type elemType, nElems) {
+    const D = newBlockDom({0..#nElems});
+    var A: [D] elemType;
+
+    const intBits = numBits(int);
+    // Test sorting positive values with consecutive active bit ranges
+    // (bits 0-(maxBits-1) are active)
+    for maxBits in 1..intBits do
+      testSortActiveBitRange(A, elemType, nElems, 0..#maxBits);
+
+    // Test sorting where clusters of bits are active (bits 0-15, 16-31, ..)
+    for startBit in 0..#intBits by 16 do
+      testSortActiveBitRange(A, elemType, nElems, startBit..#16);
+
+    // Test sorting negative values for consecutive active bit ranges
+    // (startBit-(intBits-1) are active)
+    for maxBits in 1..intBits do
+      testSortActiveBitRange(A, elemType, nElems, intBits-maxBits..intBits-1);
+
+    // Test sorting values where a strides of bits are active
+    for stride in 1..intBits do
+      testSortActiveBitRange(A, elemType, nElems, 0..intBits-1 by stride);
+
+    // Test integers that use the full bit range 
+    testSortActiveBitRange(A, elemType, nElems, 0..#intBits);
+  }
+
+
+  /* Performance Testing */
+
+  // By default, sort ints with uint(16) values using 1/50 of memory
+  config type perfElemType = int,
+              perfValRange = uint(16);
+  config const perfMemFraction = 50;
+  config param perfOnlyCompile = false; // reduces compilation time
+
+  proc testPerformance() {
+    param elemSize = numBytes(perfElemType);
+    const totMem = here.physicalMemory(unit = MemUnits.Bytes);
+    const fraction = totMem / elemSize / perfMemFraction * numLocales;
+    const nElems = if numElems > 0 then numElems else fraction;
+
+    const D = newBlockDom({0..#nElems});
+    var A: [D] perfElemType;
+    testSortRandVals(A, perfValRange, nElems);
+  }
+ 
+  proc main() {
+    const correctness = mode == testMode.correctness || mode == testMode.correctnessFast;
+    if !perfOnlyCompile && correctness {
+      const nElems = if numElems > 0 then numElems else numLocales*10000;
+      testSortIndexPerm(int, nElems);
+      testSortIndexPerm(real, nElems);
+      testSortMultRandVals(int, nElems);
+      testSortMultRandVals(real, nElems);
+      if mode == testMode.correctness {
+        testSortActiveBitRanges(int, nElems);
+      }
+    } else {
+      testPerformance();
+    }
+  }
+}


### PR DESCRIPTION
This adds a pretty carefully crafted test that has been really useful in
some work I've been doing to optimize sorting. There are 3 main
correctness variants:
 - Sort int/real arrays where the initial values are permuted indices
   There are variants that reverse the indices, shift the indices so 1/2
   are neg, make every other value neg, etc. This is a pretty simple and
   deterministic test.
 - Sort int/real arrays of random values between min(T) and max(T) where
   T is all int/uint types. e.g. it creates an int/real array where the
   values fit in 16-bit ints. This is representative of the typical
   input I would expect for sorting.
 - Sort int arrays where we take random 64-bit values and mask to create
   different interesting "active bit ranges". For instance we might mask
   so only the first or last 32-bits are active, or mask so that every
   other bit or only the first and last bits are active. This is a weird
   test, but it has uncovered a lot of bugs in my optimizations. Radix
   sort treats values as "bags of bits" and this stresses weird bit
   patterns.

The correctness test uses 10_000*numLocales elements. There are a lot of
variations, especially for the activeBitRange checks. Those can be
skipped with `--mode=testMode.correctnessFast`

The performance test is basically what I used in #162. It sorts int(64)
arrays populated with uint(16) values using 1/50 of memory. The array
type, value range, and memory fraction are configs. The default was
chosen because it will only go through the main radix sort loop once, so
it gives a good baseline.

This also fixes bugs uncovered by the sort test.

 - Ensure getBitWidth is bounded by `numBits(T)`. If min(int) was
   present it would return 65, which isn't valid.
 - Fix how negative numbers were being checked for. It was broken for
   `-0.0`, so swap to using `signbit` for reals.
 - `getDigit` for reals was trying to convert the real to a uint and
   then shift that. However, it was converting with casts that resulted
   in type-punning which is UB. Instead use memcpy to cast. This is the
   right way to convert types, and all C compilers will optimize this
   pattern (we have used this idiom and verified the asm is optimal in
   our runtime.)