### PR TITLE
fixed unrecognized server command to return error/exception to python…

### DIFF
--- a/arkouda/client.py
+++ b/arkouda/client.py
@@ -3,8 +3,7 @@ import warnings, pkg_resources
 
 __all__ = ["verbose", "pdarrayIterThresh", "maxTransferBytes",
            "AllSymbols", "set_defaults", "connect", "disconnect",
-           "shutdown", "get_config", "get_mem_used", "__version__",
-           "generic_msg"]
+           "shutdown", "get_config", "get_mem_used", "__version__"]
 
 # Try to read the version from the file located at ../VERSION
 VERSIONFILE = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "VERSION")

--- a/arkouda/client.py
+++ b/arkouda/client.py
@@ -3,7 +3,8 @@ import warnings, pkg_resources
 
 __all__ = ["verbose", "pdarrayIterThresh", "maxTransferBytes",
            "AllSymbols", "set_defaults", "connect", "disconnect",
-           "shutdown", "get_config", "get_mem_used", "__version__"]
+           "shutdown", "get_config", "get_mem_used", "__version__",
+           "generic_msg"]
 
 # Try to read the version from the file located at ../VERSION
 VERSIONFILE = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "VERSION")

--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -196,7 +196,7 @@ proc main() {
                             repMsg = "disconnected from arkouda server tcp://*:%t".format(ServerPort);
                         }
                         otherwise {
-                            if v {writeln("Error: unrecognized command: %s".format(reqMsg)); try! stdout.flush();}
+                            repMsg = "Error: unrecognized command: %s".format(reqMsg);
                         }
                     }
                     sendRepMsg(repMsg);


### PR DESCRIPTION
Fixes #315 

* fixed main dispatch loop in server
* exposed `ak.generic_msg()` through the arkouda python package so I could test it without explicitly adding a test to the package. changed back to original code instead using `from arkouda import generic_msg` to test a bad message
