### PR TITLE
Bump benchmarks/argsort.py problem size

### DIFF
--- a/benchmarks/argsort.py
+++ b/benchmarks/argsort.py
@@ -4,13 +4,10 @@ import time, argparse
 import numpy as np
 import arkouda as ak
 
-def time_ak_argsort(N_per_locale, trials, dtype, scale_by_locales):
+def time_ak_argsort(N_per_locale, trials, dtype):
     print(">>> arkouda argsort")
     cfg = ak.get_config()
-    if scale_by_locales:
-        N = N_per_locale * cfg["numLocales"]
-    else:
-        N = N_per_locale
+    N = N_per_locale * cfg["numLocales"]
     print("numLocales = {}, N = {:,}".format(cfg["numLocales"], N))
     if dtype == 'int64':
         a = ak.randint(0, 2**32, N)
@@ -54,10 +51,9 @@ def create_parser():
     parser = argparse.ArgumentParser(description="Measure performance of sorting an array of random values.")
     parser.add_argument('hostname', help='Hostname of arkouda server')
     parser.add_argument('port', type=int, help='Port of arkouda server')
-    parser.add_argument('-n', '--size', type=int, default=10**7, help='Problem size: length of array to argsort')
+    parser.add_argument('-n', '--size', type=int, default=10**8, help='Problem size: length of array to argsort')
     parser.add_argument('-t', '--trials', type=int, default=6, help='Number of times to run the benchmark')
     parser.add_argument('-d', '--dtype', default='int64', help='Dtype of array (int64 or float64)')
-    parser.add_argument('-s', '--scale-by-locales', default=False, action='store_true', help='For arkouda, scale up the array by the number of locales')
     parser.add_argument('--numpy', default=False, action='store_true', help='Run the same operation in NumPy to compare performance.')
     return parser
 
@@ -72,7 +68,7 @@ if __name__ == "__main__":
     
     print("array size = {:,}".format(args.size))
     print("number of trials = ", args.trials)
-    time_ak_argsort(args.size, args.trials, args.dtype, args.scale_by_locales)
+    time_ak_argsort(args.size, args.trials, args.dtype)
     if args.numpy:
         time_np_argsort(args.size, args.trials, args.dtype)
     sys.exit(0)


### PR DESCRIPTION
Sorting is much faster now, so increase the problem size of argsort.py
to match the other benchmarks.