### PR TITLE
Random string gen

### DIFF
--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -9,7 +9,8 @@ from arkouda.pdarrayclass import pdarray, create_pdarray
 from arkouda.strings import Strings
 
 __all__ = ["array", "zeros", "ones", "zeros_like", "ones_like", "arange",
-           "linspace", "randint"]
+           "linspace", "randint", "uniform", "standard_normal",
+           "random_strings_uniform", "random_strings_lognormal"]
 
 def array(a):
     """

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -1,7 +1,9 @@
 from arkouda.client import generic_msg, verbose, pdarrayIterThresh
 from arkouda.pdarrayclass import pdarray, create_pdarray, parse_single_value
 from arkouda.dtypes import *
+from arkouda.dtypes import NUMBER_FORMAT_STRINGS
 import numpy as np
+import json
 
 global verbose
 global pdarrayIterThresh
@@ -87,7 +89,7 @@ class Strings:
                                                               self.offsets.name,
                                                               self.bytes.name,
                                                               self.objtype,
-                                                              other)
+                                                              json.dumps([other]))
         else:
             raise ValueError("Strings: {} not supported between Strings and {}".format(op, type(other)))
         repMsg = generic_msg(msg)
@@ -186,7 +188,7 @@ class Strings:
                                                         self.offsets.name,
                                                         self.bytes.name,
                                                         "str",
-                                                        substr)
+                                                        json.dumps([substr]))
         repMsg = generic_msg(msg)
         return create_pdarray(repMsg)
 
@@ -217,7 +219,7 @@ class Strings:
                                                         self.offsets.name,
                                                         self.bytes.name,
                                                         "str",
-                                                        substr)
+                                                        json.dumps([substr]))
         repMsg = generic_msg(msg)
         return create_pdarray(repMsg)
 
@@ -248,10 +250,210 @@ class Strings:
                                                         self.offsets.name,
                                                         self.bytes.name,
                                                         "str",
-                                                        substr)
+                                                        json.dumps([substr]))
         repMsg = generic_msg(msg)
         return create_pdarray(repMsg)
 
+    def peel(self, delimiter, times=1, includeDelimiter=False, keepPartial=False, fromRight=False):
+        """
+        Peel off one or more delimited fields from each string (similar 
+        to string.partition), returning two new arrays of strings.
+
+        Parameters
+        ----------
+        delimiter : str
+            The separator where the split will occur
+        times : int
+            The number of times the delimiter is sought, i.e. skip over 
+            the first (times-1) delimiters
+        includeDelimiter : bool
+            If true, append the delimiter to the end of the first return 
+            array. By default, it is prepended to the beginning of the 
+            second return array.
+        keepPartial : bool
+            If true, a string that does not contain <times> instances of 
+            the delimiter will be returned in the first array. By default, 
+            such strings are returned in the second array.
+        fromRight : bool
+            If true, peel from the right instead of the left (see also rpeel)
+
+        Returns
+        -------
+        left : Strings
+            The field(s) peeled from the end of each string (unless 
+            fromRight is true)
+        right : Strings
+            The remainder of each string after peeling (unless fromRight 
+            is true)
+        
+        See Also
+        --------
+        rpeel, stick, lstick
+
+        Examples
+        --------
+        >>> s = ak.array(['a.b', 'c.d', 'e.f.g'])
+        >>> s.peel('.')
+        (array(['a', 'c', 'e']), array(['b', 'd', 'f.g']))
+        >>> s.peel('.', includeDelimiter=True)
+        (array(['a.', 'c.', 'e.']), array(['b', 'd', 'f.g']))
+        >>> s.peel('.', times=2)
+        (array(['', '', 'e.f']), array(['a.b', 'c.d', 'g']))
+        >>> s.peel('.', times=2, keepPartial=True)
+        (array(['a.b', 'c.d', 'e.f']), array(['', '', 'g']))
+        """
+        if isinstance(delimiter, bytes):
+            delimiter = delimiter.decode()
+        if not isinstance(delimiter, str):
+            raise TypeError("Delimiter must be a string, not {}".format(type(delimiter)))
+        if not np.isscalar(times) or resolve_scalar_dtype(times) != 'int64':
+            raise TypeError("Times must be integer, not {}".format(type(times)))
+        if times < 1:
+            raise ValueError("Times must be > 0")
+        msg = "segmentedEfunc {} {} {} {} {} {} {} {} {} {}".format("peel",
+                                                                    self.objtype,
+                                                                    self.offsets.name,
+                                                                    self.bytes.name,
+                                                                    "str",
+                                                                    NUMBER_FORMAT_STRINGS['int64'].format(times),
+                                                                    NUMBER_FORMAT_STRINGS['bool'].format(includeDelimiter),
+                                                                    NUMBER_FORMAT_STRINGS['bool'].format(keepPartial),
+                                                                    NUMBER_FORMAT_STRINGS['bool'].format(not fromRight),
+                                                                    json.dumps([delimiter]))
+        repMsg = generic_msg(msg)
+        arrays = repMsg.split('+', maxsplit=3)
+        leftStr = Strings(arrays[0], arrays[1])
+        rightStr = Strings(arrays[2], arrays[3])
+        return leftStr, rightStr
+
+    def rpeel(self, delimiter, times=1, includeDelimiter=False, keepPartial=False):
+        """
+        Peel off one or more delimited fields from the end of each string 
+        (similar to string.rpartition), returning two new arrays of strings.
+
+        Parameters
+        ----------
+        delimiter : str
+            The separator where the split will occur
+        times : int
+            The number of times the delimiter is sought, i.e. skip over 
+            the last (times-1) delimiters
+        includeDelimiter : bool
+            If true, prepend the delimiter to the start of the first return 
+            array. By default, it is appended to the end of the 
+            second return array.
+        keepPartial : bool
+            If true, a string that does not contain <times> instances of 
+            the delimiter will be returned in the second array. By default, 
+            such strings are returned in the first array.
+
+        Returns
+        -------
+        left : Strings
+            The remainder of the string after peeling
+        right : Strings
+            The field(s) that were peeled from the right of each string
+        
+        See Also
+        --------
+        peel, stick, lstick
+
+        Examples
+        --------
+        >>> s = ak.array(['a.b', 'c.d', 'e.f.g'])
+        >>> s.rpeel('.')
+        (array(['a', 'c', 'e.f']), array(['b', 'd', 'g']))
+        # Compared against peel
+        >>> s.peel('.')
+        (array(['a', 'c', 'e']), array(['b', 'd', 'f.g']))
+        """
+        return self.peel(delimiter, times=times, includeDelimiter=includeDelimiter, keepPartial=keepPartial, fromRight=True)
+
+    def stick(self, other, delimiter="", toLeft=False):
+        """
+        Join the strings from another array onto one end of the strings 
+        of this array, optionally inserting a delimiter.
+
+        Parameters
+        ----------
+        other : Strings
+            The strings to join onto self's strings
+        delimiter : str
+            String inserted between self and other
+        toLeft : bool
+            If true, join other strings to the left of self. By default,
+            other is joined to the right of self.
+
+        Returns
+        -------
+        Strings
+            The array of joined strings
+
+        See Also
+        --------
+        lstick, peel, rpeel
+
+        Examples
+        --------
+        >>> s = ak.array(['a', 'c', 'e'])
+        >>> t = ak.array(['b', 'd', 'f'])
+        >>> s.stick(t, delimiter='.')
+        array(['a.b', 'c.d', 'e.f'])
+        """
+        if not isinstance(other, Strings):
+            raise TypeError("stick: not supported between Strings and {}".format(type(other)))
+        if isinstance(delimiter, bytes):
+            delimiter = delimiter.decode()
+        if not isinstance(delimiter, str):
+            raise TypeError("Delimiter must be a string, not {}".format(type(delimiter)))
+        msg = "segmentedBinopvv {} {} {} {} {} {} {} {} {}".format("stick",
+                                                             self.objtype,
+                                                             self.offsets.name,
+                                                             self.bytes.name,
+                                                             other.objtype,
+                                                             other.offsets.name,
+                                                             other.bytes.name,
+                                                             NUMBER_FORMAT_STRINGS['bool'].format(toLeft),
+                                                             json.dumps([delimiter]))
+        repMsg = generic_msg(msg)
+        return Strings(*repMsg.split('+'))
+
+    def __add__(self, other):
+        return self.stick(other)
+    
+    def lstick(self, other, delimiter=""):
+        """
+        Join the strings from another array onto the left of the strings 
+        of this array, optionally inserting a delimiter.
+
+        Parameters
+        ----------
+        other : Strings
+            The strings to join onto self's strings
+        delimiter : str
+            String inserted between self and other
+
+        Returns
+        -------
+        Strings
+            The array of joined strings, as other + self
+
+        See Also
+        --------
+        stick, peel, rpeel
+
+        Examples
+        --------
+        >>> s = ak.array(['a', 'c', 'e'])
+        >>> t = ak.array(['b', 'd', 'f'])
+        >>> s.lstick(t, delimiter='.')
+        array(['b.a', 'd.c', 'f.e'])
+        """
+        return self.stick(other, delimiter=delimiter, toLeft=True)
+
+    def __radd__(self, other):
+        return self.lstick(other)
+    
     def hash(self):
         """
         Compute a 128-bit hash of each string.

