### PR TITLE
Make the server compatible with Chapel master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,11 +146,18 @@ endif
 # Version needs to be escape-quoted for chpl to interpret as string
 CHPL_FLAGS_WITH_VERSION = $(CHPL_FLAGS)
 CHPL_FLAGS_WITH_VERSION += -sarkoudaVersion="\"$(VERSION)\""
+
+ifeq ("$(shell chpl --version | sed -n "s/chpl version 1\.\([0-9]*\).*/\1/p")", "20")
+	CHPL_COMPAT_FLAGS := -sversion120=true --no-overload-sets-checks
+else
+	CHPL_COMPAT_FLAGS := -sversion120=false
+endif
+
 ARKOUDA_SOURCES = $(shell find $(ARKOUDA_SOURCE_DIR)/ -type f -name '*.chpl')
 ARKOUDA_MAIN_SOURCE := $(ARKOUDA_SOURCE_DIR)/$(ARKOUDA_MAIN_MODULE).chpl
 
 $(ARKOUDA_MAIN_MODULE): check-deps $(ARKOUDA_SOURCES) $(ARKOUDA_MAKEFILES)
-	$(CHPL) $(CHPL_DEBUG_FLAGS) $(CHPL_FLAGS_WITH_VERSION) $(ARKOUDA_MAIN_SOURCE) -o $@
+	$(CHPL) $(CHPL_DEBUG_FLAGS) $(CHPL_COMPAT_FLAGS) $(CHPL_FLAGS_WITH_VERSION) $(ARKOUDA_MAIN_SOURCE) -o $@
 
 CLEAN_TARGETS += arkouda-clean
 .PHONY: arkouda-clean

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ endif
 # need this to avoid a slew of warnings from HDF5 on some platforms
 # --ccflags="-Wno-incompatible-pointer-types"
 CHPL_FLAGS += --ccflags="-Wno-incompatible-pointer-types"
-CHPL_FLAGS += -lhdf5 -lhdf5_hl -lzmq
+CHPL_FLAGS += -lhdf5 -lhdf5_hl -lzmq -lmpi
 
 # add-path: Append custom paths for non-system software.
 # Note: Darwin `ld` only supports `-rpath <path>`, not `-rpath=<paths>`.

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ default: $(DEFAULT_TARGET)
 VERBOSE ?= 0
 
 CHPL := chpl
+ifeq ("$(shell chpl --version | sed -n "s/chpl version 1\.\([0-9]*\).*/\1/p")", "20")
+  CHPL_VERSION_120 := 1
+endif
+
 CHPL_DEBUG_FLAGS += --print-passes
 ifndef ARKOUDA_DEVELOPER
 CHPL_FLAGS += --fast
@@ -20,7 +24,10 @@ endif
 # need this to avoid a slew of warnings from HDF5 on some platforms
 # --ccflags="-Wno-incompatible-pointer-types"
 CHPL_FLAGS += --ccflags="-Wno-incompatible-pointer-types"
-CHPL_FLAGS += -lhdf5 -lhdf5_hl -lzmq -lmpi
+CHPL_FLAGS += -lhdf5 -lhdf5_hl -lzmq
+ifndef CHPL_VERSION_120
+  CHPL_FLAGS += -lmpi
+endif
 
 # add-path: Append custom paths for non-system software.
 # Note: Darwin `ld` only supports `-rpath <path>`, not `-rpath=<paths>`.
@@ -147,7 +154,7 @@ endif
 CHPL_FLAGS_WITH_VERSION = $(CHPL_FLAGS)
 CHPL_FLAGS_WITH_VERSION += -sarkoudaVersion="\"$(VERSION)\""
 
-ifeq ("$(shell chpl --version | sed -n "s/chpl version 1\.\([0-9]*\).*/\1/p")", "20")
+ifdef CHPL_VERSION_120
 	CHPL_COMPAT_FLAGS := -sversion120=true --no-overload-sets-checks
 else
 	CHPL_COMPAT_FLAGS := -sversion120=false

