### PR TITLE
Split string gather

### DIFF
--- a/src/RandArray.chpl
+++ b/src/RandArray.chpl
@@ -54,6 +54,14 @@ module RandArray {
     }
   }
 
+  proc fillNormal(a:[?D] real) {
+    var u1:[D] real;
+    var u2:[D] real;
+    fillRandom(u1);
+    fillRandom(u2);
+    a = sqrt(-2*log(u1))*cos(2*pi*u2);
+  }
+
   enum charSet {
     Uppercase,
     Lowercase,
@@ -69,12 +77,30 @@ module RandArray {
   charBounds[charSet.Printable] = (32, 127);
   charBounds[charSet.Binary] = (0, 0);
 
-  proc newRandStrings(n: int, const minLen: int, const maxLen: int, characters:charSet = charSet.Uppercase) throws {
+  proc newRandStringsUniformLength(const n: int, const minLen: int, const maxLen: int, characters:charSet = charSet.Uppercase) throws {
     if (n < 0) || (minLen < 0) || (maxLen < minLen) {
       throw new owned ArgumentError();
     }
     var lengths = makeDistArray(n, int);
     fillInt(lengths, minLen+1, maxLen+1);
+    const nBytes = + reduce lengths;
+    var segs = (+ scan lengths) - lengths;
+    var vals = makeDistArray(nBytes, uint(8));
+    var (lb, ub) = charBounds[characters];
+    fillUInt(vals, lb, ub);
+    // Strings are null-terminated
+    [(s, l) in zip(segs, lengths)] vals[s+l-1] = 0:uint(8);
+    return (segs, vals);
+  }
+
+  proc newRandStringsLogNormalLength(const n: int, const logMean: numeric, const logStd: numeric, characters:charSet = charSet.Uppercase) throws {
+    if (n < 0) || (logStd <= 0) {
+      throw new owned ArgumentError();
+    }
+    var ltemp = makeDistArray(n, real);
+    fillNormal(ltemp);
+    ltemp = exp(logMean + logStd*ltemp);
+    var lengths:[ltemp.domain] int = [l in ltemp] ceil(l):int;
     const nBytes = + reduce lengths;
     var segs = (+ scan lengths) - lengths;
     var vals = makeDistArray(nBytes, uint(8));

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -186,6 +186,7 @@ module SegmentedArray {
            it is the difference between the src offset of the current segment ("left")
            and the src index of the last byte in the previous segment (right - 1).
         */
+        if DEBUG { writeln("Using aggregation at the expense of memory"); stdout.flush(); }
         var srcIdx = makeDistArray(retBytes, int);
         srcIdx = 1;
         var diffs: [D] int;
@@ -201,7 +202,8 @@ module SegmentedArray {
         forall (v, si) in zip(gatheredVals, srcIdx) with (var agg = newSrcAggregator(uint(8))) {
           agg.copy(v, va[si]);
         }
-      } else {      
+      } else {
+        if DEBUG { writeln("Using unorderedCopy"); stdout.flush(); }
         ref va = values.a;
         // Copy string data to gathered result
         forall (go, gl, idx) in zip(gatheredOffsets, gatheredLengths, iv) {

--- a/test/SipHashSpeedTest.chpl
+++ b/test/SipHashSpeedTest.chpl
@@ -1,27 +1,58 @@
 use SipHash;
+use RandArray;
 use Time;
 use BlockDist;
 
 config const NINPUTS = 10_000;
 config const INPUTSIZE = 8;
+config const LENGTHS = "fixed";
 config param COMMDEBUG = false;
 
-proc main() {
-  const D1 = {0..#(NINPUTS*INPUTSIZE)}; 
+proc testFixedLength(n:int, size:int) {
+  var t = new Timer();
+  const D1 = {0..#(n*size)}; 
   const DD1: domain(1) dmapped Block(boundingBox=D1) = D1;
   var buf: [DD1] uint(8);
   forall (b, i) in zip(buf, 0..) {
     b = i: uint(8);
   }
-  const D2 = {0..#NINPUTS};
+  const D2 = {0..#n};
   const DD2: domain(1) dmapped Block(boundingBox=D2) = D2;
   var hashes: [DD2] 2*uint(64);
   if COMMDEBUG { startCommDiagnostics(); }
-  var t = getCurrentTime();
+  t.start();
   forall (h, i) in zip(hashes, DD2) {
-    h = sipHash128(buf, i*INPUTSIZE..#INPUTSIZE);
+    h = sipHash128(buf, i*size..#size);
   }
-  var elapsed = getCurrentTime() - t;
+  t.stop();
   if COMMDEBUG { stopCommDiagnostics(); writeln(getCommDiagnostics());}
-  writeln("Hashed %i blocks (%i bytes) in %.2dr seconds\nRate = %.2dr MB/s".format(NINPUTS, NINPUTS*INPUTSIZE, elapsed, (NINPUTS*INPUTSIZE)/(1024*1024*elapsed)));
+  return t.elapsed();
+}
+
+proc testVariableLength(n:int, meanSize:int) {
+  var t = new Timer();
+  const logMean:real = log(meanSize:real)/2;
+  const logStd:real = sqrt(2*logMean);
+  var (segs, vals) = newRandStringsLogNormalLength(n, logMean, logStd);
+  const D = segs.domain;
+  var lengths: [D] int;
+  lengths[{D.low..D.high-1}] = segs[{D.low+1..D.high}] - segs[{D.low..D.high-1}];
+  lengths[D.high] = vals.size - segs[D.high];
+  var hashes: [segs.domain] 2*uint(64);
+  t.start();
+  forall (h, i, l) in zip(hashes, segs, lengths) {
+    h = sipHash128(vals, i..#l);
+  }
+  t.stop();
+  return (t.elapsed(), vals.size);
+}
+
+proc main() {
+  if LENGTHS == "fixed" {
+    var elapsed = testFixedLength(NINPUTS, INPUTSIZE);
+    writeln("Hashed %i blocks (%i bytes) in %.2dr seconds\nRate = %.2dr MB/s".format(NINPUTS, NINPUTS*INPUTSIZE, elapsed, (NINPUTS*INPUTSIZE)/(1024*1024*elapsed)));
+  } else if LENGTHS == "variable" {
+    var (elapsed, nbytes) = testVariableLength(NINPUTS, INPUTSIZE);
+    writeln("Hashed %i blocks (%i bytes) in %.2dr seconds\nRate = %.2dr MB/s".format(NINPUTS, nbytes, elapsed, (nbytes)/(1024*1024*elapsed)));
+  }    
 }

--- a/test/StringGatherSpeedTest.chpl
+++ b/test/StringGatherSpeedTest.chpl
@@ -1,0 +1,29 @@
+use SegmentedArray;
+use RandArray;
+use MultiTypeSymbolTable;
+use RadixSortLSD;
+
+config const N = 10_000;
+config const MEANLEN = 10;
+
+proc testPermute(n:int, meanLen: numeric) {
+  var st = new owned SymTab();
+  var t = new Timer();
+  const logMean = log(meanLen:real)/2;
+  const logStd = sqrt(2*logMean);
+  var (segs, vals) = newRandStringsLogNormalLength(n, logMean, logStd);
+  var strings = new owned SegString(segs, vals, st);
+  var rint: [segs.domain] int;
+  fillInt(rint, 0, max(int));
+  var perm = radixSortLSD_ranks(rint);
+  t.start();
+  var (psegs, pvals) = strings[perm];
+  t.stop();
+  return (t.elapsed(), vals.size);
+}
+
+proc main() {
+  var (elapsed, size) = testPermute(N, MEANLEN);
+  writeln("Permuted %i strings (%i bytes) in %t seconds".format(N, size, elapsed()));
+  writeln("Rate = %t MB/s".format(size / (1024 * 1024 * elapsed())));
+}

--- a/test/StringGatherSpeedTest.chpl
+++ b/test/StringGatherSpeedTest.chpl
@@ -24,6 +24,6 @@ proc testPermute(n:int, meanLen: numeric) {
 
 proc main() {
   var (elapsed, size) = testPermute(N, MEANLEN);
-  writeln("Permuted %i strings (%i bytes) in %t seconds".format(N, size, elapsed()));
-  writeln("Rate = %t MB/s".format(size / (1024 * 1024 * elapsed())));
+  writeln("Permuted %i strings (%i bytes) in %t seconds".format(N, size, elapsed));
+  writeln("Rate = %t MB/s".format(size / (1024 * 1024 * elapsed)));
 }

--- a/tests/python_hash_rate.py
+++ b/tests/python_hash_rate.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+import random
+import sys
+import string
+import time
+import argparse
+
+NINPUTS = 1_000_000
+INPUTSIZE = 8
+
+def test_hash(N, I):
+    S = []
+    for i in range(N):
+        s = ''.join(random.choices(string.ascii_letters, k=I))
+        S.append(s)
+
+    start = time.time()
+    x = set(S)
+    t = time.time() - start
+
+    print(f"Hashed {NINPUTS} blocks ({NINPUTS*INPUTSIZE} bytes) in {t:.3f} seconds")
+    print(f"Rate = {(NINPUTS*INPUTSIZE)/(1024*1024*t):.2f} MB/s")
+
+    
+if __name__=='__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--NINPUTS', type=int, default=NINPUTS, help='Number of inputs to hash')
+    parser.add_argument('--INPUTSIZE', type=int, default=INPUTSIZE, help='Size of each input.')
+    args = parser.parse_args()
+    test_hash(args.NINPUTS, args.INPUTSIZE)
+


### PR DESCRIPTION
Addresses #272 by conditioning the strategy for gathering strings on `CHPL_COMM`. On single-locale or ugni, it uses unorderedCopy. On other networks, it now pre-computes a vector of local source indices  usable with `newSrcAggregator`. This costs a lot of memory, but avoids "death by small messages" on infiniband. This PR passes `tests/string_test.py` on single-locale linux.

Included is a new performance test for string gather. Some runs with `test-bin/StringGatherSpeedTest --N=1_000_000 --MEANLEN=100`:

| Platform | CHPL_COMM | Locales | strategy | Rate |
| ----------- | ----------- | --------- | ------ | ------ |
| laptop | none | 1 |  unordered | 172 MB/s |
| laptop | gasnet | 2 | aggregation | 4.6 MB/s |
| laptop | gasnet | 4 | aggregation | 3.1 MB/s |
| IB cluster | gasnet | 4 | aggregation | 10.3 MB/s |
| IB cluster | gasnet | 4 | unordered | 0.7 MB/s |

I think my aggregation strategy could still use work -- there is probably a more efficient way to do this, but this is an improvement for now.