### PR TITLE
Remove mention of --legacy-classes since Arkouda no longer uses it

### DIFF
--- a/pydoc/setup/installation.rst
+++ b/pydoc/setup/installation.rst
@@ -66,15 +66,6 @@ If you are planning to contribute to arkouda as a developer, you may wish to ins
 Troubleshooting
 ****************
 
-Legacy classes
-=====================
-
-Error: The build fails because ``--legacy-classes`` is not recognized
-
-Cause: A version of Chapel older than 1.20.0 is being used
-
-Solution: Either upgrade Chapel or manually remove the ``--legacy-classes`` flag from the Arkouda ``Makefile``.
-
 Chapel not built for this configuration
 ==========================================
 


### PR DESCRIPTION
This is a minor housecleaning PR.  While looking around for remaining references to the `--legacy-classes` flag, I came across this one.  Since Arkouda is no longer relying on the flag, I think this troubleshooting mode no longer needs to be described.