--- a/src/Chapel120.chpl
+++ b/src/Chapel120.chpl
@@ -13,12 +13,12 @@ module Chapel120 {
   use ZMQ;
   use IO;
 
-  proc Socket.recv(type T: bytes) where version120 {
+  proc Socket.recv(type T: bytes) throws where version120 {
     // there is no validation in 1.20, so use string for ZMQ but return bytes
     return this.recv(string):bytes;
   }
 
-  proc Socket.send(msg: bytes) where version120 {
+  proc Socket.send(msg: bytes) throws where version120 {
     // there is no validation in 1.20, so use string for ZMQ but return bytes
     this.send(convertToString(msg));
   }

--- a/src/Chapel120.chpl
+++ b/src/Chapel120.chpl
@@ -1,0 +1,43 @@
+//
+// This module is designed to provide some backwards compatibility
+// with Chapel 1.20 for arkouda.
+//
+module Chapel120 {
+  //
+  // TODO: Would be cool / smart if Chapel code could query compiler
+  // version number directly to avoid needing this param and the
+  // last resort overload below...  See Chapel issue #5491.
+  //
+  config param version120 = false;
+  
+  use ZMQ;
+  use IO;
+
+  proc Socket.recv(type T: bytes) where version120 {
+    // there is no validation in 1.20, so use string for ZMQ but return bytes
+    return this.recv(string):bytes;
+  }
+
+  proc Socket.send(msg: bytes) where version120 {
+    // there is no validation in 1.20, so use string for ZMQ but return bytes
+    this.send(convertToString(msg));
+  }
+
+  proc bytes.format(args ...?k): bytes throws where version120 {
+    var s = convertToString(this);
+    return s.format((...args)):bytes;
+  }
+
+  proc channel.readbytes(ref str_out:bytes, len:int(64) = -1):bool throws 
+                                                               where version120 {
+    var s: string;
+    const ret = this.readstring(s, len);
+    str_out = s:bytes;
+    return ret;
+  }
+
+  private inline proc convertToString(b: bytes): string {
+    return createStringWithBorrowedBuffer(b.buff, b.len, b._size);
+  }
+
+}

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -7,6 +7,9 @@ module GenSymIO {
   use FileSystem;
   use Sort;
   use CommAggregation;
+
+  use Chapel120;
+
   config const GenSymIO_DEBUG = false;
   config const SEGARRAY_OFFSET_NAME = "segments";
   config const SEGARRAY_VALUE_NAME = "values";

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -83,7 +83,7 @@ module GenSymIO {
       } else if entry.dtype == DType.UInt8 {
         tmpw.write(toSymEntry(entry, uint(8)).a);
       } else {
-	return try! b"Error: Unhandled dtype %s".format(entry.dtype);
+        return try! b"Error: Unhandled dtype %s".format(entry.dtype);
       }
       tmpw.close();
     } catch {

--- a/src/In1d.chpl
+++ b/src/In1d.chpl
@@ -4,6 +4,7 @@ module In1d
     use ServerConfig;
     use Unique;
     use CommAggregation;
+    use RadixSortLSD;
 
     use Time only;
     use Math only;

--- a/src/SegStringSort.chpl
+++ b/src/SegStringSort.chpl
@@ -125,7 +125,7 @@ module SegStringSort {
       const l = lengths[i];
       var buf: [0..#(l+1)] uint(8);
       buf[{0..#l}] = va[{oa[i]..#l}];
-      si[1] = createStringWithBorrowedBuffer(c_ptrTo(buf), l, l+1);
+      si[1] = try! createStringWithBorrowedBuffer(c_ptrTo(buf), l, l+1);
       si[2] = i;
     }
     return stringsWithInds;

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -828,7 +828,7 @@ module SegmentedArray {
     // Byte buffer is null-terminated, so length is buffer.size - 1
     // The contents of the buffer should be copied out because cBytes will go out of scope
     // var s = new string(cBytes, D.size-1, D.size, isowned=false, needToCopy=true);
-    var s = createStringWithNewBuffer(cBytes, D.size-1, D.size);
+    var s = try! createStringWithNewBuffer(cBytes, D.size-1, D.size);
     return s;
   }
 }

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -8,6 +8,7 @@ module ServerConfig
     use SymArrayDmap only makeDistDom;
 
     public use IO;
+    private use SysCTypes;
 
     use ServerErrorStrings;
 

--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -15,6 +15,7 @@ use GenSymIO;
 use SymArrayDmap;
 use ServerErrorStrings;
 
+
 proc main() {
     writeln("arkouda server version = ",arkoudaVersion); try! stdout.flush();
     writeln("memory tracking = ", memTrack); try! stdout.flush();
@@ -36,18 +37,33 @@ proc main() {
 
     var reqCount: int = 0;
     var repCount: int = 0;
+
     var t1 = new Time.Timer();
     t1.clear();
     t1.start();
+
+    proc sendRepMsg(repMsg: ?t) where t==string || t==bytes {
+        repCount += 1;
+        if v {
+          if t==bytes {
+              writeln("repMsg:"," <binary-data>");
+          } else {
+            writeln("repMsg:",repMsg);
+          }
+          try! stdout.flush();
+        }
+        socket.send(repMsg);
+    }
+
     while !shutdownServer {
         // receive requests
-        var reqMsg = socket.recv(string);
+        var reqMsgRaw = socket.recv(bytes);
 
         reqCount += 1;
 
         // shutdown server
-        if reqMsg == "shutdown" {
-            if logging {writeln("reqMsg: ", reqMsg); try! stdout.flush();}
+        if reqMsgRaw == b"shutdown" {
+            if logging {writeln("reqMsg: ", reqMsgRaw); try! stdout.flush();}
             shutdownServer = true;
             repCount += 1;
             socket.send("shutdown server (%i req)".format(repCount));
@@ -55,92 +71,102 @@ proc main() {
             break;
         }
 
+        const fieldsRaw = reqMsgRaw.split(1);
+        const cmdRaw = fieldsRaw[1];
         var repMsg: string;
-        
-        // peel off the command
-        var fields = reqMsg.split(1);
-        var cmd = fields[1];
         var s0 = t1.elapsed();
-        
-        if (logging) {
-            if cmd == "array" { // has binary data in it's payload
-                writeln("reqMsg: ", cmd, " <binary-data>");
+        // parse requests, execute requests, format responses
+        try {
+            // first handle the case where we received arbitrary data
+            if cmdRaw == b"array" {
+                if logging { writeln("reqMsg: ", cmdRaw, " <binary-data>"); }
+                repMsg = arrayMsg(reqMsgRaw, st);
             }
             else {
-                writeln("reqMsg: ", reqMsg);
-            }
-            writeln(">>> %s started at %.17r sec".format(cmd, s0));
-            try! stdout.flush();
-        }
+                // received command does not have binary data, safe to decode
+                var reqMsg: string;
+                try! {
+                    reqMsg = reqMsgRaw.decode();
+                }
+                catch e: DecodeError {
+                    if v {
+                        writeln("Error: illegal byte sequence in command: ",
+                                reqMsgRaw.decode(decodePolicy.replace));
+                        try! stdout.flush();
+                    }
+                    sendRepMsg(unknownError(""));
+                }
+                if v { writeln("reqMsg: ", reqMsg); }
 
-        try {
-            // parse requests, execute requests, format responses
-            select cmd
-            {
-                when "segmentedEfunc"    {repMsg = segmentedEfuncMsg(reqMsg, st);}
-                when "segmentedIndex"    {repMsg = segmentedIndexMsg(reqMsg, st);}
-                when "segmentedBinopvv"  {repMsg = segBinopvvMsg(reqMsg, st);}
-                when "segmentedBinopvs"  {repMsg = segBinopvsMsg(reqMsg, st);}
-                when "segmentedGroup"    {repMsg = segGroupMsg(reqMsg, st);}
-                when "segmentedIn1d"     {repMsg = segIn1dMsg(reqMsg, st);}
-                when "lshdf"             {repMsg = lshdfMsg(reqMsg, st);}
-                when "readhdf"           {repMsg = readhdfMsg(reqMsg, st);}
-                when "tohdf"             {repMsg = tohdfMsg(reqMsg, st);}
-                when "array"             {repMsg = arrayMsg(reqMsg, st);}
-                when "create"            {repMsg = createMsg(reqMsg, st);}
-                when "delete"            {repMsg = deleteMsg(reqMsg, st);}
-                when "binopvv"           {repMsg = binopvvMsg(reqMsg, st);}
-                when "binopvs"           {repMsg = binopvsMsg(reqMsg, st);}
-                when "binopsv"           {repMsg = binopsvMsg(reqMsg, st);}
-                when "opeqvv"            {repMsg = opeqvvMsg(reqMsg, st);}
-                when "opeqvs"            {repMsg = opeqvsMsg(reqMsg, st);}
-                when "efunc"             {repMsg = efuncMsg(reqMsg, st);}
-                when "efunc3vv"          {repMsg = efunc3vvMsg(reqMsg, st);}
-                when "efunc3vs"          {repMsg = efunc3vsMsg(reqMsg, st);}
-                when "efunc3sv"          {repMsg = efunc3svMsg(reqMsg, st);}
-                when "efunc3ss"          {repMsg = efunc3ssMsg(reqMsg, st);}
-                when "reduction"         {repMsg = reductionMsg(reqMsg, st);}
-                when "countReduction"    {repMsg = countReductionMsg(reqMsg, st);}
-                when "countLocalRdx"     {repMsg = countLocalRdxMsg(reqMsg, st);}
-                when "findSegments"      {repMsg = findSegmentsMsg(reqMsg, st);}
-                when "findLocalSegments" {repMsg = findLocalSegmentsMsg(reqMsg, st);}
-                when "segmentedReduction"{repMsg = segmentedReductionMsg(reqMsg, st);}
-                when "segmentedLocalRdx" {repMsg = segmentedLocalRdxMsg(reqMsg, st);}
-                when "arange"            {repMsg = arangeMsg(reqMsg, st);}
-                when "linspace"          {repMsg = linspaceMsg(reqMsg, st);}
-                when "randint"           {repMsg = randintMsg(reqMsg, st);}
-                when "histogram"         {repMsg = histogramMsg(reqMsg, st);}
-                when "in1d"              {repMsg = in1dMsg(reqMsg, st);}
-                when "unique"            {repMsg = uniqueMsg(reqMsg, st);}
-                when "value_counts"      {repMsg = value_countsMsg(reqMsg, st);}
-                when "set"               {repMsg = setMsg(reqMsg, st);}
-                when "info"              {repMsg = infoMsg(reqMsg, st);}
-                when "str"               {repMsg = strMsg(reqMsg, st);}
-                when "repr"              {repMsg = reprMsg(reqMsg, st);}
-                when "tondarray"         {repMsg = tondarrayMsg(reqMsg, st);}
-                when "[int]"             {repMsg = intIndexMsg(reqMsg, st);}
-                when "[slice]"           {repMsg = sliceIndexMsg(reqMsg, st);}
-                when "[pdarray]"         {repMsg = pdarrayIndexMsg(reqMsg, st);}
-                when "[int]=val"         {repMsg = setIntIndexToValueMsg(reqMsg, st);}
-                when "[pdarray]=val"     {repMsg = setPdarrayIndexToValueMsg(reqMsg, st);}            
-                when "[pdarray]=pdarray" {repMsg = setPdarrayIndexToPdarrayMsg(reqMsg, st);}            
-                when "[slice]=val"       {repMsg = setSliceIndexToValueMsg(reqMsg, st);}            
-                when "[slice]=pdarray"   {repMsg = setSliceIndexToPdarrayMsg(reqMsg, st);}
-                when "argsort"           {repMsg = argsortMsg(reqMsg, st);}
-                when "coargsort"         {repMsg = coargsortMsg(reqMsg, st);}
-                when "concatenate"       {repMsg = concatenateMsg(reqMsg, st);}
-                when "localArgsort"      {repMsg = localArgsortMsg(reqMsg, st);}
-                when "sort"              {repMsg = sortMsg(reqMsg, st);}
-                when "getconfig"         {repMsg = getconfigMsg(reqMsg, st);}
-                when "getmemused"        {repMsg = getmemusedMsg(reqMsg, st);}
-                when "connect" {
-                    repMsg = "connected to arkouda server tcp://*:%t".format(ServerPort);
+                const fields = reqMsg.split(1);
+                const cmd = fields[1];
+
+                // now take care of the case where we send arbitrary data:
+                if cmd == "tondarray" {
+                    sendRepMsg(tondarrayMsg(reqMsg, st));
                 }
-                when "disconnect" {
-                    repMsg = "disconnected from arkouda server tcp://*:%t".format(ServerPort);
-                }
-                otherwise {
-                    if (logging) {writeln("Error: unrecognized command: %s".format(reqMsg)); try! stdout.flush();}
+                else {
+                    // here we know that everything is strings
+                    select cmd
+                    {
+                        when "lshdf"             {repMsg = lshdfMsg(reqMsg, st);}
+                        when "readhdf"           {repMsg = readhdfMsg(reqMsg, st);}
+                        when "tohdf"             {repMsg = tohdfMsg(reqMsg, st);}
+                        when "create"            {repMsg = createMsg(reqMsg, st);}
+                        when "delete"            {repMsg = deleteMsg(reqMsg, st);}
+                        when "binopvv"           {repMsg = binopvvMsg(reqMsg, st);}
+                        when "binopvs"           {repMsg = binopvsMsg(reqMsg, st);}
+                        when "binopsv"           {repMsg = binopsvMsg(reqMsg, st);}
+                        when "opeqvv"            {repMsg = opeqvvMsg(reqMsg, st);}
+                        when "opeqvs"            {repMsg = opeqvsMsg(reqMsg, st);}
+                        when "efunc"             {repMsg = efuncMsg(reqMsg, st);}
+                        when "efunc3vv"          {repMsg = efunc3vvMsg(reqMsg, st);}
+                        when "efunc3vs"          {repMsg = efunc3vsMsg(reqMsg, st);}
+                        when "efunc3sv"          {repMsg = efunc3svMsg(reqMsg, st);}
+                        when "efunc3ss"          {repMsg = efunc3ssMsg(reqMsg, st);}
+                        when "reduction"         {repMsg = reductionMsg(reqMsg, st);}
+                        when "countReduction"    {repMsg = countReductionMsg(reqMsg, st);}
+                        when "countLocalRdx"     {repMsg = countLocalRdxMsg(reqMsg, st);}
+                        when "findSegments"      {repMsg = findSegmentsMsg(reqMsg, st);}
+                        when "findLocalSegments" {repMsg = findLocalSegmentsMsg(reqMsg, st);}
+                        when "segmentedReduction"{repMsg = segmentedReductionMsg(reqMsg, st);}
+                        when "segmentedLocalRdx" {repMsg = segmentedLocalRdxMsg(reqMsg, st);}
+                        when "arange"            {repMsg = arangeMsg(reqMsg, st);}
+                        when "linspace"          {repMsg = linspaceMsg(reqMsg, st);}
+                        when "randint"           {repMsg = randintMsg(reqMsg, st);}
+                        when "histogram"         {repMsg = histogramMsg(reqMsg, st);}
+                        when "in1d"              {repMsg = in1dMsg(reqMsg, st);}
+                        when "unique"            {repMsg = uniqueMsg(reqMsg, st);}
+                        when "value_counts"      {repMsg = value_countsMsg(reqMsg, st);}
+                        when "set"               {repMsg = setMsg(reqMsg, st);}
+                        when "info"              {repMsg = infoMsg(reqMsg, st);}
+                        when "str"               {repMsg = strMsg(reqMsg, st);}
+                        when "repr"              {repMsg = reprMsg(reqMsg, st);}
+                        when "[int]"             {repMsg = intIndexMsg(reqMsg, st);}
+                        when "[slice]"           {repMsg = sliceIndexMsg(reqMsg, st);}
+                        when "[pdarray]"         {repMsg = pdarrayIndexMsg(reqMsg, st);}
+                        when "[int]=val"         {repMsg = setIntIndexToValueMsg(reqMsg, st);}
+                        when "[pdarray]=val"     {repMsg = setPdarrayIndexToValueMsg(reqMsg, st);}            
+                        when "[pdarray]=pdarray" {repMsg = setPdarrayIndexToPdarrayMsg(reqMsg, st);}            
+                        when "[slice]=val"       {repMsg = setSliceIndexToValueMsg(reqMsg, st);}            
+                        when "[slice]=pdarray"   {repMsg = setSliceIndexToPdarrayMsg(reqMsg, st);}
+                        when "argsort"           {repMsg = argsortMsg(reqMsg, st);}
+                        when "coargsort"         {repMsg = coargsortMsg(reqMsg, st);}
+                        when "concatenate"       {repMsg = concatenateMsg(reqMsg, st);}
+                        when "localArgsort"      {repMsg = localArgsortMsg(reqMsg, st);}
+                        when "sort"              {repMsg = sortMsg(reqMsg, st);}
+                        when "getconfig"         {repMsg = getconfigMsg(reqMsg, st);}
+                        when "getmemused"        {repMsg = getmemusedMsg(reqMsg, st);}
+                        when "connect" {
+                            repMsg = "connected to arkouda server tcp://*:%t".format(ServerPort);
+                        }
+                        when "disconnect" {
+                            repMsg = "disconnected from arkouda server tcp://*:%t".format(ServerPort);
+                        }
+                        otherwise {
+                            if v {writeln("Error: unrecognized command: %s".format(reqMsg)); try! stdout.flush();}
+                        }
+                    }
                 }
             }
         } catch (e: ErrorWithMsg) {
@@ -149,23 +175,14 @@ proc main() {
             repMsg = unknownError("");
         }
         
-        // send responses
-        // send count for now
-        repCount += 1;
-        if (logging) {
-          if cmd == "tondarray" {
-              writeln("repMsg:"," <binary-data>");
-          } else {
-            writeln("repMsg:",repMsg);
-          }
-          try! stdout.flush();
-        }
-        socket.send(repMsg);
+        // if we generated a string message, send it
+        if !repMsg.isEmpty() then
+            sendRepMsg(repMsg);
 
         if (logging && memTrack) {writeln("bytes of memoryUsed() = ",memoryUsed()); try! stdout.flush();}
 
         // end timer for command processing
-        if (logging) {writeln("<<< %s took %.17r sec".format(cmd, t1.elapsed() - s0)); try! stdout.flush();}
+        if (logging) {writeln("<<< %s took %.17r sec".format(cmdRaw.decode(decodePolicy.replace), t1.elapsed() - s0)); try! stdout.flush();}
     }
     t1.stop();
     deleteServerConnectionInfo();

--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -15,6 +15,8 @@ use GenSymIO;
 use SymArrayDmap;
 use ServerErrorStrings;
 
+use Chapel120; // the compatibility layer
+
 
 proc main() {
     writeln("arkouda server version = ",arkoudaVersion); try! stdout.flush();
@@ -57,6 +59,7 @@ proc main() {
 
     while !shutdownServer {
         // receive requests
+
         var reqMsgRaw = socket.recv(bytes);
 
         reqCount += 1;

--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -46,7 +46,7 @@ proc main() {
 
     proc sendRepMsg(repMsg: ?t) where t==string || t==bytes {
         repCount += 1;
-        if v {
+        if logging {
           if t==bytes {
               writeln("repMsg:"," <binary-data>");
           } else {
@@ -99,7 +99,7 @@ proc main() {
                     }
                     sendRepMsg(unknownError(""));
                 }
-                if v { writeln("reqMsg: ", reqMsg); }
+                if logging { writeln("reqMsg: ", reqMsg); }
 
                 const fields = reqMsg.split(1);
                 const cmd = fields[1];


### PR DESCRIPTION
This PR updates Arkouda server to be able to use Chapel master while keeping it
compatible with 1.20. This is mainly motivated by UTF-8 validation on Chapel
strings that was added after 1.20. With that change, messages with arbitrary data
can no longer use Chapel `string`s and should use `bytes` instead.

Summary of changes in the order of importance:
- Updates `arkouda_server` to use `bytes` type when the message can include
  arbitrary data. This is currently limited to `array` and `tondarray` commands.

- Updates some of the helper functions to handle `bytes` messages.

- Adds `src/Chapel120.chpl` as a small compatibility layer. This file includes
  some ZMQ and IO overloads that converts `bytes` to `strings` in order to be
  able to use Chapel 1.20, which had some unimplemented features for `bytes`

- Adds `CHPL_VERSION_120` and `CHPL_COMPAT_FLAGS` to Makefile. These are set
  appropriately depending on what `chpl --version` returns.

- Adds few `use` statements. Because `use` is by default private now on Chapel
  master, some Arkouda source files need to explicitly `use` Chapel and/or
  Arkouda modules

Note: Some (all?) unit tests in the `test` dir may also need some work to bring
them up to speed with Chapel master. This PR does not do that as of now.
Those changes can be added to this PR or can be a follow up. But it depends on
whether we move forward with the changes in this PR.

Tested with `check.py` and `groupby_test.py` which normally break with UTF-8
validated strings on Chapel:
- [x] They pass with Chapel 1.20
- [x] They pass with Chapel Master (fee8582)