### PR TITLE
Add gasnet CI testing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,8 +17,11 @@ jobs:
 
   arkouda_tests_linux:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: [chapel, chapel-gasnet]
     container:
-      image: chapel/chapel:1.20.0
+      image: chapel/${{matrix.image}}:1.20.0
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,25 +2,33 @@ name: CI
 
 on: [push, pull_request]
 
+env:
+  ARKOUDA_DEVELOPER: true # faster compilation, and enable checks
+  CHPL_RT_OVERSUBSCRIBED: yes # limit contention on limited CI hardware
+
 jobs:
-  lint_job:
+  lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: look for tabs
+    - uses: actions/checkout@v2
+    - name: Check for tabs
       run: |
         ! git --no-pager grep -n $'\t' -- '*.chpl'
 
-  linux_job:
+  arkouda_tests_linux:
     runs-on: ubuntu-latest
     container:
       image: chapel/chapel:1.20.0
     steps:
-    - uses: actions/checkout@v1
-    - name: linux comm=none
+    - uses: actions/checkout@v2
+    - name: Install dependencies
       run: |
         apt-get update && apt-get install -y libhdf5-dev libzmq3-dev python3-pip
         echo "\$(eval \$(call add-path,/usr/lib/x86_64-linux-gnu/hdf5/serial/))" > Makefile.paths
-        ARKOUDA_DEVELOPER=true make
+    - name: Build/Install Arkouda
+      run: |
+        make
         pip3 install -e .
+    - name: Arkouda make check
+      run: |
         make check

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ endif
 CHPL_DEBUG_FLAGS += --print-passes
 ifndef ARKOUDA_DEVELOPER
 CHPL_FLAGS += --fast
+else
+CHPL_FLAGS += --ccflags="-O1"
 endif
 # need this to avoid a slew of warnings from HDF5 on some platforms
 # --ccflags="-Wno-incompatible-pointer-types"


### PR DESCRIPTION
Add gasnet CI testing in order to test aggregation and other code paths
that aren't used under comm=none.

This also makes a few CI and developer quality of life improvements.
 - Have `ARKOUDA_DEVELOPER` throw `-O1` to the backend. This enables
   optimizations that significantly help execution time, without hurting
   compilation time much (I tend to develop with `ARKOUDA_DEVELOPER` set
   for fast compilation cycles and do performance testing without it
   set.)
 - Upgrade to checkout v2, which has faster fetching and other
   improvements (https://github.com/actions/checkout/releases/tag/v2.0.0).
 - Move dependency install and build commands into different steps so
   it's easier to find output you care about.

Part of https://github.com/mhmerrill/arkouda/issues/217