### PR TITLE
BUG: Changed incorrect overload name for strings not equals

### DIFF
--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -98,7 +98,7 @@ class Strings:
     def __eq__(self, other):
         return self.binop(other, "==")
 
-    def __neq__(self, other):
+    def __ne__(self, other):
         return self.binop(other, "!=")
 
     def __getitem__(self, key):


### PR DESCRIPTION
BUG: Changed incorrect overload name for not eqauls from '__neq__' to '__ne__'. Resolves #305