### PR TITLE
Reduce travis virtual memory pressure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,5 @@ jobs:
         docker run -it -v ${TRAVIS_BUILD_DIR}:/repo.git -w /repo.git chapel/chapel:1.20.0 /bin/bash -c '
         apt-get update && apt-get install -y libhdf5-dev libzmq3-dev python3-pip &&
         echo "\$(eval \$(call add-path,/usr/lib/x86_64-linux-gnu/hdf5/serial/))" > Makefile.paths &&
-        ARKOUDA_DEVELOPER=true make'
+        ARKOUDA_DEVELOPER=true CHPL_FLAGS="--stop-after-pass codegen --savec savec" make && 
+        time -p make -f savec/Makefile'


### PR DESCRIPTION
Split the Chapel and backend compilation to reduce memory pressure.
Memory used by the Chapel compiler is not released to the system before
invoking the backend compiler. Here we stop after doing codegen, and
then build the C code to reduce total memory pressure. Travis is pretty
resources constrained (either 4 or 8 GB of virtual memory) so split the
steps to reduce virtual memory footprint.

This is lame, but the only thing I can think of to meaningfully reduce
memory pressure for the 1.20 compiler. This should allow #204 to compile
under travis.