### PR TITLE
Make the server compatible with Chapel master

### DIFF
--- a/src/RandArray.chpl
+++ b/src/RandArray.chpl
@@ -3,6 +3,7 @@ module RandArray {
   use SegmentedArray;
   use ServerErrorStrings;
   use Map;
+  use SipHash;
 
   proc fillInt(a:[] ?t, const aMin, const aMax) where isIntType(t) {
     coforall loc in Locales {

--- a/src/RandArray.chpl
+++ b/src/RandArray.chpl
@@ -61,7 +61,7 @@ module RandArray {
     Binary
   }
 
-  var charBounds: map(false, charSet, 2*int);
+  var charBounds: map(keyType=charSet, valType=2*int, parSafe=false);
   charBounds[charSet.Uppercase] = (65, 91);
   charBounds[charSet.Lowercase] = (97, 123);
   charBounds[charSet.Numeric] = (48, 58);

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -10,7 +10,7 @@ module SegmentedArray {
   use PrivateDist;
   use ServerConfig;
   use Unique;
-  use Time only getCurrentTime;
+  use Time only Timer, getCurrentTime;
 
   private config const DEBUG = false;
   private config param useHash = false;


### PR DESCRIPTION
Updates Arkouda server so that it is compatible with Chapel 1.20 and master.

- Adds explicit types to map constructor, and changes the order to match
  master's order.

- Adds few uses since `use` is private by default on master now.

Test:
- [x] check.py and few other scripts pass