### PR TITLE
Run benchmarks in a correctness-only mode for CI testing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,6 +42,7 @@ jobs:
       run: |
          ./benchmarks/run_benchmarks.py --correctness-only --dtype=int64
          ./benchmarks/run_benchmarks.py --correctness-only --dtype=float64
+         ./benchmarks/run_benchmarks.py --correctness-only --dtype=bool scatter gather
 
   unit_tests_linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,6 +38,10 @@ jobs:
     - name: Arkouda unit tests
       run: |
         ./util/test/runClient tests/operator_tests.py tests/string_test.py
+    - name: Arkouda benchmark --correctness-only
+      run: |
+         ./benchmarks/run_benchmarks.py --correctness-only --dtype=int64
+         ./benchmarks/run_benchmarks.py --correctness-only --dtype=float64
 
   unit_tests_linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,7 +37,7 @@ jobs:
         make check
     - name: Arkouda unit tests
       run: |
-        ./util/test/runClient tests/operator_tests.py tests/string_test.py
+        ./util/test/runClient tests/operator_tests.py
     - name: Arkouda benchmark --correctness-only
       run: |
          ./benchmarks/run_benchmarks.py --correctness-only --dtype=int64

--- a/benchmarks/argsort.py
+++ b/benchmarks/argsort.py
@@ -47,6 +47,16 @@ def time_np_argsort(N, trials, dtype):
     bytes_per_sec = (a.size * a.itemsize) / tavg
     print("Average rate = {:.4f} GiB/sec".format(bytes_per_sec/2**30))
 
+def check_correctness(dtype):
+    N = 10**4
+    if dtype == 'int64':
+        a = ak.randint(0, 2**32, N)
+    elif dtype == 'float64':
+        a = ak.randint(0, 1, N, dtype=ak.float64)
+
+    perm = ak.argsort(a)
+    assert ak.is_sorted(a[perm])
+
 def create_parser():
     parser = argparse.ArgumentParser(description="Measure performance of sorting an array of random values.")
     parser.add_argument('hostname', help='Hostname of arkouda server')
@@ -55,6 +65,7 @@ def create_parser():
     parser.add_argument('-t', '--trials', type=int, default=6, help='Number of times to run the benchmark')
     parser.add_argument('-d', '--dtype', default='int64', help='Dtype of array (int64 or float64)')
     parser.add_argument('--numpy', default=False, action='store_true', help='Run the same operation in NumPy to compare performance.')
+    parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')
     return parser
 
 if __name__ == "__main__":
@@ -65,6 +76,10 @@ if __name__ == "__main__":
         raise ValueError("Dtype must be either int64 or float64, not {}".format(args.dtype))
     ak.verbose = False
     ak.connect(args.hostname, args.port)
+
+    if args.correctness_only:
+        check_correctness(args.dtype)
+        sys.exit(0)
     
     print("array size = {:,}".format(args.size))
     print("number of trials = ", args.trials)

--- a/benchmarks/gather.py
+++ b/benchmarks/gather.py
@@ -78,22 +78,30 @@ def create_parser():
     parser = argparse.ArgumentParser(description="Measure the performance of random gather: C = V[I]")
     parser.add_argument('hostname', help='Hostname of arkouda server')
     parser.add_argument('port', type=int, help='Port of arkouda server')
-    parser.add_argument('-i', '--index-size', type=int, default=10**8, help='Length of index array (number of gathers to perform)')
-    parser.add_argument('-v', '--value-size', type=int, default=10**8, help='Length of array from which values are gathered')
+    parser.add_argument('-n', '--size', type=int, default=10**8, help='Problem size: length of index and gather arrays')
+    parser.add_argument('-i', '--index-size', type=int, help='Length of index array (number of gathers to perform)')
+    parser.add_argument('-v', '--value-size', type=int, help='Length of array from which values are gathered')
     parser.add_argument('-t', '--trials', type=int, default=6, help='Number of times to run the benchmark')
     parser.add_argument('-d', '--dtype', default='int64', help='Dtype of value array (int64 or float64)')
     parser.add_argument('-r', '--randomize', default=False, action='store_true', help='Use random values instead of ones')
     parser.add_argument('--numpy', default=False, action='store_true', help='Run the same operation in NumPy to compare performance.')
