### PR TITLE
Add a mechanism to write/read the hostname and port to/from a file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,14 +250,8 @@ CLEAN_TARGETS += doc-clean
 doc-clean:
 	$(RM) -r $(DOC_DIR)
 
-COMM = $(shell $(CHPL_HOME)/util/chplenv/chpl_comm.py 2>/dev/null)
-ifneq ($(COMM),none)
-NUM_LOCALES := -nl 2
-endif
-SERVER_CONNECTION_INFO := $(ARKOUDA_PROJECT_DIR)/ak-server-info
 check:
-	$(ARKOUDA_PROJECT_DIR)/arkouda_server --serverConnectionInfo   $(SERVER_CONNECTION_INFO) $(NUM_LOCALES) &>/dev/null &
-	$(ARKOUDA_PROJECT_DIR)/tests/check.py --server-connection-info $(SERVER_CONNECTION_INFO) --shutdown-server
+	@$(ARKOUDA_PROJECT_DIR)/util/test/checkInstall
 
 #################
 #### Test.mk ####

--- a/Makefile
+++ b/Makefile
@@ -250,6 +250,15 @@ CLEAN_TARGETS += doc-clean
 doc-clean:
 	$(RM) -r $(DOC_DIR)
 
+COMM = $(shell $(CHPL_HOME)/util/chplenv/chpl_comm.py 2>/dev/null)
+ifneq ($(COMM),none)
+NUM_LOCALES := -nl 2
+endif
+SERVER_CONNECTION_INFO := $(ARKOUDA_PROJECT_DIR)/ak-server-info
+check:
+	$(ARKOUDA_PROJECT_DIR)/arkouda_server --serverConnectionInfo   $(SERVER_CONNECTION_INFO) $(NUM_LOCALES) &>/dev/null &
+	$(ARKOUDA_PROJECT_DIR)/tests/check.py --server-connection-info $(SERVER_CONNECTION_INFO) --shutdown-server
+
 #################
 #### Test.mk ####
 #################

