### PR TITLE
Completely disable --cache-remote

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,12 +22,6 @@ endif
 CHPL_FLAGS += --ccflags="-Wno-incompatible-pointer-types"
 CHPL_FLAGS += -lhdf5 -lhdf5_hl -lzmq
 
-# --cache-remote does not work with ugni in Chapel 1.20
-COMM = $(shell $(CHPL_HOME)/util/chplenv/chpl_comm.py 2>/dev/null)
-ifneq ($(COMM),ugni)
-CHPL_FLAGS += --cache-remote
-endif
-
 # add-path: Append custom paths for non-system software.
 # Note: Darwin `ld` only supports `-rpath <path>`, not `-rpath=<paths>`.
 define add-path


### PR DESCRIPTION
In 1.20 the remote cache hurts performance of larger transfers, like the
ones now used with aggregation. This issue has been fixed on master, but
until 1.21 is released just stop using `--cache-remote`.

I plan on looking more in depth at how much Arkouda benefits from
`--cache-remote` with chapel master where many cache-remote bugs and
performance issues have been fixed. Until those fixes are in an official
release I think it makes sense to disable the cache.

Benchmark performance on 16 nodes of an FDR InfiniBand cluster:

| benchmark  | before      | after       |
| ---------- | ----------- | ----------- |
| argsort.py |  0.33 GiB/s |  1.35 GiB/s |
| gather.py  |  3.21 GiB/s |  9.93 GiB/s |
| scatter.py |  4.86 GiB/s | 32.91 GiB/s |