+    parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')
     return parser
     
 if __name__ == "__main__":
     import sys
     parser = create_parser()
     args = parser.parse_args()
+    args.index_size = args.size if args.index_size is None else args.index_size
+    args.value_size = args.size if args.value_size is None else args.value_size
     if args.dtype not in ('int64', 'float64'):
         raise ValueError("Dtype must be either int64 or float64, not {}".format(args.dtype))
     ak.verbose = False
     ak.connect(args.hostname, args.port)
+
+    if args.correctness_only:
+        check_correctness(args.dtype, args.randomize)
+        sys.exit(0)
     
     print("size of index array = {:,}".format(args.index_size))
     print("size of values array = {:,}".format(args.value_size))

--- a/benchmarks/gather.py
+++ b/benchmarks/gather.py
@@ -82,7 +82,7 @@ def create_parser():
     parser.add_argument('-i', '--index-size', type=int, help='Length of index array (number of gathers to perform)')
     parser.add_argument('-v', '--value-size', type=int, help='Length of array from which values are gathered')
     parser.add_argument('-t', '--trials', type=int, default=6, help='Number of times to run the benchmark')
-    parser.add_argument('-d', '--dtype', default='int64', help='Dtype of value array (int64 or float64)')
+    parser.add_argument('-d', '--dtype', default='int64', help='Dtype of value array (int64, float64, or bool)')
     parser.add_argument('-r', '--randomize', default=False, action='store_true', help='Use random values instead of ones')
     parser.add_argument('--numpy', default=False, action='store_true', help='Run the same operation in NumPy to compare performance.')
     parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')
@@ -94,8 +94,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
     args.index_size = args.size if args.index_size is None else args.index_size
     args.value_size = args.size if args.value_size is None else args.value_size
-    if args.dtype not in ('int64', 'float64'):
-        raise ValueError("Dtype must be either int64 or float64, not {}".format(args.dtype))
+    if args.dtype not in ('int64', 'float64', 'bool'):
+        raise ValueError("Dtype must be either int64, float64, or bool, not {}".format(args.dtype))
     ak.verbose = False
     ak.connect(args.hostname, args.port)
 

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -73,6 +73,7 @@ def create_parser():
     #parser.add_argument('--large', default=False, action='store_true', help='Run a larger problem size')
 
     parser.add_argument('-nl', '--num-locales', default=get_arkouda_numlocales(), help='Number of locales to use for the server')
+    parser.add_argument('benchmarks', nargs='*', help='Basename of benchmarks to run with extension stripped')
     parser.add_argument('--gen-graphs', default=False, action='store_true', help='Generate graphs, requires $CHPL_HOME')
     parser.add_argument('--dat-dir', default=os.path.join(benchmark_dir, 'datdir'), help='Directory with .dat files stored')
     parser.add_argument('--graph-dir', default=os.path.join(benchmark_dir, 'graphdir'), help='Directory to place generated graphs')
@@ -89,7 +90,8 @@ def main():
 
     start_arkouda_server(args.num_locales)
 
-    for benchmark in BENCHMARKS:
+    args.benchmarks = args.benchmarks or BENCHMARKS
+    for benchmark in args.benchmarks:
         benchmark_py = os.path.join(benchmark_dir, '{}.py'.format(benchmark))
         out = run_client(benchmark_py, client_args)
         if args.gen_graphs:

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -69,18 +69,6 @@ def generate_graphs(dat_dir, graph_dir, graph_infra, platform_name):
 def create_parser():
     parser = argparse.ArgumentParser(description=__doc__)
 
