### PR TITLE
Readd `make check` for linux64 testing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,4 +33,5 @@ jobs:
         apt-get update && apt-get install -y libhdf5-dev libzmq3-dev python3-pip
         echo "\$(eval \$(call add-path,/usr/lib/x86_64-linux-gnu/hdf5/serial/))" > Makefile.paths
         ARKOUDA_DEVELOPER=true make
-
+        pip3 install -e .
+        make check


### PR DESCRIPTION
The Chapel docker base image was updated to debian:10 so we now have a
new enough python to actually run the client.

Part of https://github.com/mhmerrill/arkouda/issues/217