### PR TITLE
In1d by sorting

### DIFF
--- a/src/In1dMsg.chpl
+++ b/src/In1dMsg.chpl
@@ -56,7 +56,7 @@ module In1dMsg
 
                 // brute force if below small bound
                 if (ar2.size <= sBound) {
-                    if v {try! writeln("%t <= %t".format(ar2.size,sBound)); try! stdout.flush();}
+                    if v {try! writeln("%t <= %t, using GlobalAr2Bcast".format(ar2.size,sBound)); try! stdout.flush();}
 
                     var truth = in1dGlobalAr2Bcast(ar1.a, ar2.a);
                     if (invert) {truth = !truth;}
@@ -65,15 +65,21 @@ module In1dMsg
                 }
                 // per locale assoc domain if below medium bound
                 else if (ar2.size <= mBound) {
-                    if v {try! writeln("%t <= %t".format(ar2.size,mBound)); try! stdout.flush();}
+                    if v {try! writeln("%t <= %t, using Ar2PerLocAssoc".format(ar2.size,mBound)); try! stdout.flush();}
                     
                     var truth = in1dAr2PerLocAssoc(ar1.a, ar2.a);
                     if (invert) {truth = !truth;}
                     
                     st.addEntry(rname, new shared SymEntry(truth));
                 }
