### PR TITLE
Remove mpi dependency for chapel-master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,6 @@ endif
 CHPL_FLAGS += --ccflags="-Wno-incompatible-pointer-types"
 CHPL_FLAGS += -smemTrack=true
 CHPL_FLAGS += -lhdf5 -lhdf5_hl -lzmq
-ifndef CHPL_VERSION_120
-  CHPL_FLAGS += -lmpi
-endif
 
 # add-path: Append custom paths for non-system software.
 # Note: Darwin `ld` only supports `-rpath <path>`, not `-rpath=<paths>`.


### PR DESCRIPTION
The default hdf5 module no longer brings in mpi as of chapel-lang/chapel#15018