-    # TODO support passing through size/trials/type/whatever to benchmarks
-    #parser.add_argument('-n', '--size', type=int, default=10**8, help='Problem size: length of arrays A and B')
-    #parser.add_argument('-t', '--trials', type=int, default=6, help='Number of times to run the benchmark')
-    #parser.add_argument('-d', '--dtype', default='int64', help='Dtype of arrays (int64 or float64)')
-    #parser.add_argument('-r', '--randomize', default=False, action='store_true', help='Fill arrays with random values instead of ones')
-
-    # TODO support running numpy variations
-    #parser.add_argument('--numpy', default=False, action='store_true', help='Run the same operation in NumPy to compare performance.')
-
-    # TODO support running correctness mode only
-    # parser.add_argument('correctnss', default=False, action='store_true', help='Run correctness checks only')
-
     # TODO support alias for a larger default N
     #parser.add_argument('--large', default=False, action='store_true', help='Run a larger problem size')
 
@@ -94,7 +82,7 @@ def create_parser():
 
 def main():
     parser = create_parser()
-    args = parser.parse_args()
+    args, client_args = parser.parse_known_args()
 
     if args.gen_graphs:
         os.makedirs(args.dat_dir, exist_ok=True)
@@ -103,7 +91,7 @@ def main():
 
     for benchmark in BENCHMARKS:
         benchmark_py = os.path.join(benchmark_dir, '{}.py'.format(benchmark))
-        out = run_client(benchmark_py)
+        out = run_client(benchmark_py, client_args)
         if args.gen_graphs:
             add_to_dat(benchmark, out, args.dat_dir, args.graph_infra)
         print(out)

--- a/benchmarks/scan.py
+++ b/benchmarks/scan.py
@@ -68,6 +68,28 @@ def time_np_scan(N, trials, dtype, random):
         bytes_per_sec = (a.size * a.itemsize * 2) / t
         print("  {} Average rate = {:.2f} GiB/sec".format(op, bytes_per_sec/2**30))
 
+def check_correctness(dtype, random):
+    N = 10**4
+    if random:
+        if dtype == 'int64':
+            a = np.random.randint(0, 2**32, N)
+        elif dtype == 'float64':
+            a = np.random.random(N)
+    else:
+        if dtype == 'int64':
+            a = np.arange(0, N, 1, dtype=dtype)
+        elif dtype == 'float64':
+            a = np.arange(1, 1+1/N, (1/N)/N, dtype=dtype)
+
+    for op in OPS:
+        npa = a
+        aka = ak.array(a)
+        fxn = getattr(np, op)
+        npr = fxn(npa)
+        fxn = getattr(ak, op)
+        akr = fxn(aka)
+        assert np.allclose(npr, akr.to_ndarray())
+
 def create_parser():
     parser = argparse.ArgumentParser(description="Measure the performance of scans (cumulative reductions) over arrays.")
     parser.add_argument('hostname', help='Hostname of arkouda server')
@@ -77,6 +99,7 @@ def create_parser():
     parser.add_argument('-d', '--dtype', default='int64', help='Dtype of array (int64 or float64)')
     parser.add_argument('-r', '--randomize', default=False, action='store_true', help='Fill array with random values instead of range')
     parser.add_argument('--numpy', default=False, action='store_true', help='Run the same operation in NumPy to compare performance.')
+    parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')
     return parser
 
 if __name__ == "__main__":
@@ -87,6 +110,10 @@ if __name__ == "__main__":
         raise ValueError("Dtype must be either int64 or float64, not {}".format(args.dtype))
     ak.verbose = False
     ak.connect(args.hostname, args.port)
+
+    if args.correctness_only:
+        check_correctness(args.dtype, args.randomize)
+        sys.exit(0)
     
     print("array size = {:,}".format(args.size))
     print("number of trials = ", args.trials)

--- a/benchmarks/scatter.py
+++ b/benchmarks/scatter.py
@@ -89,7 +89,7 @@ def create_parser():
     parser.add_argument('-i', '--index-size', type=int, help='Length of index array (number of scatters to perform)')
     parser.add_argument('-v', '--value-size', type=int, help='Length of array from which values are scattered')
     parser.add_argument('-t', '--trials', type=int, default=6, help='Number of times to run the benchmark')