-                // error if above medium bound
-                else {return try! "Error: %s: ar2 size too large %t".format(pn,ar2.size);}
+                // sort-based strategy if above medium bound
+                else {
+                    if v {try! writeln("%t > %t, using sort-based strategy".format(ar2.size, mBound)); try! stdout.flush();}
+                    var truth = in1dSort(ar1.a, ar2.a);
+                    if (invert) {truth = !truth;}
+
+                    st.addEntry(rname, new shared SymEntry(truth));
+                }
                 
             }
             otherwise {return notImplementedError(pn,gAr1.dtype,"in",gAr2.dtype);}

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -9,6 +9,7 @@ module SegmentedArray {
   use Reflection;
   use PrivateDist;
   use ServerConfig;
+  use Unique;
   use Time only getCurrentTime;
 
   private config const DEBUG = false;

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -385,49 +385,75 @@ module SegmentedArray {
     }
 
     proc isSorted(): bool {
-      var res = true; // strings are sorted?
-      // Is this position done comparing with its predecessor?
-      var done: [offsets.aD] bool;
-      // First string has no predecessor, so comparison is automatically done
-      done[offsets.aD.low] = true;
-      // Do not check null terminators
-      const lengths = getLengths() - 1;
-      const maxLen = max reduce lengths;
+      if (size < 2) {
+        return true;
+      }
       ref oa = offsets.a;
       ref va = values.a;
-      // Compare each pair of strings byte-by-byte
-      for pos in 0..#maxLen {
-        forall (o, l, d, i) in zip(oa, lengths, done, offsets.aD) 
-          with (ref res) {
-          if (!d) {
-            // If either of the strings is exhausted, mark this entry done
-            if (pos >= l) || (pos >= lengths[i-1]) {
-              d = true;
-            } else {
-              const prevByte = va[oa[i-1] + pos];
-              const currByte = va[o + pos];
-              // If we can already tell the pair is sorted, mark done
-              if (prevByte < currByte) {
-                d = true;
-              // If we can tell the pair is not sorted, the return is false
-              } else if (prevByte > currByte) {
-                res = false;
-              } // If we can't tell yet, keep checking
-            }
+      var ascending: [offsets.aD] bool;
+      const high = offsets.aD.high;
+      forall (i, a) in zip(offsets.aD, ascending) {
+        if (i < high) {
+          var asc: bool;
+          const ref left = va[oa[i]..oa[i+1]-1];
+          if (i < high - 1) {
+            const ref right = va[oa[i+1]..oa[i+2]-1];
+            a = (memcmp(left, right) <= 0);
+          } else { // i == high - 1
+            const ref right = va[oa[i+1]..values.aD.high];
+            a = (memcmp(left, right) <= 0);
           }
-        }
-        // If some pair is not sorted, return false
-        if !res {
-          return false;
-        // If all comparisons are conclusive, return true
-        }
-        /* else if (&& reduce done) { */
-        /*   return true; */
-        /* } // else keep going */
+        } else { // i == high
+          a = true;
+        } 
       }
-      // If we get to this point, it's because there is at least one pair of strings with length maxLen that are the same up to the last byte. That last byte determines res.
-      return res;
+      return (&& reduce ascending);
     }
+    
+    /* proc isSorted(): bool { */
+    /*   var res = true; // strings are sorted? */
+    /*   // Is this position done comparing with its predecessor? */
+    /*   var done: [offsets.aD] bool; */
+    /*   // First string has no predecessor, so comparison is automatically done */
+    /*   done[offsets.aD.low] = true; */
+    /*   // Do not check null terminators */
+    /*   const lengths = getLengths() - 1; */
+    /*   const maxLen = max reduce lengths; */
+    /*   ref oa = offsets.a; */
+    /*   ref va = values.a; */
+    /*   // Compare each pair of strings byte-by-byte */
+    /*   for pos in 0..#maxLen { */
+    /*     forall (o, l, d, i) in zip(oa, lengths, done, offsets.aD)  */
+    /*       with (ref res) { */
+    /*       if (!d) { */
+    /*         // If either of the strings is exhausted, mark this entry done */
+    /*         if (pos >= l) || (pos >= lengths[i-1]) { */
+    /*           d = true; */
+    /*         } else { */
+    /*           const prevByte = va[oa[i-1] + pos]; */
+    /*           const currByte = va[o + pos]; */
+    /*           // If we can already tell the pair is sorted, mark done */
+    /*           if (prevByte < currByte) { */
+    /*             d = true; */
+    /*           // If we can tell the pair is not sorted, the return is false */
+    /*           } else if (prevByte > currByte) { */
+    /*             res = false; */
+    /*           } // If we can't tell yet, keep checking */
+    /*         } */
+    /*       } */
+    /*     } */
+    /*     // If some pair is not sorted, return false */
+    /*     if !res { */
+    /*       return false; */
+    /*     // If all comparisons are conclusive, return true */
+    /*     } */
+    /*     /\* else if (&& reduce done) { *\/ */
+    /*     /\*   return true; *\/ */
+    /*     /\* } // else keep going *\/ */
+    /*   } */
+    /*   // If we get to this point, it's because there is at least one pair of strings with length maxLen that are the same up to the last byte. That last byte determines res. */
+    /*   return res; */
+    /* } */
 
     proc argsort(checkSorted:bool=true): [offsets.aD] int throws {
       const ref D = offsets.aD;
@@ -442,6 +468,19 @@ module SegmentedArray {
     }
 
   } // class SegString
+
+  inline proc memcmp(const ref x: [?xD] uint(8), const ref y: [?yD] uint(8)): int {
+    const l = min(x.size, y.size);
+    var ret = 0;
+    for (i, j) in zip(xD.low..#l, yD.low..#l) {
+      ret = x[i] - y[j];
+      if (ret != 0) {
+        break;
+      }
+    }
+    return ret;
+  }
+
 
   enum SearchMode { contains, startsWith, endsWith }
   class UnknownSearchMode: Error {}
@@ -676,40 +715,64 @@ module SegmentedArray {
       if DEBUG {writeln("Unique strings in first array: %t\nUnique strings in second array: %t\nConcat length: %t".format(uoMain.size, uoTest.size, segs.size)); try! stdout.flush();}
       var st = new owned SymTab();
       const ar = new owned SegString(segs, vals, st);
-      const order = ar.argsort(checkSorted=false);
+      const order = ar.argsort();
       const (sortedSegs, sortedVals) = ar[order];
       const sar = new owned SegString(sortedSegs, sortedVals, st);
       if DEBUG { writeln("Sorted concatenated unique strings:"); sar.show(10); stdout.flush(); }
       const D = sortedSegs.domain;
       // First compare lengths and only check pairs whose lengths are equal (because gathering them is expensive)
-      var idx: [D] bool;
+      var flag: [D] bool;
       const lengths = sar.getLengths();
-      // Gather right-hand elements of equal-length pairs
-      idx[{D.low+1..D.high}] = (lengths[{D.low+1..D.high}] == lengths[{D.low..D.high-1}]);
-      idx[D.low] = false;
-      var (rightSegs, rightVals) = sar[idx];
-      var right = new owned SegString(rightSegs, rightVals, st);
-      if DEBUG {writeln("Equal-length pairs from right: ", (+ reduce idx)); right.show(5); try! stdout.flush();}
-      
-      // Now gather left-hand elements of equal-length pairs
-      idx[{D.low..D.high-1}] = (lengths[{D.low+1..D.high}] == lengths[{D.low..D.high-1}]);
-      idx[D.high] = false;
-      // For translating bool to int index
-      const idxLocs = (+ scan idx) - 1;
-      var (leftSegs, leftVals) = sar[idx];
-      var left = new owned SegString(leftSegs, leftVals, st);
-      if DEBUG {writeln("Equal-length pairs from left: ", (+ reduce idx)); left.show(5); try! stdout.flush();}
-      // Update places where lengths are equal with result of comparison
-      var flag: [D] bool = idx;
-      var same = (left == right);
-      if DEBUG {writeln("Duplicate pairs: %t / %t / %t".format(+ reduce same, left.size, sar.size)); try! stdout.flush();}
-      forall (f, l) in zip(flag, idxLocs) with (var agg = newSrcAggregator(bool)) {
-        if f {
-          agg.copy(f, same[l]);
+      const ref saro = sar.offsets.a;
+      const ref sarv = sar.values.a;
+      const high = D.high;
+      forall (i, f, o, l) in zip(D, flag, saro, lengths) {
+        if (i < high) && (l == lengths[i+1]) {
+          const ref left = sarv[o..saro[i+1]-1];
+          var eq: bool;
+          if (i < high - 1) {
+            const ref right = sarv[saro[i+1]..saro[i+2]-1];
+            eq = (memcmp(left, right) == 0);
+          } else {
+            const ref right = sarv[saro[i+1]..sar.values.aD.high];
+            eq = (memcmp(left, right) == 0);
+          }
+          if eq {
+            f = true;
+            flag[i+1] = true;
+          }
         }
       }
+      /* // Gather right-hand elements of equal-length pairs */
+      /* var idx: [D] bool; */
+      /* idx[{D.low+1..D.high}] = (lengths[{D.low+1..D.high}] == lengths[{D.low..D.high-1}]); */
+      /* idx[D.low] = false; */
+      /* var (rightSegs, rightVals) = sar[idx]; */
+      /* var right = new owned SegString(rightSegs, rightVals, st); */
+      /* if DEBUG {writeln("Equal-length pairs from right: ", (+ reduce idx)); right.show(5); try! stdout.flush();} */
+      
+      /* // Now gather left-hand elements of equal-length pairs */
+      /* idx[{D.low..D.high-1}] = (lengths[{D.low+1..D.high}] == lengths[{D.low..D.high-1}]); */
+      /* idx[D.high] = false; */
+      /* // For translating bool to int index */
+      /* const idxLocs = (+ scan idx) - 1; */
+      /* var (leftSegs, leftVals) = sar[idx]; */
+      /* var left = new owned SegString(leftSegs, leftVals, st); */
+      /* if DEBUG {writeln("Equal-length pairs from left: ", (+ reduce idx)); left.show(5); try! stdout.flush();} */
+      /* // Update places where lengths are equal with result of comparison */
+      /* var flag: [D] bool = idx; */
+      /* var same = (left == right); */
+      /* if DEBUG {writeln("Duplicate pairs: %t / %t / %t".format(+ reduce same, left.size, sar.size)); try! stdout.flush();} */
+      /* forall (i, t, f, l) in zip(D, idx, flag, idxLocs) with (var agg = newSrcAggregator(bool)) { */
+      /*   if t { */
+      /*     agg.copy(f, same[l]); */
+      /*     on flag[i+1] { */
+      /*       agg.copy(flag[i+1], same[l]); */
+      /*     } */
+      /*   } */
+      /* } */
       if DEBUG {writeln("Flag pop: ", + reduce flag); try! stdout.flush();}
-      // Now flag contains true for left-hand elements of duplicate pairs
+      // Now flag contains true for both elements of duplicate pairs
       if invert {flag = !flag;}
       // Permute back to unique order
       var ret: [D] bool;

--- a/src/UniqueMsg.chpl
+++ b/src/UniqueMsg.chpl
@@ -97,7 +97,7 @@ module UniqueMsg
             // check and throw if over memory limit
             overMemLimit((8 * str.size * 8)
                          + (2 * here.maxTaskPar * numLocales * 2**16 * 8));
-            var (uo, uv, c) = uniqueGroup(str);
+            var (uo, uv, c, inv) = uniqueGroup(str);
             st.addEntry(offsetName, new shared SymEntry(uo));
             st.addEntry(valueName, new shared SymEntry(uv));
             var s = try! "created " + st.attrib(offsetName) + " +created " + st.attrib(valueName);

--- a/test/UnitTestIn1d.chpl
+++ b/test/UnitTestIn1d.chpl
@@ -9,18 +9,51 @@ module UnitTestIn1d
 
 
     // fill a with integers from interval aMin..(aMax-1)
-    proc fillRandInt(a: [?aD] int, aMin: int, aMax: int) {
+    proc fillRandInt(a: [?aD] ?t, aMin: t, aMax: t) {
 
         var t1 = Time.getCurrentTime();
         
         coforall loc in Locales {
             on loc {
                 var R = new owned RandomStream(real); R.getNext();
-                [i in a.localSubdomain()] a[i] = (R.getNext() * (aMax -aMin) + aMin):int;
+                [i in a.localSubdomain()] a[i] = (R.getNext() * (aMax -aMin) + aMin):t;
             }
         }
 
         writeln("compute time = ", Time.getCurrentTime() - t1,"sec"); try! stdout.flush();
+    }
+
+    proc createRandomStrings(n: int, m: int, minLen: int, maxLen: int, coverage: real, st: borrowed SymTab) throws {
+      var t = new Timer();
+      t.start();
+      const nVals:int = (m/coverage):int;
+      writeln("nVals = ", nVals);
+      var uLens = makeDistArray(nVals, int);
+      // Add 1 for null byte
+      fillRandInt(uLens, minLen+1, maxLen+1);
+      const uBytes = + reduce uLens;
+      var uSegs = (+ scan uLens) - uLens;
+      var uVals = makeDistArray(uBytes, uint(8));
+      fillRandInt(uVals, 65:uint(8), 90:uint(8)); // ascii uppercase
+      // Terminate with null bytes
+      [(s, l) in zip(uSegs, uLens)] uVals[s+l-1] = 0:uint(8);
+      var uStr = new owned SegString(uSegs, uVals, st);
+      // Indices to sample from unique strings
+      var inds = makeDistArray(n, int);
+      fillRandInt(inds, 0, nVals);
+      var (segs, vals) = uStr[inds];
+      var str1 = new shared SegString(segs, vals, st);
+      writeln("compute time = ", t.elapsed());
+      writeln("str1 = ");
+      str1.show(5);
+      var inds2 = makeDistArray(m, int);
+      // [(i, ii) in zip(inds2.domain, inds2)] ii = i;
+      inds2 = 0..#m;
+      var (segs2, vals2) = uStr[inds2];
+      var str2 = new shared SegString(segs2, vals2, st);
+      writeln("str2 = ");
+      str2.show(5);
+      return (str1, str2);
     }
 
     proc test_in1d(n: int, m: int, nVals: int) {
@@ -66,12 +99,36 @@ module UnitTestIn1d
         writeln("Results of both strategies match? >>> ", && reduce (truth == truth2), " <<<");
     }
 
-    config const N = 1_000_000;
+    proc test_strings(n: int, m: int, minLen: int, maxLen: int, coverage: real) throws {
+        writeln("(n, m, minLen, maxLen)");
+        writeln((n, m, minLen, maxLen)); try! stdout.flush();
+
+        var st = new owned SymTab();
+        var (str1, str2) = createRandomStrings(n, m, minLen, maxLen, coverage, st);
+        var expected: real = coverage*n;
+
+        writeln(">>> in1d");
+        var t1 = Time.getCurrentTime();
+        // returns a boolean vector
+        var truth = in1d(str1, str2);
+        writeln("total time = ", Time.getCurrentTime() - t1, "sec"); try! stdout.flush();
+        writeln("<<< #str1[i] in str2 = ", + reduce truth, " (expected ", expected, ")");try! stdout.flush();
+
+    }
+
+    config const N = 10_000;
     config const M = 1_000;
-    config const NVALS = 1_000_000;
+    config const NVALS = 10_000;
+    config const testStrings = true;
+    config const MINLEN = 0;
+    config const MAXLEN = 10;
+    config const COVERAGE = 0.5;
 
     proc main() {
         test_in1d(N, M, NVALS);
+        if testStrings {
+          try! test_strings(N, M, MINLEN, MAXLEN, COVERAGE);
+        }
     }
     
 }

--- a/test/UnitTestIn1d.chpl
+++ b/test/UnitTestIn1d.chpl
@@ -50,12 +50,20 @@ module UnitTestIn1d
             expected = n:real;
         }
 
-        writeln(">>> in1d");
+        writeln(">>> in1dAr2PerLocAssoc");
         var t1 = Time.getCurrentTime();
         // returns a boolean vector
         var truth = in1dAr2PerLocAssoc(a, b);
         writeln("total time = ", Time.getCurrentTime() - t1, "sec"); try! stdout.flush();
         writeln("<<< #a[i] in b = ", + reduce truth, " (expected ", expected, ")");try! stdout.flush();
+
+        writeln(">>> in1dSort");
+        t1 = Time.getCurrentTime();
+        var truth2 = in1dSort(a, b);
+        writeln("total time = ", Time.getCurrentTime() - t1, "sec"); try! stdout.flush();
+        writeln("<<< #a[i] in b = ", + reduce truth2, " (expected ", expected, ")");try! stdout.flush();
+
+        writeln("Results of both strategies match? >>> ", && reduce (truth == truth2), " <<<");
     }
 
     config const N = 1_000_000;

--- a/test/UnitTestIn1d.chpl
+++ b/test/UnitTestIn1d.chpl
@@ -99,7 +99,7 @@ module UnitTestIn1d
         writeln("Results of both strategies match? >>> ", && reduce (truth == truth2), " <<<");
     }
 
-    proc test_strings(n: int, m: int, minLen: int, maxLen: int, coverage: real) throws {
+    proc test_strings(n: int, m: int, minLen: int, maxLen: int, coverage: real, thorough: bool) throws {
         writeln("(n, m, minLen, maxLen)");
         writeln((n, m, minLen, maxLen)); try! stdout.flush();
 
@@ -113,7 +113,19 @@ module UnitTestIn1d
         var truth = in1d(str1, str2);
         writeln("total time = ", Time.getCurrentTime() - t1, "sec"); try! stdout.flush();
         writeln("<<< #str1[i] in str2 = ", + reduce truth, " (expected ", expected, ")");try! stdout.flush();
-
+        if thorough {
+          var res: [truth.domain] bool;
+          forall i in 0..#str1.size {
+            const s = str1[i];
+            for j in 0..#str2.size {
+              if (s == str2[j]) {
+                res[i] = true;
+                break;
+              }
+            }
+          }
+          writeln("Long check passed? >>> ", && reduce (truth == res), " <<<");
+        }
     }
 
     config const N = 10_000;
@@ -123,11 +135,12 @@ module UnitTestIn1d
     config const MINLEN = 0;
     config const MAXLEN = 10;
     config const COVERAGE = 0.5;
+    config const longCheck = false;
 
     proc main() {
         test_in1d(N, M, NVALS);
         if testStrings {
-          try! test_strings(N, M, MINLEN, MAXLEN, COVERAGE);
+          try! test_strings(N, M, MINLEN, MAXLEN, COVERAGE, longCheck);
         }
     }
     

--- a/test/UnitTestUnique.chpl
+++ b/test/UnitTestUnique.chpl
@@ -1,6 +1,9 @@
 module UnitTestUnique
 {
     use Unique;
+    use MultiTypeSymbolTable;
+    use MultiTypeSymEntry;
+    use SegmentedArray;
     
     use Random;
     use Time only;
@@ -10,14 +13,14 @@ module UnitTestUnique
 
 
     // fill a with integers from interval aMin..(aMax-1)
-    proc fillRandInt(a: [?aD] int, aMin: int, aMax: int) {
+    proc fillRandInt(a: [?aD] ?t, aMin: t, aMax: t) {
 
         var t1 = Time.getCurrentTime();
         
         coforall loc in Locales {
             on loc {
                 var R = new owned RandomStream(real); R.getNext();
-                for i in a.localSubdomain() { a[i] = (R.getNext() * (aMax -aMin) + aMin):int; }
+                for i in a.localSubdomain() { a[i] = (R.getNext() * (aMax -aMin) + aMin):t; }
             }
         }
 
@@ -40,6 +43,59 @@ module UnitTestUnique
         }
 
         writeln("compute time = ", Time.getCurrentTime() - t1,"sec"); try! stdout.flush();
+    }
+
+    proc createRandomStrings(n: int, minLen: int, maxLen: int, nUnique: int, st: borrowed SymTab) throws {
+      var t = new Timer();
+      t.start();
+      var uLens = makeDistArray(nUnique, int);
+      // Add 1 for null byte
+      fillRandInt(uLens, minLen+1, maxLen+1);
+      const uBytes = + reduce uLens;
+      var uSegs = (+ scan uLens) - uLens;
+      var uVals = makeDistArray(uBytes, uint(8));
+      fillRandInt(uVals, 32:uint(8), 126:uint(8)); // printable ascii
+      // Terminate with null bytes
+      [(s, l) in zip(uSegs, uLens)] uVals[s+l-1] = 0:uint(8);
+      /* var uSegName = st.nextName(); */
+      /* var uValName = st.nextName(); */
+      /* st.addEntry(uSegName, uSegs); */
+      /* st.addEntry(uValName, uVals); */
+      /* var uStr = new owned SegString(uSegName, uValName, st); */
+      var uStr = strFromArrays(uSegs, uVals, st);
+      // Indices to sample from unique strings
+      var inds = makeDistArray(n, int);
+      fillRandInt(inds, 0, nUnique - 1);
+      var (segs, vals) = uStr[inds];
+      var str = strFromArrays(segs, vals, st);
+      writeln("compute time = ", t.elapsed());
+      writeln("Random strings:");
+      show(str);
+      return str;
+    }
+
+    proc strFromArrays(segs: [] int, vals: [] uint(8), st: borrowed SymTab) throws {
+      var segName = st.nextName();
+      var valName = st.nextName();
+      var segEntry = new shared SymEntry(segs);
+      var valEntry = new shared SymEntry(vals);
+      st.addEntry(segName, segEntry);
+      st.addEntry(valName, valEntry);
+      var str = new shared SegString(segName, valName, st);
+      return str;
+    }
+
+    proc show(str: SegString) throws {
+      const n = str.size;
+      for i in 0..#min(n, 5) {
+        writeln(str[i]);
+      }
+      if (n >= 10) {
+        writeln("...");
+        for i in n-5..#5 {
+          writeln(str[i]);
+        }
+      }
     }
 
     // n: length of array
