### PR TITLE
Make it easier to automate running server and client programs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,6 +250,9 @@ CLEAN_TARGETS += doc-clean
 doc-clean:
 	$(RM) -r $(DOC_DIR)
 
+check:
+	@$(ARKOUDA_PROJECT_DIR)/util/test/checkInstall
+
 #################
 #### Test.mk ####
 #################

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -37,6 +37,11 @@ module ServerConfig
     config param arkoudaVersion:string;
     
     /*
+    Write the server `hostname:port` to this file.
+    */
+    config const serverConnectionInfo: string = getEnv("ARKOUDA_SERVER_CONNECTION_INFO", "");
+
+    /*
     Hostname where I am running 
     */ 
     var serverHostname: string = try! get_hostname();
@@ -103,6 +108,13 @@ module ServerConfig
         }
         var res: string = try! "%jt".format(cfg);
         return res;
+    }
+
+    proc getEnv(name: string, default=""): string {
+        extern proc getenv(name : c_string) : c_string;
+        var val = getenv(name.localize().c_str()): string;
+        if val.isEmpty() { val = default; }
+        return val;
     }
 
     /*

--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -32,6 +32,7 @@ proc main() {
     var socket = context.socket(ZMQ.REP);
     socket.bind("tcp://*:%t".format(ServerPort));
     writeln("server listening on %s:%t".format(serverHostname, ServerPort)); try! stdout.flush();
+    createServerConnectionInfo();
 
     var reqCount: int = 0;
     var repCount: int = 0;
@@ -167,7 +168,27 @@ proc main() {
         if (logging) {writeln("<<< %s took %.17r sec".format(cmd, t1.elapsed() - s0)); try! stdout.flush();}
     }
     t1.stop();
+    deleteServerConnectionInfo();
     
     writeln("requests = ",reqCount," responseCount = ",repCount," elapsed sec = ",t1.elapsed());
+}
+
+proc createServerConnectionInfo() {
+    use IO;
+    if !serverConnectionInfo.isEmpty() {
+        try! {
+            var w = open(serverConnectionInfo, iomode.cw).writer();
+            w.writef("%s %t\n", serverHostname, ServerPort);
+        }
+    }
+}
+
+proc deleteServerConnectionInfo() {
+    use FileSystem;
+    if !serverConnectionInfo.isEmpty() {
+        try! {
+            remove(serverConnectionInfo);
+        }
+    }
 }
 

--- a/util/test/checkInstall
+++ b/util/test/checkInstall
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+"""
+Run check.py, automatically starting/stopping the server.
+"""
+
+import sys
+import logging
+
+from util import *
+
+logging.basicConfig(level=logging.INFO)
+
+start_arkouda_server(get_arkouda_numlocales())
+ret = run_client_live([os.path.join(get_arkouda_home(), 'tests', 'check.py')])
+stop_arkouda_server()
+print('{} running checks'.format('Error' if ret else 'Success'))
+sys.exit(ret)

--- a/util/test/runClient
+++ b/util/test/runClient
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""
+Run an arkouda client program, automatically starting/stopping the server.
+Assumes that the client takes `hostname port` the first positional arguments.
+"""
+
+import argparse
+import sys
+
+from util import *;
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument('client', help='The arkouda client program to run')
+parser.add_argument('-nl', '--numLocales', type=int, help='Number of locales')
+
+args, client_args = parser.parse_known_args()
+numlocales = args.numLocales or get_arkouda_numlocales()
+
+start_arkouda_server(numlocales)
+ret = run_client_live([args.client] + client_args)
+stop_arkouda_server()
+sys.exit(ret)

--- a/util/test/util.py
+++ b/util/test/util.py
@@ -1,0 +1,117 @@
+import atexit
+import contextlib
+import logging
+import os
+import socket
+import subprocess
+import sys
+import time
+
+from collections import namedtuple
+
+import arkouda
+
+def get_arkouda_home():
+    arkouda_home = os.getenv('ARKOUDA_HOME')
+    if not arkouda_home:
+        dirname = os.path.dirname
+        arkouda_home = dirname(dirname(dirname(os.path.realpath(__file__))))
+    return arkouda_home
+
+def get_arkouda_server():
+    return os.path.join(get_arkouda_home(), 'arkouda_server')
+
+def is_multilocale_arkouda():
+    out = subprocess.check_output([get_arkouda_server(), '--about'], encoding='utf-8')
+    return 'CHPL_COMM: none' not in out
+
+def get_arkouda_numlocales():
+    if is_multilocale_arkouda():
+        return int(os.getenv('ARKOUDA_NUMLOCALES', 2))
+    else:
+        return 1
+
+def get_arkouda_server_info_file():
+    dflt = os.path.join(get_arkouda_home(), 'ak-server-info')
+    return os.getenv('ARKOUDA_SERVER_CONNECTION_INFO', dflt)
+
+def read_server_and_port_from_file(server_connection_info):
+    while True:
+        try:
+            with open(server_connection_info, 'r') as f:
+                (hostname, port) = f.readline().split(' ')
+                port = int(port)
+                if hostname == socket.gethostname():
+                    hostname = 'localhost'
+                return (hostname, port)
+        except (ValueError, FileNotFoundError) as e:
+            time.sleep(1)
+            continue
+
+
+ServerInfo = namedtuple('ServerInfo', 'host port process')
+_server_info = ServerInfo(None, None, None)
+
+def set_server_info(info):
+    global _server_info
+    _server_info = info
+
+def get_server_info():
+    if _server_info.host is None or _server_info.process.poll() is not None:
+        raise ValueError('Arkouda server is not running')
+    return _server_info
+
+def kill_server(server_process):
+    if server_process.poll() is None:
+        try:
+            logging.info('Attemping clean server shutdown')
+            stop_arkouda_server()
+        except ValueError as e:
+            pass
+
+        if server_process.poll() is None:
+            logging.warn('Attemping dirty server shutdown')
+            server_process.kill()
+
+def start_arkouda_server(numlocales, verbose=False, log=False):
+    connection_file = get_arkouda_server_info_file()
+    with contextlib.suppress(FileNotFoundError):
+        os.remove(connection_file)
+
+    cmd = [get_arkouda_server(),
+           '--logging={}'.format('true' if log else 'false'),
+           '--v={}'.format('true' if verbose else 'false'),
+           '--serverConnectionInfo={}'.format(connection_file),
+           '-nl {}'.format(numlocales)]
+
+    logging.info('Starting "{}"'.format(cmd))
+    process = subprocess.Popen(cmd, stdout=subprocess.DEVNULL)
+    atexit.register(kill_server, process)
+
+    (host, port) = read_server_and_port_from_file(connection_file)
+    set_server_info(ServerInfo(host, port, process))
+
+def stop_arkouda_server():
+    server_info = get_server_info()
+    logging.info('Stopping the arkouda server')
+    arkouda.connect(server_info.host, server_info.port)
+    arkouda.shutdown()
+    server_info.process.wait(20)
+
+
+def run_client(client_args):
+    server_info = get_server_info()
+    cmd = client_args + [server_info.host, str(server_info.port)]
+    logging.info('Running client "{}"'.format(cmd))
+    out = subprocess.check_output(cmd, encoding='utf-8')
+    return out
+
+def run_client_live(client_args):
+    server_info = get_server_info()
+    cmd = client_args + [server_info.host, str(server_info.port)]
+    logging.info('Running client "{}"'.format(cmd))
+    try:
+        subprocess.check_call(cmd, encoding='utf-8')
+        return 0
+    except subprocess.CalledProcessError as e:
+        return e.returncode


### PR DESCRIPTION
This implements a few features to make it easier to run a client and
automatically start/stop the server. This should make it easier to add
automated testing and benchmarking in multi-locale configurations.

Add a mechanism to write the server hostname and port to a file
---

Add `--serverConnectionInfo` (`ARKOUDA_SERVER_CONNECTION_INFO`) that
will have the server write connection info (`hostname port`) out to a
file. When running the server and client on a system with a shared file
system this should make it easier to share hostname/port information
automatically instead of having to manually copy the values each time.

With this you can do something like:

```
./arkouda_server -nl 16 --serverConnectionInfo ak-server-info
./benchmarks/stream.py $(cat ak-server-info)
```

Add `make check`
---

Add util.py, that has functionality to start the server, stop the
server, run a client, pick a default number of locales based on how
arkouda was compiled, and several other options. Use this to implement a
script that starts the server, runs check.py, and stops the server. This
script is called by `make check`

Add client wrapper that starts/stops server
---

For running a standalone test or benchmark without having to manually
start/stop the server and copy the host/port info. e.g.
`./util/test/runClient ./benchmarks/stream.py -nl 16`