-    parser.add_argument('-d', '--dtype', default='int64', help='Dtype of value array (int64 or float64)')
+    parser.add_argument('-d', '--dtype', default='int64', help='Dtype of value array (int64, float64, or bool)')
     parser.add_argument('-r', '--randomize', default=False, action='store_true', help='Use random values instead of ones')
     parser.add_argument('--numpy', default=False, action='store_true', help='Run the same operation in NumPy to compare performance.')
     parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')
@@ -101,8 +101,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
     args.index_size = args.size if args.index_size is None else args.index_size
     args.value_size = args.size if args.value_size is None else args.value_size
-    if args.dtype not in ('int64', 'float64'):
-        raise ValueError("Dtype must be either int64 or float64, not {}".format(args.dtype))
+    if args.dtype not in ('int64', 'float64', 'bool'):
+        raise ValueError("Dtype must be either int64, float64, or bool, not {}".format(args.dtype))
     ak.verbose = False
     ak.connect(args.hostname, args.port)
 

--- a/benchmarks/scatter.py
+++ b/benchmarks/scatter.py
@@ -85,22 +85,30 @@ def create_parser():
     parser = argparse.ArgumentParser(description="Measure performance of random scatter: C[I] = V")
     parser.add_argument('hostname', help='Hostname of arkouda server')
     parser.add_argument('port', type=int, help='Port of arkouda server')
-    parser.add_argument('-i', '--index-size', type=int, default=10**8, help='Length of index array (number of scatters to perform)')
-    parser.add_argument('-v', '--value-size', type=int, default=10**8, help='Length of array from which values are scattered')
+    parser.add_argument('-n', '--size', type=int, default=10**8, help='Problem size: length of index and scatter arrays')
+    parser.add_argument('-i', '--index-size', type=int, help='Length of index array (number of scatters to perform)')
+    parser.add_argument('-v', '--value-size', type=int, help='Length of array from which values are scattered')
     parser.add_argument('-t', '--trials', type=int, default=6, help='Number of times to run the benchmark')
     parser.add_argument('-d', '--dtype', default='int64', help='Dtype of value array (int64 or float64)')
     parser.add_argument('-r', '--randomize', default=False, action='store_true', help='Use random values instead of ones')
     parser.add_argument('--numpy', default=False, action='store_true', help='Run the same operation in NumPy to compare performance.')
+    parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')
     return parser
     
 if __name__ == "__main__":
     import sys
     parser = create_parser()
     args = parser.parse_args()
+    args.index_size = args.size if args.index_size is None else args.index_size
+    args.value_size = args.size if args.value_size is None else args.value_size
     if args.dtype not in ('int64', 'float64'):
         raise ValueError("Dtype must be either int64 or float64, not {}".format(args.dtype))
     ak.verbose = False
     ak.connect(args.hostname, args.port)
+
+    if args.correctness_only:
+        check_correctness(args.dtype, args.randomize)
+        sys.exit(0)
     
     print("size of index array = {:,}".format(args.index_size))
     print("size of values array = {:,}".format(args.value_size))

--- a/benchmarks/stream.py
+++ b/benchmarks/stream.py
@@ -84,6 +84,7 @@ def create_parser():
     parser.add_argument('-r', '--randomize', default=False, action='store_true', help='Fill arrays with random values instead of ones')
     parser.add_argument('-a', '--alpha', default=1.0, help='Scalar multiple')
     parser.add_argument('--numpy', default=False, action='store_true', help='Run the same operation in NumPy to compare performance.')
+    parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')
     return parser
 
 if __name__ == "__main__":
@@ -99,6 +100,10 @@ if __name__ == "__main__":
 
     ak.verbose = False
     ak.connect(args.hostname, args.port)
+
+    if args.correctness_only:
+        check_correctness(args.alpha, args.dtype, args.randomize)
+        sys.exit(0)
     
     print("array size = {:,}".format(args.size))
     print("number of trials = ", args.trials)


### PR DESCRIPTION
Add a `--correctness-only` mode for the benchmarks and run that for CI
testing with all supported types.  This adds `check_correctness()` for
argsort, reduce, and scan and a `--correctness-only` mode for all
benchmarks that just calls `check_correctness()` and exits.

This also updates gather/scatter benchmarks to allow bools and to
support a `--size` argument.