@@ -98,13 +154,51 @@ module UnitTestUnique
         writeln("original array correctly reconstructed from inverse? >>> ", && reduce (a == a2), " <<<");
     }
 
+    proc test_strings(n: int, minLen: int, maxLen: int, nVals: int) throws {
+
+        writeln("n = ",n);
+        writeln("minLen = ", minLen);
+        writeln("maxLen = ", maxLen);
+        writeln("nVals = ",nVals);
+        try! stdout.flush();
+
+        var st = new owned SymTab();
+        var str = createRandomStrings(n, minLen, maxLen, nVals, st);
+        
+        writeln(">>> uniqueGroup");
+        var t1 = Time.getCurrentTime();
+
+        var (uo1, uv1, c1, inv1) = uniqueGroup(str);
+
+        writeln("total time = ", Time.getCurrentTime() - t1, "sec"); try! stdout.flush();
+        var uStr1 = strFromArrays(uo1, uv1, st);
+        writeln("Unique strings:");
+        show(uStr1);
+        
+        writeln("uStr1.size = ",uStr1.size);
+        writeln("totalCounts = ",+ reduce c1); try! stdout.flush();
+        writeln("testing return_inverse...");
+        var (uo2, uv2, c2, inv2) = uniqueGroup(str, returnInverse=true);
+        var uStr2 = strFromArrays(uo2, uv2, st);
+        writeln("offsets, values, and counts match? >>> ", (&& reduce (uo2 == uo1)) && (&& reduce (uv2 == uv1)) && (&& reduce (c2 == c1)), " <<<" );
+        var (rtSegs, rtVals) = uStr2[inv2];
+        var roundTrip = strFromArrays(rtSegs, rtVals, st);
+        writeln("original array correctly reconstructed from inverse? >>> ", && reduce (str == roundTrip), " <<<");
+    }
+
     config const N = 1_000_000; // length of array
     config const AMIN = 1_000; // min value
     config const AMAX = 30_000_000_000; // max value
     config const NVALS = 1_000; // number of unique values
