### PR TITLE
Make dependency checks compatible with chapel master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,14 +90,14 @@ check-zmq: $(ZMQ_CHECK)
 	@echo "Checking for ZMQ"
 	$(CHPL) $(CHPL_FLAGS) $< -o $(DEP_INSTALL_DIR)/$@
 	$(DEP_INSTALL_DIR)/$@ -nl 1
-	rm -f $(DEP_INSTALL_DIR)/$@
+	@rm -f $(DEP_INSTALL_DIR)/$@ $(DEP_INSTALL_DIR)/$@_real
 
 HDF5_CHECK = $(DEP_INSTALL_DIR)/checkHDF5.chpl
 check-hdf5: $(HDF5_CHECK)
 	@echo "Checking for HDF5"
 	$(CHPL) $(CHPL_FLAGS) $< -o $(DEP_INSTALL_DIR)/$@
 	$(DEP_INSTALL_DIR)/$@ -nl 1
-	rm -f $(DEP_INSTALL_DIR)/$@
+	@rm -f $(DEP_INSTALL_DIR)/$@ $(DEP_INSTALL_DIR)/$@_real
 
 ALL_TARGETS := $(ARKOUDA_MAIN_MODULE)
 .PHONY: all

--- a/dep/checkHDF5.chpl
+++ b/dep/checkHDF5.chpl
@@ -1,8 +1,8 @@
-use HDF5;
+use HDF5, SysCTypes;
 
 proc main() {
   var H5major: c_uint, H5minor: c_uint, H5micro: c_uint;
   C_HDF5.H5get_libversion(H5major, H5minor, H5micro);
-  writeln("Found HDF5 version: %t".format((H5major:uint, H5minor:uint, H5micro:uint)));
+  writef("Found HDF5 version: %t.%t.%t\n", H5major, H5minor, H5micro);
   return 0;
 }

--- a/dep/checkZMQ.chpl
+++ b/dep/checkZMQ.chpl
@@ -2,6 +2,6 @@ use ZMQ;
 
 proc main() {
   var (Zmajor, Zminor, Zmicro) = ZMQ.version;
-  writeln("Found ZMQ version: %t.%t.%t".format(Zmajor, Zminor, Zmicro));
+  writef("Found ZMQ version: %t.%t.%t\n", Zmajor, Zminor, Zmicro);
   return 0;
 }


### PR DESCRIPTION
Use SysCTypes when needed and swap from writeln with a format call to
writef to avoid needing a `use IO`

While here, unify the output format and remove the `_real` binary when
cleaning up the executables.