### PR TITLE
Optimize coargsort for numeric arrays

### DIFF
--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -445,6 +445,7 @@ module ArgSortMsg
       /* var arrays: [0..#n] borrowed GenSymEntry; */
       var size: int;
       // Check that all arrays exist in the symbol table and have the same size
+      var hasStr = false;
       for (name, objtype, i) in zip(names, types, 1..) {
         // arrays[i] = st.lookup(name): borrowed GenSymEntry;
         var thisSize: int;
@@ -457,6 +458,7 @@ module ArgSortMsg
             var (myNames, _) = name.splitMsgToTuple('+', 2);
             var g = st.lookup(myNames);
             thisSize = g.size;
+            hasStr = true;
           }
           otherwise {return unrecognizedTypeError(pn, objtype);}
         }
@@ -467,6 +469,77 @@ module ArgSortMsg
           if (thisSize != size) { return incompatibleArgumentsError(pn, "Arrays must all be same size"); }
         }
         
+      }
+
+      // If there were no string arrays, merge the arrays into a single array and sort
+      // that. This eliminates having to merge index vectors, but has a memory overhead
+      // and increases the size of the comm we have to do since the KEY is larger). We
+      // merge the elements into a `uint(RSLSD_bitsPerDigit)` tuple. This wastes space
+      // (e.g. when merging 2 arrays that use 7 and 9 bits), but it allows us to use
+      // `getDigit`, which changes the bit patterns to correctly sort negatives. We
+      // consider tuple[1] to be the most significant digit.
+      //
+      // TODO support string? This further increases size (128-bits for each hash), so we
+      // need to be OK with memory overhead and comm from the KEY)
+      if !hasStr {
+        param bitsPerDigit = RSLSD_bitsPerDigit;
+        var bitWidths: [names.domain] int;
+        var negs: [names.domain] bool;
+        var totalDigits: int;
+
+        for (bitWidth, name, neg) in zip(bitWidths, names, negs) {
+          // TODO checkSorted and exclude array if already sorted?
+          var g: borrowed GenSymEntry = st.lookup(name);
+          select g.dtype {
+            when DType.Int64   { (bitWidth, neg) = getBitWidth(toSymEntry(g, int ).a); }
+            when DType.Float64 { (bitWidth, neg) = getBitWidth(toSymEntry(g, real).a); }
+            otherwise          { throw new owned ErrorWithMsg(dtype2str(g.dtype)); }
+          }
+          totalDigits += (bitWidth + (bitsPerDigit-1)) / bitsPerDigit;
+        }
+
+        // TODO support arbitrary size with array-of-arrays or segmented array
+        proc mergedArgsort(param numDigits) throws {
+
+          overMemLimit(((4 + 3) * size * (numDigits * bitsPerDigit / 8))
+                       + (2 * here.maxTaskPar * numLocales * 2**16 * 8));
+
+          var ivname = st.nextName();
+          var merged = makeDistArray(size, numDigits*uint(bitsPerDigit));
+          var curDigit = 1 + numDigits - totalDigits;
+          for (name, nBits, neg) in zip(names, bitWidths, negs) {
+              var g: borrowed GenSymEntry = st.lookup(name);
+              proc mergeArray(type t) {
+                var e = toSymEntry(g, t);
+                ref A = e.a;
+
+                const r = 0..#nBits by bitsPerDigit;
+                for rshift in r {
+                  const myDigit = (r.high - rshift) / bitsPerDigit;
+                  const last = myDigit == 0;
+                  forall (m, a) in zip(merged, A) {
+                    m[curDigit+myDigit] =  getDigit(a, rshift, last, neg):uint(bitsPerDigit);
+                  }
+                }
+                curDigit += r.size;
+              }
+              select g.dtype {
+                when DType.Int64   { mergeArray(int); }
+                when DType.Float64 { mergeArray(real); }
+                otherwise          { throw new owned ErrorWithMsg(dtype2str(g.dtype)); }
+              }
+          }
+
+          var iv = argsortDefault(merged);
+          st.addEntry(ivname, new shared SymEntry(iv));
+          return try! "created " + st.attrib(ivname);
+        }
+
+        // Since we're using tuples, we have to stamp out for each size we want to
+        // support. For now support 8, 16, and 32 byte sorting.
+        if totalDigits <=  4 { return mergedArgsort( 4); }
+        if totalDigits <=  8 { return mergedArgsort( 8); }
+        if totalDigits <= 16 { return mergedArgsort(16); }
       }
 
       // check and throw if over memory limit

--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -506,7 +506,7 @@ module ArgSortMsg
 
           var ivname = st.nextName();
           var merged = makeDistArray(size, numDigits*uint(bitsPerDigit));
