### PR TITLE
Remove mac CI testing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,18 +11,7 @@ jobs:
       run: |
         ! git --no-pager grep -n $'\t' -- '*.chpl'
 
-  mac_job:
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v1
-    - name: mac comm=none
-      run: |
-        brew install hdf5 zeromq chapel
-        ARKOUDA_DEVELOPER=true make
-        pip3 install -e .
-        make check
-
-  std_job:
+  linux_job:
     runs-on: ubuntu-latest
     container:
       image: chapel/chapel:1.20.0


### PR DESCRIPTION
I've seen a number of timeouts for mac CI testing with errors like "An
error occurred while provisioning resources (Error Type: Disconnect)."
e.g. https://github.com/mhmerrill/arkouda/runs/468784420

I think false-positives makes you less inclined to trust CI, so disable
mac testing until the infrastructure is more stable.