### PR TITLE
[Review] Allow Arkouda to Return Numba CUDA Array for GPU Processing

### DIFF
--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -522,11 +522,11 @@ class pdarray:
         Examples
         --------
         >>> a = ak.arange(0, 5, 1)
-        >>> a.to_ndarray()
+        >>> a.to_cuda()
         array([0, 1, 2, 3, 4])
 
-        >>> type(a.to_ndarray())
-        numpy.ndarray
+        >>> type(a.to_cuda())
+        numpy.devicendarray
         """
         # Total number of bytes in the array data
         arraybytes = self.size * self.dtype.itemsize
@@ -540,8 +540,8 @@ class pdarray:
             raise RuntimeError("Expected {} bytes but received {}".format(self.size*self.dtype.itemsize, len(rep_msg)))
         # Use struct to interpret bytes as a big-endian numeric array
         fmt = '>{:n}{}'.format(self.size, structDtypeCodes[self.dtype.name])
-        # Return a numpy ndarray
-        return cuda.to_device(np.array(struct.unpack(fmt, rep_msg)))
+        # Return a numba devicendarray
+        return cuda.to_device(struct.unpack(fmt, rep_msg))
 
     def save(self, prefix_path, dataset='array', mode='truncate'):
         """

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1,10 +1,5 @@
 import json, struct
 import numpy as np
-try:
-    from numba import cuda
-except ModuleNotFoundError as error:
-    print(error)
-    print('CUDA is not enabled or installed. Consult documentation.')
 
 from arkouda.client import generic_msg, verbose, maxTransferBytes, pdarrayIterThresh
 from arkouda.dtypes import *
@@ -532,6 +527,12 @@ class pdarray:
         >>> type(a.to_cuda())
         numpy.devicendarray
         """
+        try:
+            from numba import cuda
+        except ModuleNotFoundError as error:
+            print(error)
+            print('CUDA is not enabled or installed. Consult documentation.')
+        
         # Total number of bytes in the array data
         arraybytes = self.size * self.dtype.itemsize
         # Guard against overflowing client memory

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1,6 +1,10 @@
 import json, struct
 import numpy as np
-from numba import cuda
+try:
+    from numba import cuda
+except ModuleNotFoundError as error:
+    print(error)
+    print('CUDA is not enabled or installed. Consult documentation.')
 
 from arkouda.client import generic_msg, verbose, maxTransferBytes, pdarrayIterThresh
 from arkouda.dtypes import *

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -529,9 +529,12 @@ class pdarray:
         """
         try:
             from numba import cuda
-        except ModuleNotFoundError as error:
-            print(error)
-            print('CUDA is not enabled or installed. Consult documentation.')
+            if not(cuda.is_available()):
+                raise ImportError('CUDA is not available. Check for the CUDA toolkit and ensure a GPU is installed.')
+                return
+        except:
+            raise ModuleNotFoundError('Numba is not enabled or installed and is required for GPU support.')
+            return
         
         # Total number of bytes in the array data
         arraybytes = self.size * self.dtype.itemsize


### PR DESCRIPTION
This is a work in progress PR and forum for discussion on how to add GPU awareness to the Arkouda project in the best and most reasonable way. I've added a new function in the `pdarrayclass` to pass a `pdarray` type to CUDA using the popular Numba Python package. This also adds Numba and the CUDA Toolkit (most easily installed via Conda) as dependencies. Numba's [`__cuda_array_interface__`](https://numba.pydata.org/numba-doc/dev/cuda/cuda_array_interface.html) standard with `deviceNDArray` sets standards for how memory is organized on GPU. If a library accepts the `__cuda_array_interface__`, you can zero-copy on GPU between compatible frameworks.

This PR allows someone to load in large datasets into Arkouda and interact with it as expected, take a subset of relevant data, and then push it to GPU for speciality processing. By leveraging Numba, this allows us to open the aperture to NVIDIA's RAPIDS libraries for data science and signal processing, CuPy for GPU accelerated NumPy, and PyTorch for DL.

I've currently only tested single GPU usage, but I imagine this PR would be helped by Numba adopting CUDA UVM support (Issue here: https://github.com/numba/numba/issues/4362) 

Sample usage:
```python
import arkouda as ak
ak.connect('adamt-nvidia', 5555)

N = 10**6
arr = ak.arange(1, N+1, 1)
reduce_arr_ak = ak.sum(arr)

# CUDA - cuDF (RAPIDS DataFrame)
import cudf
cuda_arr = arr.to_cuda()
gdf_reduce = cudf.Series(cuda_arr).sum()

# CUDA - CuPy
import cupy as cp
# look at cuda_arr addresses
cuda_arr.__cuda_array_interface__['data']
# Examine cupy context (this is zero copy)
cp.asarray(cuda_arr).__cuda_array_interface__['data']
# Perform reduction
gpu_reduce_cupy = cp.sum(cp.asarray(cuda_arr))

# Can also do all the other cool CuPy functions
gpu_fft = cp.fft.fft(cp.asarray(cuda_arr))

# With PyTorch 1.4 (currently in nightly), you can go to PyTorch without DLPack
import torch
gpu_tensor = torch.as_tensor(cuda_arr)

# Finally, we can go back to Arkouda from the Numba deviceNDArray type via
ak.array(cuda_arr)
```

Looking forward to the discussion and making this ultimately better and beyond a single GPU. This could also use the eyes of more NVIDIA folks who better understand the multi-GPU Numba use-cases.

You can install the latest RAPIDS packages with:
`conda install -c rapidsai-nightly -c nvidia -c conda-forge \
    -c defaults rapids=0.12 python=3.7 cudatoolkit=10.1`

The latest version of PyTorch can be installed with:
`conda install -c pytorch-nightly pytorch`

I'd like to again stress that this is a 'quick and dirty' _hack_ for enabling GPU support within the Arkouda project.

Happy Holidays,
Adam Thompson