### PR TITLE
added __bool__ method to pdarray class

### DIFF
--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -73,6 +73,11 @@ class pdarray:
         except:
             pass
 
+    def __bool__(self):
+        if self.size != 1:
+            raise ValueError("The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()")
+        return self[0]
+
     def __len__(self):
         return self.shape[0]
 


### PR DESCRIPTION
this now produces the same behavior as numpy as far as I can tell.
`pda and 5` -> Python calls `pda.__bool__()` and produces `ValueError...` unless size of `pda` is `1` then gets the truth value of the only element
`5 and pda` -> Python calls `pda.__repr__()` just like NumPy and gets `True`

I know this behavior seems weird but that's how NumPy does it :-)