+    config const testStrings = true;
+    config const MINLEN = 0;
+    config const MAXLEN = 10;
 
     proc main() {
         test_unique(N, AMIN, AMAX, NVALS);
+        if testStrings {
+          try! test_strings(N, MINLEN, MAXLEN, NVALS);
+        }
     }
     
 }

--- a/test/UnitTestUnique.chpl
+++ b/test/UnitTestUnique.chpl
@@ -78,7 +78,24 @@ module UnitTestUnique
 
         writeln("aV1.size = ",aV1.size);
         writeln("totalCounts = ",+ reduce aC1); try! stdout.flush();
-
+        var present: [aDom] bool;
+        forall (x, p) in zip(a, present) {
+          for u in aV1 {
+            if (x == u) {
+              p = true;
+              break;
+            }
+          }
+        }
+        writeln("all values present? >>> ", && reduce present, " <<<"); try! stdout.flush();
+        writeln("testing return_inverse...");
+        var (aV2, aC2, inv) = uniqueSortWithInverse(a);
+        writeln("values and counts match? >>> ", (&& reduce (aV2 == aV1)) && (&& reduce (aC2 == aC1)), " <<<" );
+        var a2: [aDom] int;
+        forall (x, idx) in zip(a2, inv) {
+            x = aV2[idx];
+        }
+        writeln("original array correctly reconstructed from inverse? >>> ", && reduce (a == a2), " <<<");
     }
 
     config const N = 1_000_000; // length of array

