### PR TITLE
URGENT bug fix in SipHash

### DIFF
--- a/src/SipHash.chpl
+++ b/src/SipHash.chpl
@@ -38,15 +38,15 @@ module SipHash {
             (p[D.low+7]: uint(64) << 56));
   }
 
-  private inline proc U8TO64_LE(p: c_ptr(uint(8)), D): uint(64) {
-    return ((p[D.low]: uint(64)) |
-            (p[D.low+1]: uint(64) << 8) |
-            (p[D.low+2]: uint(64) << 16) |
-            (p[D.low+3]: uint(64) << 24) |
-            (p[D.low+4]: uint(64) << 32) |
-            (p[D.low+5]: uint(64) << 40) |
-            (p[D.low+6]: uint(64) << 48) |
-            (p[D.low+7]: uint(64) << 56));
+  private inline proc U8TO64_LE(p: c_ptr(uint(8))): uint(64) {
+    return ((p[0]: uint(64)) |
+            (p[1]: uint(64) << 8) |
+            (p[2]: uint(64) << 16) |
+            (p[3]: uint(64) << 24) |
+            (p[4]: uint(64) << 32) |
+            (p[5]: uint(64) << 40) |
+            (p[6]: uint(64) << 48) |
+            (p[7]: uint(64) << 56));
   }
 
 
@@ -64,39 +64,19 @@ module SipHash {
   }
   
   proc sipHash64(msg: [] uint(8), D): uint(64) {
-    if contiguousIndices(msg) {
-      ref start = msg[D.low];
-      if D.high < D.low {
-        var res = computeSipHash(c_ptrTo(start), 0..#0, 8);
-        return res[1];
-      }
-      ref end = msg[D.high];
-      const startLocale = start.locale.id;
-      const endLocale = end.locale.id;
-      const hereLocale = here.id;
-      const l = D.size;
-      if startLocale == endLocale {
-        if startLocale == hereLocale {
-          var res = computeSipHash(c_ptrTo(start), 0..#l, 8);
-          return res[1];
-        } else {
-          var a = c_malloc(msg.eltType, l);
-          GET(a, startLocale, getAddr(start), l);
-          var h = computeSipHash(a, 0..#l, 8);
-          c_free(a);
-          return h[1];
-        }
-      }
-    }
-    var res = computeSipHash(msg, D, 8);
-    return res[1];
+    var h = computeSipHashLocalize(msg, D, 8);
+    return h[1];
   }
 
   proc sipHash128(msg: [] uint(8), D): 2*uint(64) {
+    return computeSipHashLocalize(msg, D, 16);
+  }
+  
+  proc computeSipHashLocalize(msg: [] uint(8), D, param outlen: int): 2*uint(64) {
     if contiguousIndices(msg) {
       ref start = msg[D.low];
       if D.high < D.low {
-        return computeSipHash(c_ptrTo(start), 0..#0, 16);
+        return computeSipHash(c_ptrTo(start), 0..#0, outlen);
       }
       ref end = msg[D.high];
       const startLocale = start.locale.id;
@@ -105,17 +85,17 @@ module SipHash {
       const l = D.size;
       if startLocale == endLocale {
         if startLocale == hereLocale {
-          return computeSipHash(c_ptrTo(start), 0..#l, 16);
+          return computeSipHash(c_ptrTo(start), 0..#l, outlen);
         } else {
           var a = c_malloc(msg.eltType, l);
           GET(a, startLocale, getAddr(start), l);
-          var h = computeSipHash(a, 0..#l, 16);
+          var h = computeSipHash(a, 0..#l, outlen);
           c_free(a);
           return h;
         }
       }
     }
-    return computeSipHash(msg, D, 16);
+    return computeSipHash(msg, D, outlen);
   }
   
   private proc computeSipHash(msg, D, param outlen: int) {
@@ -130,7 +110,8 @@ module SipHash {
     const k1 = 0x0f0e0d0c0b0a0908: uint(64);
     var m: uint(64);
     var i: int;
-    const lastPos = D.size - (D.size % 8); // C index, 0-up
+    const lastPos = if isSubtype(msg.type, c_ptr) then D.size - (D.size % 8)
+      else D.low + D.size - (D.size % 8); // if C index, 0-up
     // const uint8_t *end = in + inlen - (inlen % sizeof(uint64_t));
     const left: int = D.size & 7;
     // const int left = inlen & 7;
@@ -172,8 +153,12 @@ module SipHash {
       }
     }
 
-    for pos in 0..lastPos-1 by 8 {
-        m = U8TO64_LE(msg, pos..#8);
+    for pos in D.low..lastPos-1 by 8 {
+        if isSubtype(msg.type, c_ptr) {
+          m = U8TO64_LE(msg + pos);
+        } else {
+          m = U8TO64_LE(msg, pos..#8);
+        }
         v3 ^= m;
         TRACE();
         for i in 0..#cROUNDS {

--- a/test/UnitTestSipHash.chpl
+++ b/test/UnitTestSipHash.chpl
@@ -486,21 +486,19 @@ proc U8TO2U64_LE(vec: [?D] uint(8)): 2*uint(64) {
 const version = ["sip64", "sip128"];
 
 proc main() {
-  var k: [0..#16] uint(8) = for i in 0..#16 do i: uint(8);
+  var msg: [0..#64] uint(8) = for i in 0..#64 do i: uint(8);
   var errors: int;
   for ver in version {
     for i in 0..#64 {
-      var msg: [0..#i] uint(8);
-      [j in 0..#i] msg[j] = j: uint(8);
       if ver == "sip64" {
-        const h = sipHash64(msg, k);
+        const h = sipHash64(msg, 0..#i);
         const vec = U8TOU64_LE(vectors_sip64[i]);
         if (h != vec) {
           errors += 1;
           writeln("%i:\n%016xu vs \n%016xu\n".format(i, h, vec));
         }
       } else if ver == "sip128" {
-        const h = sipHash128(msg, k);
+        const h = sipHash128(msg, 0..#i);
         const vec = U8TO2U64_LE(vectors_sip128[i]);
         if (h != vec) {
           errors += 1;


### PR DESCRIPTION
After the switch to using C pointers inside `computeSipHash`, there was an indexing error that caused the hashing function to ignore all but the first block and the partial block at the end (if input length was not a multiple of 8). This PR fixes the indexing and updates `test/UnitTestSipHash.chpl` to run with the new syntax. Before fixing the indexing bug, the updated `UnitTestSipHash` was failing, but now it passes.