### PR TITLE
Optimize SipHash when msg[D.low..D.high] lives on one locale

### DIFF
--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -72,4 +72,15 @@ module AryUtil
         var R = new owned RandomStream(real, seed); R.getNext();
         [a in A] a = (R.getNext() * (a_max - a_min) + a_min):int;
     }
+
+    /*
+      Determines if the passed array array maps contiguous indices to
+      contiguous memory.
+
+      :arg A: array to check
+    */
+    proc contiguousIndices(A: []) param {
+        use BlockDist;
+        return A.isDefaultRectangular() || isSubtype(A.domain.dist.type, Block);
+    }
 }

--- a/src/CommAggregation.chpl
+++ b/src/CommAggregation.chpl
@@ -1,6 +1,7 @@
 module CommAggregation {
   use SysCTypes;
   use UnorderedCopy;
+  private use CommPrimitives;
 
   // TODO these parameters need to be tuned and size should be user-settable at
   // creation time. iters before yield should be based on numLocales & buffSize
@@ -239,14 +240,5 @@ module CommAggregation {
       compilerWarning("Missing optimized unorderedCopy for " + dst.type:string);
       dst = src;
     }
-  }
-
-  // TODO can this use c_ptrTo?
-  private inline proc getAddr(const ref p): c_ptr(p.type) {
-    return __primitive("_wide_get_addr", p): c_ptr(p.type);
-  }
-
-  private inline proc PUT(addr, node, rAddr, size) {
-    __primitive("chpl_comm_put", addr, node, rAddr, size);
   }
 }

--- a/src/CommPrimitives.chpl
+++ b/src/CommPrimitives.chpl
@@ -1,0 +1,14 @@
+module CommPrimitives {
+  inline proc getAddr(const ref p): c_ptr(p.type) {
+    // TODO can this use c_ptrTo?
+    return __primitive("_wide_get_addr", p): c_ptr(p.type);
+  }
+
+  inline proc GET(addr, node, rAddr, size) {
+    __primitive("chpl_comm_get", addr, node, rAddr, size);
+  }
+
+  inline proc PUT(addr, node, rAddr, size) {
+    __primitive("chpl_comm_put", addr, node, rAddr, size);
+  }
+}


### PR DESCRIPTION
Use c_ptr to optimize indexing when msg[D.low..D.high] is local. This optimizes out more complex indexing operations, particularly in `U8TO64_LE`.

If msg[D.low..D.high] is remote, but all lives on one locale, use bulk comm to localize and then use c_ptr. The old version would do a 1-byte GET for each element we needed and this uses a single GET. This adds an allocation (which we might be able to optimize out with scratch space), but the benefit of being able to use bulk comm (and then using c_ptr) far outweighs the allocation cost.

Here is 32 node performance on Aries and InfiniBand (same machines as #231)

    ./SipHashSpeedTest -nl32 --INPUTSIZE=64 --NINPUTS=10_000_000_000 --LENGTHS=fixed

| config | before   | after    |
| ------ | -------- | -------- |
| Aries  | 190 GB/s | 515 GB/s |
| FDR IB | 195 GB/s | 545 GB/s |


    ./SipHashSpeedTest -nl32 --INPUTSIZE=64 --NINPUTS=10_000_000_000 --LENGTHS=variable
(I used a 100x smaller `--NINPUTS` for "before" to finish in a reasonable amount of time.)

| config | before   | after    |
| ------ | -------- | -------- |
| Aries  |   2 GB/s | 225 GB/s |
| FDR IB |   1 GB/s | 195 GB/s |

Part of https://github.com/mhmerrill/arkouda/issues/266