--- a/test/UnitTestUnique.chpl
+++ b/test/UnitTestUnique.chpl
@@ -57,17 +57,12 @@ module UnitTestUnique
       fillRandInt(uVals, 32:uint(8), 126:uint(8)); // printable ascii
       // Terminate with null bytes
       [(s, l) in zip(uSegs, uLens)] uVals[s+l-1] = 0:uint(8);
-      /* var uSegName = st.nextName(); */
-      /* var uValName = st.nextName(); */
-      /* st.addEntry(uSegName, uSegs); */
-      /* st.addEntry(uValName, uVals); */
-      /* var uStr = new owned SegString(uSegName, uValName, st); */
-      var uStr = strFromArrays(uSegs, uVals, st);
+      var uStr = new owned SegString(uSegs, uVals, st);
       // Indices to sample from unique strings
       var inds = makeDistArray(n, int);
       fillRandInt(inds, 0, nUnique - 1);
       var (segs, vals) = uStr[inds];
-      var str = strFromArrays(segs, vals, st);
+      var str = new shared SegString(segs, vals, st);
       writeln("compute time = ", t.elapsed());
       writeln("Random strings:");
       show(str);
@@ -171,7 +166,8 @@ module UnitTestUnique
         var (uo1, uv1, c1, inv1) = uniqueGroup(str);
 
         writeln("total time = ", Time.getCurrentTime() - t1, "sec"); try! stdout.flush();
