### PR TITLE
Remove throws from SipHash

### DIFF
--- a/src/SipHash.chpl
+++ b/src/SipHash.chpl
@@ -49,18 +49,18 @@ module SipHash {
     return c;
   }
   
-  proc sipHash64(msg: [] uint(8), D): uint(64) throws {
+  proc sipHash64(msg: [] uint(8), D): uint(64) {
     var res = computeSipHash(msg, D, 8);
     return res[1];
   }
 
-  proc sipHash128(msg: [] uint(8), D): 2*uint(64) throws {
+  proc sipHash128(msg: [] uint(8), D): 2*uint(64) {
     return computeSipHash(msg, D, 16);
   }
   
-  private proc computeSipHash(msg: [] uint(8), D, param outlen: int) throws {
+  private proc computeSipHash(msg: [] uint(8), D, param outlen: int) {
     if !((outlen == 8) || (outlen == 16)) {
-      throw new owned ArgumentError();
+      compilerError("outlen must be 8 or 16");
     }
     var v0 = 0x736f6d6570736575: uint(64);
     var v1 = 0x646f72616e646f6d: uint(64);
@@ -101,12 +101,14 @@ module SipHash {
         v2 = ROTL(v2, 32);
     }
 
-    inline proc TRACE() throws {
+    inline proc TRACE() {
       if DEBUG {
-        writeln("%i v0 %016xu".format(msg.size, v0));
-        writeln("%i v1 %016xu".format(msg.size, v1));
-        writeln("%i v2 %016xu".format(msg.size, v2));
-        writeln("%i v3 %016xu".format(msg.size, v3));
+        try! {
+          writeln("%i v0 %016xu".format(D.size, v0));
+          writeln("%i v1 %016xu".format(D.size, v1));
+          writeln("%i v2 %016xu".format(D.size, v2));
+          writeln("%i v3 %016xu".format(D.size, v3));
+        }
       }
     }
 


### PR DESCRIPTION
It's no longer needed now that outlen is a param. This eliminates a conditional at the callsite, which has a slight performance improvement (189 -> 198 MB/s) for the following serial run:

    ./SipHashSpeedTest -nl 1 --NINPUTS=1_000_000 --INPUTSIZE=8 --dataParTasksPerLocale=1

See https://github.com/chapel-lang/chapel/pull/9380 for more information on error-handling overhead.  Note that error-handling overhead is generally negligible, but the hash kernel is called millions of times and is generally very fast, so minor overheads add up. For `--INPUTSIZE=1024` there is no noticeable performance difference.