-          var curDigit = 1 + numDigits - totalDigits;
+          var curDigit = RSLSD_tupleLow + numDigits - totalDigits;
           for (name, nBits, neg) in zip(names, bitWidths, negs) {
               var g: borrowed GenSymEntry = st.lookup(name);
               proc mergeArray(type t) {

--- a/src/RadixSortLSD.chpl
+++ b/src/RadixSortLSD.chpl
@@ -13,6 +13,9 @@ module RadixSortLSD
     private param numBuckets = 1 << bitsPerDigit; // these need to be const for comms/performance reasons
     private param maskDigit = numBuckets-1; // these need to be const for comms/performance reasons
 
+    // Hack to determine tuple lower bound across 1.20-1.22
+    const RSLSD_tupleLow = [1..1].domain.low;
+
     use BlockDist;
     use BitOps;
     use AryUtil;
@@ -52,9 +55,9 @@ module RadixSortLSD
 
     inline proc getBitWidth(a: [?aD] ?t): (int, bool)
         where isHomogeneousTuple(t) && t == t.size*uint(bitsPerDigit) {
-      for digit in 1..t.size {
-        const m = max reduce [ai in a] ai[digit];
-        if m > 0 then return ((t.size-digit+1) * bitsPerDigit, false);
+      for digit in 0..t.size-1 {
+        const m = max reduce [ai in a] ai[RSLSD_tupleLow+digit];
+        if m > 0 then return ((t.size-digit) * bitsPerDigit, false);
       }
       return (t.size * bitsPerDigit, false);
     }
@@ -99,11 +102,11 @@ module RadixSortLSD
       }
     }
 
-    inline proc getDigit(key: _tuple, rshift: int, last: bool, negs: bool): int 
+    inline proc getDigit(key: _tuple, rshift: int, last: bool, negs: bool): int
         where isHomogeneousTuple(key) && key.type == key.size*uint(bitsPerDigit) {
-      return key[key.size - rshift/bitsPerDigit];
+      const keyHigh = key.size - (1-RSLSD_tupleLow);
+      return key[keyHigh - rshift/bitsPerDigit]:int;
     }
-
 
     // calculate sub-domain for task
     inline proc calcBlock(task: int, low: int, high: int) {


### PR DESCRIPTION
Optimize coargsort for int/real arrays when the combined elements require 32-bytes or less (e.g. 8 int arrays with values < 2**32). This results in a ~2x improvement for sorting 2 int arrays.

The previous coargsort would call argsort on each array, and then gather and merge the resulting index vectors. Here we merge all the arrays into a single array and call argsort once. This eliminates gathering the index vector, but does increase the peak memory footprint and the total number of bytes being communicated. Because of that, we only merge when the arrays will need less than 32-bytes of data. With more than that, the memory overhead is quite high and the performance is about on par.  The performance advantage of the merged sort starts to suffer because we exchange our KEY as part of sorting, and our KEY is now larger, which increases the total size of comm. We can probably optimize that, but we don't currently. Note that because sorting strings uses 16-bytes for the hash, this does not currently trigger for strings.

Performance results (256 node XC, Chapel 1.20):
---

```
./arkouda_server --logging=false --v=false -nl 256
./benchmarks/argsort.py --size=$((2**28))
./benchmarks/coargsort.py --size=$((2**28))
```

Results for argsort vs coargsort on a single array with 4 bytes values:

| config | argsort    | coargsort  |
| ------ | ---------: | ---------: |
| before | 48.6 GiB/s | 30.7 GiB/s |
| after  | 48.6 GiB/s | 46.2 GiB/s |

Here we can see that coargsort on a single array now has minimal overhead compared to argsort.

Results for coargsort on 2, 4, 8, and 16 arrays with 4 byte values:

| config | 2 arrays   | 4 arrays   | 8 arrays   | 16 arrays  |
| ------ | ---------: | ---------: | ---------: | ---------: |
| before | 24.3 GiB/s | 18.6 GiB/s | 12.6 GiB/s |  9.9 GiB/s |
| after  | 42.4 GiB/s | 28.0 GiB/s | 13.7 GiB/s |  9.9 GiB/s |

Here performance for sorting 2/4 arrays is significantly improved. 8 arrays has a minimal perf advantage because of the increased transfers sizes. 16 arrays of 4-byte values is over the current size limit for the optimization so that falls back to the old strategy so there is no perf change.

Implementation notes:
---

The basic algorithm is that we go through all the arrays to coargsort and compute how many bits/digits are needed using `getBitWidth()` (where each digit is 16-bits.) We then iterate through each array and use `getDigit()` to pluck out each digit and put it into the merged array.  This wastes some space (e.g. if you're merging 7 and 9 bit arrays we end up using 32 bits instead of 16) but this makes merging simpler and getDigit will modify the bits so we correctly sort negatives. The merged array is a tuple of digits (tuple of `uint(16)`). Since we have to know the size of tuples at compile time we stamp out versions of merging/sorting for 4, 8 and 16 byte merged arrays. Longer term we might want to use a dynamic array-of-arrays of segmented arrays, but to start the tuple is simplest to implement. Note that tuple[1] is the most significant digit (tuple[0] in 1.22 -- the lowest index is the most significant digit)

Part of https://github.com/mhmerrill/arkouda/issues/296