-        var uStr1 = strFromArrays(uo1, uv1, st);
+        // var uStr1 = strFromArrays(uo1, uv1, st);
+        var uStr1 = new owned SegString(uo1, uv1, st);
         writeln("Unique strings:");
         show(uStr1);
         
@@ -179,14 +175,16 @@ module UnitTestUnique
         writeln("totalCounts = ",+ reduce c1); try! stdout.flush();
         writeln("testing return_inverse...");
         var (uo2, uv2, c2, inv2) = uniqueGroup(str, returnInverse=true);
-        var uStr2 = strFromArrays(uo2, uv2, st);
+        // var uStr2 = strFromArrays(uo2, uv2, st);
+        var uStr2 = new owned SegString(uo2, uv2, st);
         writeln("offsets, values, and counts match? >>> ", (&& reduce (uo2 == uo1)) && (&& reduce (uv2 == uv1)) && (&& reduce (c2 == c1)), " <<<" );
         var (rtSegs, rtVals) = uStr2[inv2];
-        var roundTrip = strFromArrays(rtSegs, rtVals, st);
+        // var roundTrip = strFromArrays(rtSegs, rtVals, st);
+        var roundTrip = new owned SegString(rtSegs, rtVals, st);
         writeln("original array correctly reconstructed from inverse? >>> ", && reduce (str == roundTrip), " <<<");
     }
 