--- a/pydoc/usage/strings.rst
+++ b/pydoc/usage/strings.rst
@@ -28,6 +28,9 @@ Arkouda ``Strings`` objects support the following operations:
 
 * Indexing with integer, slice, integer ``pdarray``, and boolean ``pdarray`` (see :ref:`indexing-label`)
 * Comparison (``==`` and ``!=``) with string literal or other ``Strings`` object of same size
+* :ref:`setops-label`, e.g. ``unique`` and ``in1d``
+* :ref:`sorting-label`, via ``argsort`` and ``coargsort``
+* :ref:`groupby-label`, both alone and in conjunction with numeric arrays
 * Substring search
   
   .. automethod:: arkouda.Strings.contains
@@ -35,7 +38,14 @@ Arkouda ``Strings`` objects support the following operations:
   .. automethod:: arkouda.Strings.startswith
                     
   .. automethod:: arkouda.Strings.endswith
-                    
-* :ref:`setops-label`, e.g. ``unique`` and ``in1d``
-* :ref:`sorting-label`, via ``argsort`` and ``coargsort``
-* :ref:`groupby-label`, both alone and in conjunction with numeric arrays
+
+* Splitting and joining
+
+  .. automethod:: arkouda.Strings.peel
+                  
+  .. automethod:: arkouda.Strings.rpeel
+
+  .. automethod:: arkouda.Strings.stick
+
+  .. automethod:: arkouda.Strings.lstick
+