--- a/arkouda/client.py
+++ b/arkouda/client.py
@@ -1,4 +1,5 @@
-import zmq, json, os
+import zmq, json, os, time
+import socket as std_socket
 import warnings, pkg_resources
 
 __all__ = ["verbose", "pdarrayIterThresh", "maxTransferBytes",
@@ -40,8 +41,37 @@ def set_defaults():
     maxTransferBytes = maxTransferBytesDefVal
 
 
+def get_server_and_port(server_connection_info):
+    while True:
+        try:
+            with open(server_connection_info, 'r') as f:
+                (hostname, port) = f.readline().split(':')
+                port = int(port)
+                if hostname == std_socket.gethostname():
+                    hostname = 'localhost'
+                return (hostname, port)
+        except (ValueError, FileNotFoundError) as e:
+            time.sleep(1)
+            continue
+
+def get_default_server_and_port():
+    (server, port) = ("localhost", 5555)
+    server_connection_info = os.getenv('ARKOUDA_SERVER_CONNECTION_INFO')
+    if server_connection_info:
+        (server, port) = get_server_and_port(server_connection_info)
+    return (server, port)
+
+def get_default_sever():
+    (server, port) = get_default_server_and_port()
+    return server
+
+def get_default_port():
+    (server, port) = get_default_server_and_port()
+    return port
+
+
 # create context, request end of socket, and connect to it
-def connect(server = "localhost", port = 5555):
+def connect(server = get_default_sever(), port = get_default_port()):
     """
     Connect to a running arkouda server.
 

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -37,6 +37,11 @@ module ServerConfig
     config param arkoudaVersion:string;
     
     /*
+    Write the server `hostname:port` to this file.
+    */
+    config const serverConnectionInfo: string = getEnv("ARKOUDA_SERVER_CONNECTION_INFO", "");
+
+    /*
     Hostname where I am running 
     */ 
     var serverHostname: string = try! get_hostname();
@@ -103,6 +108,13 @@ module ServerConfig
         }
         var res: string = try! "%jt".format(cfg);
         return res;
+    }
+
+    proc getEnv(name: string, default=""): string {
+        extern proc getenv(name : c_string) : c_string;
+        var val = getenv(name.localize().c_str()): string;
+        if val.isEmpty() { val = default; }
+        return val;
     }
 
     /*

--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -32,6 +32,7 @@ proc main() {
     var socket = context.socket(ZMQ.REP);
     socket.bind("tcp://*:%t".format(ServerPort));
     writeln("server listening on %s:%t".format(serverHostname, ServerPort)); try! stdout.flush();
+    createServerConnectionInfo();
 
     var reqCount: int = 0;
     var repCount: int = 0;
@@ -167,7 +168,27 @@ proc main() {
         if (logging) {writeln("<<< %s took %.17r sec".format(cmd, t1.elapsed() - s0)); try! stdout.flush();}
     }
     t1.stop();
+    deleteServerConnectionInfo();
     
     writeln("requests = ",reqCount," responseCount = ",repCount," elapsed sec = ",t1.elapsed());
+}
+
+proc createServerConnectionInfo() {
+    use IO;
+    if !serverConnectionInfo.isEmpty() {
+        try! {
+            var w = open(serverConnectionInfo, iomode.cw).writer();
+            w.writef("%s:%t\n", serverHostname, ServerPort);
+        }
+    }
+}
+
+proc deleteServerConnectionInfo() {
+    use FileSystem;
+    if !serverConnectionInfo.isEmpty() {
+        try! {
+            remove(serverConnectionInfo);
+        }
+    }
 }
 

--- a/tests/check.py
+++ b/tests/check.py
@@ -1,45 +1,21 @@
 #!/usr/bin/env python3                                                         
 
-import argparse
-import os
-import sys
-import socket
-import time
-
+import importlib
 import numpy as np
+import math
+import gc
+import sys
+
 import arkouda as ak
-
-
-def create_parser():
-    parser = argparse.ArgumentParser(description="Sanity check arkouda_server")
-    parser.add_argument('--hostname', help='Hostname of arkouda server',
-                        default='localhost')
-    parser.add_argument('--port', type=int, help='Port of arkouda server',
-                        default=5555)
-    parser.add_argument('--server-connection-info',
-                        help='File containing server `hostname:port`',
-                        default=os.getenv('ARKOUDA_SERVER_CONNECTION_INFO'))
-    parser.add_argument('--shutdown-server',
-                        help='Shutdown arkouda server',
-                        default=False, action='store_true')
-    return parser
-
-parser = create_parser()
-args = parser.parse_args()
 
 print(">>> Sanity checks on the arkouda_server")
 
-if args.server_connection_info:
-    while not os.path.exists(args.server_connection_info):
-        time.sleep(1)
-    with open(args.server_connection_info, 'r') as f:
-        (args.hostname, args.port) = f.readline().split(':')
-        args.port = int(args.port)
-        if args.hostname == socket.gethostname():
-            args.hostname = 'localhost'
-
 ak.verbose = False
-ak.connect(args.hostname, args.port)
+if len(sys.argv) > 1:
+    ak.connect(server=sys.argv[1], port=sys.argv[2])
+else:
+    ak.connect()
+
 
 N = 1_000_000
 
@@ -284,8 +260,5 @@ def check_set_integer_idx(N):
 
 print("check set integer idx = value:", check_set_integer_idx(N))
 
-if args.shutdown_server:
-    ak.shutdown()
-else:
-    ak.disconnect()
+ak.disconnect()
 sys.exit(errors)

--- a/util/test/checkInstall
+++ b/util/test/checkInstall
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+function log_info()
+{
+    local msg=$@
+    echo "[Info] ${msg}"
+}
+
+log_info "Running '`basename $0`'"
+
+DFLT_ARKOUDA_PROJECT_DIR=$(cd $(dirname $(dirname $(dirname $0))) ; pwd)
+ARKOUDA_PROJECT_DIR=${1:-"$DFLT_ARKOUDA_PROJECT_DIR"}
+
+SERVER="$ARKOUDA_PROJECT_DIR/arkouda_server"
+
+if "${SERVER}" --about | grep -q "CHPL_COMM: none"; then
+  NUM_LOCALES=1
+else
+  NUM_LOCALES=2
+fi
+
+export ARKOUDA_SERVER_CONNECTION_INFO="${ARKOUDA_PROJECT_DIR}/ak-server-info"
+rm -f "${ARKOUDA_SERVER_CONNECTION_INFO}"
+
+log_info "Starting '${SERVER} -nl ${NUM_LOCALES}'"
+"${SERVER}" -nl ${NUM_LOCALES} >/dev/null &
+
+log_info "Runing checks.py"
+"${ARKOUDA_PROJECT_DIR}/tests/check.py"
+check_status=$?
+
+log_info "Stopping server"
+"${ARKOUDA_PROJECT_DIR}/tests/shutdown.py" >/dev/null
+wait
+
+if [ $check_status -eq 0 ]; then
+  log_info "Success running checks!"
+else
+  log_info "Error running checks"
+fi
+
+exit $check_status


### PR DESCRIPTION
Add `--serverConnectionInfo` (`ARKOUDA_SERVER_CONNECTION_INFO`) that
will have the server write connection info (`hostname:port`) out to a
file. Also have the client read from the file indicated by the env var
if the var is set.

When running the server and client on a machine with a shared file
system this makes make it a lot easier to convey hostname/port
information automatically instead of having to manually copy the values.

This then adds a `make check` that uses this functionality and starts
the server, runs checks.py, and shutdown the server.