### PR TITLE
Fixed argsort msg function for strings

### DIFF
--- a/arkouda/sorting.py
+++ b/arkouda/sorting.py
@@ -38,7 +38,11 @@ def argsort(pda):
     if isinstance(pda, pdarray) or isinstance(pda, Strings):
         if pda.size == 0:
             return zeros(0, dtype=int64)
-        repMsg = generic_msg("argsort {} {}".format(pda.objtype, pda.name))
+        if isinstance(pda, Strings):
+            name = '{}+{}'.format(pda.offsets.name, pda.bytes.name)
+        else:
+            name = pda.name
+        repMsg = generic_msg("argsort {} {}".format(pda.objtype, name))
         return create_pdarray(repMsg)
     else:
         raise TypeError("must be pdarray {}".format(pda))

--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -532,7 +532,7 @@ module ArgSortMsg
             }
           }
           when "str" {
-            var names = name.split();
+            var names = name.split('+');
             var strings = new owned SegString(names[1], names[2], st);
             // check and throw if over memory limit
             overMemLimit((8 * strings.size * 8)

--- a/tests/string_test.py
+++ b/tests/string_test.py
@@ -68,6 +68,13 @@ if __name__ == '__main__':
     assert((inds == matches).all())
     print("in1d and iter passed")
 
+    # argsort
+    akperm = ak.argsort(strings)
+    aksorted = strings[akperm].to_ndarray()
+    npsorted = np.sort(test_strings)
+    assert((aksorted == npsorted).all())
+    print("argsort passed")
+    
     # unique
     akuniq = ak.unique(strings)
     akset = set(akuniq.to_ndarray())


### PR DESCRIPTION
The client was incorrectly formatting the server message when `ak.argsort` was called on `Strings`. This didn't show up earlier because `GroupBy` and `unique` use `Strings.group()` instead of `argsort()`. Fixed the issue and added a test for argsort to `tests/string_test.py`.

Resolves #244 