### PR TITLE
Misc fixes and test updates

### DIFF
--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -76,7 +76,7 @@ class pdarray:
     def __bool__(self):
         if self.size != 1:
             raise ValueError("The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()")
-        return self[0]
+        return bool(self[0])
 
     def __len__(self):
         return self.shape[0]

--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -119,6 +119,8 @@ def zeros(size, dtype=np.float64):
     >>> ak.zeros(5, dtype=ak.bool)
     array([False, False, False, False, False])
     """
+    if not np.isscalar(size):
+        raise TypeError("size must be a scalar, not {}".format(type(size)))
     dtype = akdtype(dtype) # normalize dtype
     # check dtype for error
     if dtype.name not in DTypes:
@@ -156,6 +158,8 @@ def ones(size, dtype=float64):
     >>> ak.ones(5, dtype=ak.bool)
     array([True, True, True, True, True])
     """
+    if not np.isscalar(size):
+        raise TypeError("size must be a scalar, not {}".format(type(size)))
     dtype = akdtype(dtype) # normalize dtype
     # check dtype for error
     if dtype.name not in DTypes:
@@ -276,6 +280,9 @@ def arange(*args):
         stop = args[1]
         stride = args[2]
 
+    if not all((np.isscalar(start), np.isscalar(stop), np.isscalar(stride))):
+        raise TypeError("all arguments must be scalars")
+
     if stride == 0:
         raise ZeroDivisionError("division by zero")
 
@@ -315,6 +322,8 @@ def linspace(start, stop, length):
     >>> ak.linspace(0, 1, 5)
     array([0, 0.25, 0.5, 0.75, 1])
     """
+    if not all((np.isscalar(start), np.isscalar(stop), np.isscalar(length))):
+        raise TypeError("all arguments must be scalars")
     starttype = resolve_scalar_dtype(start)
     startstr = NUMBER_FORMAT_STRINGS[starttype].format(start)
     stoptype = resolve_scalar_dtype(stop)
@@ -365,6 +374,8 @@ def randint(low, high, size, dtype=int64):
     """
     # TO DO: separate out into int and float versions
     # TO DO: float version should accept non-integer low and high
+    if not all((np.isscalar(low), np.isscalar(high), np.isscalar(size))):
+        raise TypeError("all arguments must be scalars")
     dtype = akdtype(dtype) # normalize dtype
     # check dtype for error
     if dtype.name not in DTypes:

--- a/tests/check.py
+++ b/tests/check.py
@@ -26,6 +26,21 @@ def pass_fail(f):
     errors = errors or not f
     return ("Passed" if f else "Failed")
 
+def check_bool(N):
+    a = ak.arange(N)
+    b = ak.ones(N)
+    try:
+        c = a and b
+    except ValueError:
+        correct = True
+    except:
+        correct = False
+    d = ak.array([1])
+    correct = correct and (d and 5)
+    return pass_fail(correct)
+
+print("check boolean :", check_bool(N))
+
 def check_arange(N):
     # create np version
     a = np.arange(N)


### PR DESCRIPTION
This addresses #227 

* `pdarray` creation functions like `ak.arange` and `ak.zeros` now validate that all args are scalars. Before, you could call these functions on a python list and they would crash the server.
* There was still an issue with `__bool__` in the (rare) case of a singleton array. Fixed that and added a test to `check.py` that tests for proper behavior of `pdarray and other` for singleton and non-singleton arrays.
* The `operator_tests.py` script already checks the `scalar < pdarray` case, and it passes.