-    config const N = 1_000_000; // length of array
+    config const N = 10_000; // length of array
     config const AMIN = 1_000; // min value
     config const AMAX = 30_000_000_000; // max value
     config const NVALS = 1_000; // number of unique values

--- a/tests/string_test.py
+++ b/tests/string_test.py
@@ -6,7 +6,7 @@ import sys
 
 ak.verbose = False
 
-N = 10000
+N = 1000
 
 # test_strings = np.array(['These are', 'some', 'interesting',
 #                          '~!@#$%^&*()_+', 'strings', '8675309.',
@@ -55,7 +55,7 @@ if __name__ == '__main__':
     print("pdarray bool index passed")
 
     # in1d and iter
-    more_words = np.random.choice(base_words, 10)
+    more_words = np.random.choice(base_words, 100)
     akwords = ak.array(more_words)
     matches = ak.in1d(strings, akwords)
     # Every word in matches should be in the target set


### PR DESCRIPTION
Implements a third strategy for `ak.in1d(ar1, ar2)` when `ar2` is large (> 2^25 for integers and > 64 for strings). This strategy is based on unique-ing both arrays, sorting them together, finding duplicates, and mapping them back to the indices of `ar1`. To accomplish the last step, it was necessary to create a variant of `unique` that returns an inverse index. Only `in1d` uses this new variant of `unique`; other calls to `unique` use the existing version, which is faster and ligther on memory.

I added tests for the new `unique` variant and the new `in1d` strategy with integers and strings, and I modified `tests/string_test.py` so that it would trigger the sort-based `in1d` strategy. I also ran all the benchmarks on a Cray-XC and confirmed that there is no performance degradation.