--- a/src/RandArray.chpl
+++ b/src/RandArray.chpl
@@ -34,7 +34,7 @@ module RandArray {
     }
   }
 
-  proc fillReal(a:[] real, const aMin=0, const aMax=1) {
+  proc fillReal(a:[] real, const aMin:numeric=0.0, const aMax:numeric=1.0) {
     coforall loc in Locales {
       on loc {
         ref myA = a.localSlice[a.localSubdomain()];
@@ -68,6 +68,31 @@ module RandArray {
     Numeric,
     Printable,
     Binary
+  }
+
+  proc str2CharSet(str: string): charSet {
+    var ret: charSet;
+    select str.toLower() {
+      when "uppercase" {
+        ret = charSet.Uppercase;
+      }
+      when "lowercase" {
+        ret = charSet.Lowercase;
+      }
+      when "numeric" {
+        ret = charSet.Numeric;
+      }
+      when "printable" {
+        ret = charSet.Printable;
+      }
+      when "binary" {
+        ret = charSet.Binary;
+      }
+      otherwise {
+        ret = charSet.Uppercase;
+      }
+    }
+    return ret;
   }
 
   var charBounds: map(keyType=charSet, valType=2*int, parSafe=false);

--- a/src/RandMsg.chpl
+++ b/src/RandMsg.chpl
@@ -21,19 +21,19 @@ module RandMsg
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
         var fields = reqMsg.split(); // split request into fields
-        var cmd = fields[1];
-        var aMin = try! fields[2]:int;
-        var aMax = try! fields[3]:int;
-        var len = try! fields[4]:int;
-        var dtype = str2dtype(fields[5]);
+        var cmd = fields[1];     
+        var len = fields[2]:int;
+        var dtype = str2dtype(fields[3]);
 
         // get next symbol name
         var rname = st.nextName();
         
         // if verbose print action
-        if v {try! writeln("%s %i %i %i %s : %s".format(cmd,aMin,aMax,len,dtype2str(dtype),rname)); try! stdout.flush();}
+        if v {try! writeln("%s %i %s %s %s: %s".format(cmd,len,dtype2str(dtype),rname,fields[4],fields[5])); try! stdout.flush();}
         select (dtype) {
-            when (DType.Int64) {                
+            when (DType.Int64) {
+                var aMin = fields[4]:int;
+                var aMax = fields[5]:int;
                 var t1 = Time.getCurrentTime();
                 var e = st.addEntry(rname, len, int);
                 writeln("alloc time = ",Time.getCurrentTime() - t1,"sec"); try! stdout.flush();
@@ -42,7 +42,9 @@ module RandMsg
                 fillInt(e.a, aMin, aMax);
                 writeln("compute time = ",Time.getCurrentTime() - t1,"sec"); try! stdout.flush();
             }
-            when (DType.UInt8) {                
+            when (DType.UInt8) {
+                var aMin = fields[4]:int;
+                var aMax = fields[5]:int;
                 var t1 = Time.getCurrentTime();
                 var e = st.addEntry(rname, len, uint(8));
                 writeln("alloc time = ",Time.getCurrentTime() - t1,"sec"); try! stdout.flush();
@@ -52,6 +54,8 @@ module RandMsg
                 writeln("compute time = ",Time.getCurrentTime() - t1,"sec"); try! stdout.flush();
             }
             when (DType.Float64) {
+                var aMin = fields[4]:real;
+                var aMax = fields[5]:real;
                 var t1 = Time.getCurrentTime();
                 var e = st.addEntry(rname, len, real);
                 writeln("alloc time = ",Time.getCurrentTime() - t1,"sec"); try! stdout.flush();
@@ -73,6 +77,20 @@ module RandMsg
         }
         // response message
         return try! "created " + st.attrib(rname);
+    }
+
+    proc randomNormalMsg(reqMsg: string, st: borrowed SymTab): string throws {
+      var pn = Reflection.getRoutineName();
+      var fields = reqMsg.split();
+      var cmd = fields[1];
+      var len = fields[2]:int;
+      // Result + 2 scratch arrays
+      overMemLimit(3*8*len);
+      var rname = st.nextName();
+      var entry = new shared SymEntry(len, real);
+      fillNormal(entry.a);
+      st.addEntry(rname, entry);
+      return "created " + st.attrib(rname);
     }
 
 }

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -6,6 +6,9 @@ module SegmentedMsg {
   use MultiTypeSymEntry;
   use RandArray;
   use IO;
+  use GenSymIO only decode_json;
+
+  private config const DEBUG = false;
 
   proc randomStringsMsg(reqMsg: string, st: borrowed SymTab): string throws {
     var pn = Reflection.getRoutineName();
@@ -70,37 +73,115 @@ module SegmentedMsg {
   proc segmentedEfuncMsg(reqMsg: string, st: borrowed SymTab): string throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
-    var fields = reqMsg.split();
+    var fields = reqMsg.split(10);
     var cmd = fields[1];
     var subcmd = fields[2];
     var objtype = fields[3];
     var segName = fields[4];
     var valName = fields[5];
     var valtype = fields[6];
-    var val = fields[7];
-    var rname = st.nextName();
+    // var val = fields[7];
     select (objtype, valtype) {
     when ("str", "str") {
       var strings = new owned SegString(segName, valName, st);
       select subcmd {
         when "contains" {
+          var json = decode_json(fields[7], 1);
+          var val = json[json.domain.low];
+          var rname = st.nextName();
           var truth = st.addEntry(rname, strings.size, bool);
           truth.a = strings.substringSearch(val, SearchMode.contains);
+          repMsg = "created "+st.attrib(rname);
         }
         when "startswith" {
+          var json = decode_json(fields[7], 1);
+          var val = json[json.domain.low];
+          var rname = st.nextName();
           var truth = st.addEntry(rname, strings.size, bool);
           truth.a = strings.substringSearch(val, SearchMode.startsWith);
+          repMsg = "created "+st.attrib(rname);
         }
         when "endswith" {
+          var json = decode_json(fields[7], 1);
+          var val = json[json.domain.low];
+          var rname = st.nextName();
           var truth = st.addEntry(rname, strings.size, bool);
           truth.a = strings.substringSearch(val, SearchMode.endsWith);
+          repMsg = "created "+st.attrib(rname);
+        }
+        when "peel" {
+          var times = fields[7]:int;
+          var includeDelimiter = (fields[8].toLower() == "true");
+          var keepPartial = (fields[9].toLower() == "true");
+          var left = (fields[10].toLower() == "true");
+          var json = decode_json(fields[11], 1);
+          var val = json[json.domain.low];
+          var loname = st.nextName();
+          var lvname = st.nextName();
+          var roname = st.nextName();
+          var rvname = st.nextName();
+          select (includeDelimiter, keepPartial, left) {
+          when (false, false, false) {
+            var (lo, lv, ro, rv) = strings.peel(val, times, false, false, false);
+            st.addEntry(loname, new shared SymEntry(lo));
+            st.addEntry(lvname, new shared SymEntry(lv));
+            st.addEntry(roname, new shared SymEntry(ro));
+            st.addEntry(rvname, new shared SymEntry(rv));
+          } when (false, false, true) {
+            var (lo, lv, ro, rv) = strings.peel(val, times, false, false, true);
+            st.addEntry(loname, new shared SymEntry(lo));
+            st.addEntry(lvname, new shared SymEntry(lv));
+            st.addEntry(roname, new shared SymEntry(ro));
+            st.addEntry(rvname, new shared SymEntry(rv));
+          } when (false, true, false) {
+            var (lo, lv, ro, rv) = strings.peel(val, times, false, true, false);
+            st.addEntry(loname, new shared SymEntry(lo));
+            st.addEntry(lvname, new shared SymEntry(lv));
+            st.addEntry(roname, new shared SymEntry(ro));
+            st.addEntry(rvname, new shared SymEntry(rv));
+          } when (false, true, true) {
+            var (lo, lv, ro, rv) = strings.peel(val, times, false, true, true);
+            st.addEntry(loname, new shared SymEntry(lo));
+            st.addEntry(lvname, new shared SymEntry(lv));
+            st.addEntry(roname, new shared SymEntry(ro));
+            st.addEntry(rvname, new shared SymEntry(rv));
+          } when (true, false, false) {
+            var (lo, lv, ro, rv) = strings.peel(val, times, true, false, false);
+            st.addEntry(loname, new shared SymEntry(lo));
+            st.addEntry(lvname, new shared SymEntry(lv));
+            st.addEntry(roname, new shared SymEntry(ro));
+            st.addEntry(rvname, new shared SymEntry(rv));
+          } when (true, false, true) {
+            var (lo, lv, ro, rv) = strings.peel(val, times, true, false, true);
+            st.addEntry(loname, new shared SymEntry(lo));
+            st.addEntry(lvname, new shared SymEntry(lv));
+            st.addEntry(roname, new shared SymEntry(ro));
+            st.addEntry(rvname, new shared SymEntry(rv));
+          } when (true, true, false) {
+            var (lo, lv, ro, rv) = strings.peel(val, times, true, true, false);
+            st.addEntry(loname, new shared SymEntry(lo));
+            st.addEntry(lvname, new shared SymEntry(lv));
+            st.addEntry(roname, new shared SymEntry(ro));
+            st.addEntry(rvname, new shared SymEntry(rv));
+          } when (true, true, true) {
+            var (lo, lv, ro, rv) = strings.peel(val, times, true, true, true);
+            st.addEntry(loname, new shared SymEntry(lo));
+            st.addEntry(lvname, new shared SymEntry(lv));
+            st.addEntry(roname, new shared SymEntry(ro));
+            st.addEntry(rvname, new shared SymEntry(rv));
+          } otherwise {return notImplementedError(pn, "subcmd: %s, (%s, %s)".format(subcmd, objtype, valtype));}
+          }
+          repMsg = "created %s+created %s+created %s+created %s".format(st.attrib(loname),
+                                                                        st.attrib(lvname),
+                                                                        st.attrib(roname),
+                                                                        st.attrib(rvname));
         }
         otherwise {return notImplementedError(pn, "subcmd: %s, (%s, %s)".format(subcmd, objtype, valtype));}
       }
     }
     otherwise {return notImplementedError(pn, "(%s, %s)".format(objtype, valtype));}
     }
-    return "created "+st.attrib(rname);
+    return repMsg;
   }
 
   proc segmentedHashMsg(reqMsg: string, st: borrowed SymTab): string throws {
@@ -266,7 +347,7 @@ module SegmentedMsg {
   proc segBinopvvMsg(reqMsg: string, st: borrowed SymTab): string throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
-    var fields = reqMsg.split();
+    var fields = reqMsg.split(9);
     var cmd = fields[1];
     var op = fields[2];
     // Type and attrib names of left segmented array
@@ -277,39 +358,62 @@ module SegmentedMsg {
     var rtype = fields[6];
     var rsegName = fields[7];
     var rvalName = fields[8];
-    var rname = st.nextName();
     select (ltype, rtype) {
     when ("str", "str") {
       var lstrings = new owned SegString(lsegName, lvalName, st);
       var rstrings = new owned SegString(rsegName, rvalName, st);
       select op {
         when "==" {
+          var rname = st.nextName();
           var e = st.addEntry(rname, lstrings.size, bool);
           e.a = (lstrings == rstrings);
+          repMsg = "created " + st.attrib(rname);
         }
         when "!=" {
+          var rname = st.nextName();
           var e = st.addEntry(rname, lstrings.size, bool);
           e.a = (lstrings != rstrings);
+          repMsg = "created " + st.attrib(rname);
+        }
+        when "stick" {
+          var left = (fields[9].toLower() != "false");
+          var json = decode_json(fields[10], 1);
+          const delim = json[json.domain.low];
+          var oname = st.nextName();
+          var vname = st.nextName();
+          if left {
+            var (newOffsets, newVals) = lstrings.stick(rstrings, delim, false);
+            st.addEntry(oname, new shared SymEntry(newOffsets));
+            st.addEntry(vname, new shared SymEntry(newVals));
+          } else {
+            var (newOffsets, newVals) = lstrings.stick(rstrings, delim, true);
+            st.addEntry(oname, new shared SymEntry(newOffsets));
+            st.addEntry(vname, new shared SymEntry(newVals));
+          }
+          repMsg = "created %s+created %s".format(st.attrib(oname), st.attrib(vname));
+          if DEBUG {writeln(repMsg);}
         }
         otherwise {return notImplementedError(pn, ltype, op, rtype);}
         }
     }
     otherwise {return unrecognizedTypeError(pn, "("+ltype+", "+rtype+")");} 
     }
-    return "created " + st.attrib(rname);
+    return repMsg;
   }
 
   proc segBinopvsMsg(reqMsg: string, st: borrowed SymTab): string throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
-    var fields = reqMsg.split();
+    var fields = reqMsg.split(6);
     var cmd = fields[1];
     var op = fields[2];
     var objtype = fields[3];
     var segName = fields[4];
     var valName = fields[5];
     var valtype = fields[6];
-    var value = fields[7];
+    var encodedVal = fields[7];
+    var json = decode_json(encodedVal, 1);
+    var value = json[json.domain.low];
     var rname = st.nextName();
     select (objtype, valtype) {
     when ("str", "str") {

--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -160,6 +160,8 @@ proc main() {
                         when "arange"            {repMsg = arangeMsg(reqMsg, st);}
                         when "linspace"          {repMsg = linspaceMsg(reqMsg, st);}
                         when "randint"           {repMsg = randintMsg(reqMsg, st);}
+                        when "randomNormal"      {repMsg = randomNormalMsg(reqMsg, st);}
+                        when "randomStrings"     {repMsg = randomStringsMsg(reqMsg, st);}
                         when "histogram"         {repMsg = histogramMsg(reqMsg, st);}
                         when "in1d"              {repMsg = in1dMsg(reqMsg, st);}
                         when "unique"            {repMsg = uniqueMsg(reqMsg, st);}

--- a/test/UnitTestMerge.chpl
+++ b/test/UnitTestMerge.chpl
@@ -60,16 +60,16 @@ proc testMerge(n, m, minLen, maxLen) {
   writeln("%t seconds".format(t.elapsed())); stdout.flush(); t.clear();
   var cstrings = new owned SegString(csegs, cvals, st);
   cstrings.show(5);
-  var ascending = cstrings.isAscending();
-  var sorted = && reduce (ascending <= 0);
+  var diff = cstrings.ediff();
+  var sorted = && reduce (diff >= 0);
   writeln("Result is sorted? >>> ", sorted, " <<<");
   if !sorted {
     var pos = 0;
     for i in 0..#5 {
-      while (pos < cstrings.size) && (ascending[pos] <= 0) {
+      while (pos < cstrings.size) && (diff[pos] <= 0) {
         pos += 1;
       }
-      writeln("\n%i: %i\n%s\n%s".format(pos, ascending[pos], cstrings[pos], cstrings[pos+1])); stdout.flush();
+      writeln("\n%i: %i\n%s\n%s".format(pos, diff[pos], cstrings[pos], cstrings[pos+1])); stdout.flush();
       pos += 1;
     }
   }

--- a/test/UnitTestPeelStick.chpl
+++ b/test/UnitTestPeelStick.chpl
@@ -1,0 +1,173 @@
+use RandArray;
+use MultiTypeSymbolTable;
+use SegmentedArray;
+use SegmentedMsg;
+use Time;
+
+config const N: int = 10_000;
+config const MINLEN: int = 6;
+config const MAXLEN: int = 30;
+config const SUBSTRING: string = "hi";
+config const DEBUG = false;
+
+proc make_strings(substr, n, minLen, maxLen, characters, st) {
+  const nb = substr.numBytes;
+  const sbytes: [0..#nb] uint(8) = for b in substr.chpl_bytes() do b;
+  var (segs, vals) = newRandStringsUniformLength(n, minLen, maxLen, characters);
+  var strings = new owned SegString(segs, vals, st);
+  var lengths = strings.getLengths() - 1;
+  var r: [segs.domain] int;
+  fillInt(r, 0, 100);
+  var splits = (r % 3);
+  /* var present = (r < 5) & (lengths >= nb); */
+  /* present[present.domain.high] = true; */
+  /* present[present.domain.low] = true; */
+  forall (rn, o, l, s) in zip(r, segs, lengths, splits) {
+    if l >= nb {
+      if (s == 1) || ((s == 2) && (l < 2*(nb+1))) {
+        if l == nb {
+          vals[{o..#nb}] = sbytes;
+        } else {
+          const i = rn % (l - nb);
+          vals[{(o+i)..#nb}] = sbytes;
+        }
+      } else if s == 2 {
+        const i = rn % ((l/2) - nb);
+        vals[{(o+i)..#nb}] = sbytes;
+        const j = i + (l/2);
+        vals[{(o+j)..#nb}] = sbytes;
+      }
+    }
+  }
+  var strings2 = new owned SegString(segs, vals, st);
+  return (splits, strings2);
+}
+
+proc testPeel(substr:string, n:int, minLen:int, maxLen:int, characters:charSet = charSet.Uppercase) throws {
+  var st = new owned SymTab();
+  var t = new Timer();
+  writeln("Generating random strings..."); stdout.flush();
+  t.start();
+  var (answer, strings) = make_strings(substr, n, minLen, maxLen, characters, st);
+  t.stop();
+  writeln("%t seconds".format(t.elapsed())); stdout.flush(); t.clear();
+  const lengths = strings.getLengths();
+  var allSuccess = true;
+  for param times in 1..2 {
+    for param id in 0..1 {
+      param includeDelimiter:bool = id > 0;
+      for param kp in 0..1 {
+        param keepPartial:bool = kp > 0;
+        for param l in 0..1 {
+          param left:bool = l > 0;
+          writeln("strings.peel(%s, %i, includeDelimiter=%t, keepPartial=%t, left=%t)".format(substr, times, includeDelimiter, keepPartial, left));
+          t.start();
+          var (leftOffsets, leftVals, rightOffsets, rightVals) = strings.peel(substr, times, includeDelimiter, keepPartial, left);
+          t.stop();
+          writeln("%t seconds".format(t.elapsed())); stdout.flush();
+          var lstr = new owned SegString(leftOffsets, leftVals, st);
+          var rstr = new owned SegString(rightOffsets, rightVals, st);
+          if DEBUG {
+            var llen = lstr.getLengths();
+            var rlen = rstr.getLengths();
+            var badLen = + reduce ((llen <= 0) | (rlen <= 0));
+            writeln("Lengths <= 0: %t".format(badLen));
+            if badLen > 0 {
+              var n = 0;
+              for (i, ll, rl, ol) in zip(lstr.offsets.aD, llen, rlen, lengths) {
+                if (ll <= 0) {
+                  n += 1;
+                  writeln("%i: %s (%i) -> <bad> (%i) | %s (%i)".format(i, strings[i], ol, ll, rstr[i], rl));
+                } else if (rl <= 0) {
+                  n += 1;
+                  writeln("%i: %s (%i) -> %s (%i) | <bad> (%i)".format(i, strings[i], ol, lstr[i], ll, rl));
+                }
+                if n >= 5 {
+                  stdout.flush();
+                  break;
+                }
+              }
+            }
+          } 
+          for i in 0..#min(lstr.size, 5) {
+            writeln("%i: %s  |  %s".format(i, lstr[i], rstr[i]));
+          }
+          if lstr.size >= 10 {
+            for i in (lstr.size-5)..#4 {
+              writeln("%i: %s  |  %s".format(i, lstr[i], rstr[i]));
+            }
+          }
+          const delim = if includeDelimiter then "" else substr;
+          var temp: owned SegString?;
+          if left {
+            var (roundOff, roundVals) = lstr.stick(rstr, delim, true);
+            temp = new owned SegString(roundOff, roundVals, st);
+          } else {
+            var (roundOff, roundVals) = rstr.stick(lstr, delim, false);
+            temp = new owned SegString(roundOff, roundVals, st);
+          }
+          var roundTrip: borrowed SegString = temp!;
+          var eq = (strings == roundTrip) | (answer < times);
+          var success = && reduce eq;
+          writeln("\nRound trip success? >>> %t <<<\n".format(success));
+          allSuccess &&= success;
+          if !success {
+            var n = 0;
+            const rtlen = roundTrip.getLengths();
+            for (i, e) in zip(strings.offsets.aD, eq) {
+              if !e {
+                n += 1;
+                writeln("%i: %s (%i) -> %s (%i)".format(i, strings[i], lengths[i], roundTrip[i], rtlen[i]));
+              }
+              if n >= 5 {
+                break;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  writeln("All round trip tests passed? >>> %t <<<".format(allSuccess));
+}
+
+proc testMessageLayer(substr, n, minLen, maxLen) throws {
+  var st = new owned SymTab();
+  var t = new Timer();
+  writeln("Generating random strings..."); stdout.flush();
+  t.start();
+  var (answer, strings) = make_strings(substr, n, minLen, maxLen, charSet.Uppercase, st);
+  t.stop();
+  writeln("%t seconds".format(t.elapsed())); stdout.flush(); t.clear();
+  var reqMsg = "segmentedEfunc peel str %s %s str 1 True True True %jt".format(strings.offsetName, strings.valueName, [substr]);
+  writeln(reqMsg);
+  var repMsg = segmentedEfuncMsg(reqMsg, st);
+  writeln(repMsg);
+  var attribs = repMsg.split('+');
+  var temp = attribs[1].split();
+  var loname = temp[2];
+  temp = attribs[2].split();
+  var lvname = temp[2];
+  temp = attribs[3].split();
+  var roname = temp[2];
+  temp = attribs[4].split();
+  var rvname = temp[2];
+  reqMsg = "segBinopvv stick str %s %s str %s %s False %jt".format(loname, lvname, roname, rvname, [""]);
+  writeln(reqMsg);
+  repMsg = segBinopvvMsg(reqMsg, st);
+  writeln(repMsg);
+  var attribs2 = repMsg.split('+');
+  temp = attribs2[1].split();
+  var rtoname = temp[2];
+  temp = attribs2[2].split();
+  var rtvname = temp[2];
+  var roundTrip = new owned SegString(rtoname, rtvname, st);
+  var success = && reduce (strings == roundTrip);
+  writeln("Round trip successful? >>> %t <<<".format(success));
+}
+
+proc main() {
+  try! testPeel(SUBSTRING, N, MINLEN, MAXLEN);
+  try! testMessageLayer(SUBSTRING, N, MINLEN, MAXLEN);
+}
+  

--- a/test/UnitTestSubstringSearch.chpl
+++ b/test/UnitTestSubstringSearch.chpl
@@ -12,7 +12,7 @@ config const DEBUG = false;
 proc make_strings(substr, n, minLen, maxLen, characters, mode, st) {
   const nb = substr.numBytes;
   const sbytes: [0..#nb] uint(8) = for b in substr.chpl_bytes() do b;
-  var (segs, vals) = newRandStrings(n, minLen, maxLen, characters);
+  var (segs, vals) = newRandStringsUniformLength(n, minLen, maxLen, characters);
   var strings = new owned SegString(segs, vals, st);
   var lengths = strings.getLengths() - 1;
   var r: [segs.domain] int;

--- a/tests/string_test.py
+++ b/tests/string_test.py
@@ -124,3 +124,100 @@ if __name__ == '__main__':
         assert(not (permStrings[:s] == uk).any())
         assert(not (permStrings[s+l:] == uk).any())
     print("groupby passed")
+
+    # substring functions
+    from collections import Counter
+    x, w = tuple(zip(*Counter(''.join(base_words)).items()))
+    delim = np.random.choice(x, p=(np.array(w)/sum(w)))
+
+    # contains
+    found = strings.contains(delim).to_ndarray()
+    npfound = np.array([s.count(delim) > 0 for s in test_strings])
+    assert((found == npfound).all())
+    print("contains passed")
+
+    # startswith
+    found = strings.startswith(delim).to_ndarray()
+    npfound = np.array([s.startswith(delim) for s in test_strings])
+    assert((found == npfound).all())
+    print("startswith passed")
+
+    # endswith
+    found = strings.endswith(delim).to_ndarray()
+    npfound = np.array([s.endswith(delim) for s in test_strings])
+    assert((found == npfound).all())
+    print("endswith passed")
+
+    # peel
+    import itertools as it
+    tf = (True, False)
+    def munge(triple, inc, part):
+        ret = []
+        for h, s, t in triple:
+            if not part and s == '':
+                ret.append(('', h))
+            else:
+                if inc:
+                    ret.append((h + s, t))
+                else:
+                    ret.append((h, t))
+        l, r = tuple(zip(*ret))
+        return np.array(l), np.array(r)
+
+    def rmunge(triple, inc, part):
+        ret = []
+        for h, s, t in triple:
+            if not part and s == '':
+                ret.append((t, ''))
+            else:
+                if inc:
+                    ret.append((h, s + t))
+                else:
+                    ret.append((h, t))
+        l, r = tuple(zip(*ret))
+        return np.array(l), np.array(r)
+
+    def slide(triple, delim):
+        h, s, t = triple
+        h2, s2, t2 = t.partition(delim)
+        newh = h + s + h2
+        return newh, s2, t2
+
+    def rslide(triple, delim):
+        h, s, t = triple
+        h2, s2, t2 = h.rpartition(delim)
+        newt = t2 + s + t
+        return h2, s2, newt
+    
+    for times, inc, part in it.product(range(1,4), tf, tf):
+        ls, rs = strings.peel(delim, times=times, includeDelimiter=inc, keepPartial=part)
+        triples = [s.partition(delim) for s in test_strings]
+        for i in range(times-1):
+            triples = [slide(t, delim) for t in triples]
+        ltest, rtest = munge(triples, inc, part)
+        assert((ltest == ls.to_ndarray()).all() and (rtest == rs.to_ndarray()).all())
+
+    for times, inc, part in it.product(range(1,4), tf, tf):
+        ls, rs = strings.rpeel(delim, times=times, includeDelimiter=inc, keepPartial=part)
+        triples = [s.rpartition(delim) for s in test_strings]
+        for i in range(times-1):
+            triples = [rslide(t, delim) for t in triples]
+        ltest, rtest = rmunge(triples, inc, part)
+        assert((ltest == ls.to_ndarray()).all() and (rtest == rs.to_ndarray()).all())
+
+    print("peel passed")
+
+    # stick
+
+    test_strings2 = np.random.choice(base_words, N, replace=True)
+    strings2 = ak.array(test_strings2)
+    stuck = strings.stick(strings2, delimiter=delim).to_ndarray()
+    tstuck = np.array([delim.join((a, b)) for a, b in zip(test_strings, test_strings2)])
+    assert ((stuck == tstuck).all())
+    assert ((strings + strings2) == strings.stick(strings2, delimiter="")).all()
+
+    lstuck = strings.lstick(strings2, delimiter=delim).to_ndarray()
+    tlstuck = np.array([delim.join((b, a)) for a, b in zip(test_strings, test_strings2)])
+    assert ((lstuck == tlstuck).all())
+    assert ((strings2 + strings) == strings.lstick(strings2, delimiter="")).all()
+    print("stick passed")

--- a/tests/string_test.py
+++ b/tests/string_test.py
@@ -7,6 +7,7 @@ import sys
 ak.verbose = False
 
 N = 1000
+UNIQUE = N//4
 
 # test_strings = np.array(['These are', 'some', 'interesting',
 #                          '~!@#$%^&*()_+', 'strings', '8675309.',
@@ -23,12 +24,15 @@ if __name__ == '__main__':
     else:
         ak.connect()
 
-    with open(__file__, 'r') as f:
-        base_words = np.array(f.read().split())
+    # with open(__file__, 'r') as f:
+    #     base_words = np.array(f.read().split())
+    # test_strings = np.random.choice(base_words, N, replace=True)
+    # strings = ak.array(test_strings)
 
-    test_strings = np.random.choice(base_words, N, replace=True)
-
-    strings = ak.array(test_strings)
+    base_words = ak.random_strings_lognormal(2, 1, UNIQUE, characters='printable')
+    choices = ak.randint(0, UNIQUE, N)
+    strings = base_words[choices]
+    test_strings = strings.to_ndarray()
     cat = ak.Categorical(strings)
     print("strings =", strings)
     print("categorical =", cat)
@@ -62,8 +66,11 @@ if __name__ == '__main__':
     print("pdarray bool index passed")
 
     # in1d and iter
-    more_words = np.random.choice(base_words, 100)
-    akwords = ak.array(more_words)
+    # more_words = np.random.choice(base_words, 100)
+    # akwords = ak.array(more_words)
+    more_choices = ak.randint(0, UNIQUE, 100)
+    akwords = base_words[more_choices]
+    more_words = akwords.to_ndarray()
     matches = ak.in1d(strings, akwords)
     catmatches = ak.in1d(cat, akwords)
     assert((matches == catmatches).all())


### PR DESCRIPTION
**Note:** This PR should come **after** #299 since it incorporates all those changes (required for passing `tests/string_test.py`).

This PR adds four methods to the client for generating random data:
* `random_strings_uniform` (strings with uniformly distributed lengths)
* `random_strings_lognormal` (strings with log-normally distributed lengths)
* `standard_normal` (normally distributed floats)
* `uniform` (uniformly distributed floats, a less confusingly named wrapper for `randint(..., dtype=ak.float64)`)

Also, `tests/string_test.py` has been updated to directly generate test strings in arkouda, rather than reading in a file.