### PR TITLE
Remove faulty isSorted() check

### DIFF
--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -456,10 +456,10 @@ module SegmentedArray {
     /*   return res; */
     /* } */
 
-    proc argsort(checkSorted:bool=true): [offsets.aD] int throws {
+    proc argsort(checkSorted:bool=false): [offsets.aD] int throws {
       const ref D = offsets.aD;
       const ref va = values.a;
-      if checkSorted && isSorted() {
+      if checkSorted && false { // isSorted() {
         if DEBUG { writeln("argsort called on already sorted array"); stdout.flush(); }
         var ranks: [D] int = [i in D] i;
         return ranks;

--- a/src/Unique.chpl
+++ b/src/Unique.chpl
@@ -522,7 +522,7 @@ module Unique
         return (ukeys,counts);
     }
 
-    proc uniqueGroup(str: SegString, returnInverse = false) throws {
+    proc uniqueGroup(str: SegString, returnInverse = false, assumeSorted=false) throws {
         if (str.size == 0) {
             if v {writeln("zero size");try! stdout.flush();}
             var uo = makeDistArray(0, int);
@@ -544,7 +544,7 @@ module Unique
         if SegmentedArrayUseHash {
           var hashes = str.hash();
           var sorted: [aD] 2*uint;
-          if (AryUtil.isSorted(hashes)) {
+          if (assumeSorted || AryUtil.isSorted(hashes)) {
             perm = aD;
             sorted = hashes; 
           }
@@ -560,7 +560,7 @@ module Unique
         } else {
           var soff: [aD] int;
           var sval: [str.values.aD] uint(8);
-          if str.isSorted() {
+          if assumeSorted {
             perm = aD;
             soff = str.offsets.a;
             sval = str.values.a;


### PR DESCRIPTION
SegString.isSorted() has a bug that causes out of memory errors. This PR temporarily sidesteps calls to that function until we can fix the bug, but allows the user to guarantee that the input is sorted and avoid duplicating work.