### PR TITLE
Make arkouda neutral to 0- vs. 1-based tuple indexing

### DIFF
--- a/src/RadixSortLSD.chpl
+++ b/src/RadixSortLSD.chpl
@@ -37,10 +37,10 @@ module RadixSortLSD
 
     inline proc getBitWidth(a: [?aD] (uint, uint)): (int, bool) {
       const negs = false;
-      var highMax = max reduce [ai in a] ai[1];
+      var highMax = max reduce [ai in a] ai[0];
       var whigh = numBits(uint) - clz(highMax);
       if (whigh == 0) {
-        var lowMax = max reduce [ai in a] ai[2];
+        var lowMax = max reduce [ai in a] ai[1];
         var wlow = numBits(uint) - clz(lowMax);
         const bitWidth = wlow: int;
         return (bitWidth, negs);
@@ -79,9 +79,9 @@ module RadixSortLSD
 
     inline proc getDigit(key: 2*uint, rshift: int, last: bool, negs: bool): int {
       if (rshift >= numBits(uint)) {
-        return getDigit(key[1], rshift - numBits(uint), last, negs);
+        return getDigit(key[0], rshift - numBits(uint), last, negs);
       } else {
-        return getDigit(key[2], rshift, last, negs);
+        return getDigit(key[1], rshift, last, negs);
       }
     }
 
@@ -126,8 +126,8 @@ module RadixSortLSD
         if vv {writeln("type = ", t:string, ", nBits = ", nBits);}
         
         // form (key,rank) vector
-        param KEY = 1; // index of key in pair
-        param RANK = 2; // index of rank in pair
+        param KEY = 0; // index of key in pair
+        param RANK = 1; // index of rank in pair
         var kr0: [aD] (t,int) = [(key,rank) in zip(a,aD)] (key,rank);
         var kr1: [aD] (t,int);
         

--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -667,7 +667,7 @@ module ReductionMsg
           vi = values.domain.high;
         }
         if (vi >= low) {
-          r = cummin[vi][1];
+          (_,r) = cummin[vi];
         }
       }
       return res;
@@ -704,7 +704,7 @@ module ReductionMsg
           vi = values.domain.high;
         }
         if (vi >= low) {
-          r = cummax[vi][1];
+          (_,r) = cummax[vi];
         }
       }
       return res;
@@ -742,8 +742,8 @@ module ReductionMsg
           vi = values.domain.high;
         }
         if (vi >= low) {
-          v = cummin[vi][0][1];
-          l = cummin[vi][1];
+          ((_,v),_) = cummin[vi];
+          (_    ,l) = cummin[vi];
         }
       }
       return (vals, locs);
@@ -784,8 +784,8 @@ module ReductionMsg
           vi = values.domain.high;
         }
         if (vi >= low) {
-          v = cummax[vi][0][1];
-          l = cummax[vi][1];
+          ((_,v),_) = cummax[vi];
+          (_,    l) = cummax[vi];
         }
       }
       return (vals, locs);
@@ -972,15 +972,18 @@ module ReductionMsg
        agg.copy(IVi, firstIV[idx]);
       }
       var sortedKV: [kD] (int, int);
-      forall (kvi, idx) in zip(sortedKV, IV) with (var agg = newSrcAggregator(int)) {
-        agg.copy(kvi[0], keys[idx]);
-        agg.copy(kvi[1], values[idx]);
+      forall ((kvi0,kvi1), idx) in zip(sortedKV, IV) with (var agg = newSrcAggregator(int)) {
+        agg.copy(kvi0, keys[idx]);
+        agg.copy(kvi1, values[idx]);
       }
       if v {writeln("sort time = ", Time.getCurrentTime() - t1); try! stdout.flush();}
       if v {writeln("Finding unique (key, value) pairs..."); try! stdout.flush();}
       var truth: [kD] bool;
       // true where new (k, v) pair appears
-      [(t, kv, i) in zip(truth, sortedKV, kD)] if i > kD.low { t = (sortedKV[i-1][1] != kv[1]); }
+      [(t, (_,val), i) in zip(truth, sortedKV, kD)] if i > kD.low {
+        const (_,sortedVal) = sortedKV[i-1];
+        t = (sortedKV[i-1][1] != val);
+      }
       // first value of every segment is automatically new
       [s in segments] truth[s] = true;
       // count cumulative new values and take diffs at segment boundaries

--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -667,7 +667,7 @@ module ReductionMsg
           vi = values.domain.high;
         }
         if (vi >= low) {
-          r = cummin[vi][2];
+          r = cummin[vi][1];
         }
       }
       return res;
@@ -704,7 +704,7 @@ module ReductionMsg
           vi = values.domain.high;
         }
         if (vi >= low) {
-          r = cummax[vi][2];
+          r = cummax[vi][1];
         }
       }
       return res;
@@ -742,8 +742,8 @@ module ReductionMsg
           vi = values.domain.high;
         }
         if (vi >= low) {
-          v = cummin[vi][1][2];
-          l = cummin[vi][2];
+          v = cummin[vi][0][1];
+          l = cummin[vi][1];
         }
       }
       return (vals, locs);
@@ -784,8 +784,8 @@ module ReductionMsg
           vi = values.domain.high;
         }
         if (vi >= low) {
-          v = cummax[vi][1][2];
-          l = cummax[vi][2];
+          v = cummax[vi][0][1];
+          l = cummax[vi][1];
         }
       }
       return (vals, locs);
@@ -973,14 +973,14 @@ module ReductionMsg
       }
       var sortedKV: [kD] (int, int);
       forall (kvi, idx) in zip(sortedKV, IV) with (var agg = newSrcAggregator(int)) {
-        agg.copy(kvi[1], keys[idx]); 
-        agg.copy(kvi[2], values[idx]);
+        agg.copy(kvi[0], keys[idx]);
+        agg.copy(kvi[1], values[idx]);
       }
       if v {writeln("sort time = ", Time.getCurrentTime() - t1); try! stdout.flush();}
       if v {writeln("Finding unique (key, value) pairs..."); try! stdout.flush();}
       var truth: [kD] bool;
       // true where new (k, v) pair appears
-      [(t, kv, i) in zip(truth, sortedKV, kD)] if i > kD.low { t = (sortedKV[i-1][2] != kv[2]); }
+      [(t, kv, i) in zip(truth, sortedKV, kD)] if i > kD.low { t = (sortedKV[i-1][1] != kv[1]); }
       // first value of every segment is automatically new
       [s in segments] truth[s] = true;
       // count cumulative new values and take diffs at segment boundaries

--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -982,7 +982,7 @@ module ReductionMsg
       // true where new (k, v) pair appears
       [(t, (_,val), i) in zip(truth, sortedKV, kD)] if i > kD.low {
         const (_,sortedVal) = sortedKV[i-1];
-        t = (sortedKV[i-1][1] != val);
+        t = (sortedVal != val);
       }
       // first value of every segment is automatically new
       [s in segments] truth[s] = true;

--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -995,7 +995,7 @@ module ReductionMsg
       var keyhits: [hD] int;
       forall i in truth.domain with (var agg = newDstAggregator(int)) {
         if (truth[i]) {
-          var key = sortedKV[i][1];
+          var (key,_) = sortedKV[i];
           agg.copy(keyhits[count[i]-1], key);
         }
       }

--- a/src/SegStringSort.chpl
+++ b/src/SegStringSort.chpl
@@ -16,10 +16,10 @@ module SegStringSort {
   private const MEMFACTOR = SSS_MEMFACTOR;
 
   record StringIntComparator {
-    proc keyPart(a: (string, int), i: int) {
-      var len = a[0].numBytes;
+    proc keyPart((a0,_): (string, int), i: int) {
+      var len = a0.numBytes;
       var section = if i <= len then 0:int(8) else -1:int(8);
-      var part = if i <= len then a[0].byte(i) else 0:uint(8);
+      var part = if i <= len then a0.byte(i) else 0:uint(8);
       return (section, part);
     }
   }
@@ -58,7 +58,8 @@ module SegStringSort {
       sort(stringsWithInds, comparator=myComparator);
       if v { writeln("Sorted long strings in %t seconds".format(getCurrentTime() - tl)); stdout.flush(); tl = getCurrentTime(); }
       forall (h, s) in zip(highDom, stringsWithInds.domain) with (var agg = newDstAggregator(int)) {
-        agg.copy(gatherInds[h], stringsWithInds[s][1]);
+        const (_,val) = stringsWithInds[s];
+        agg.copy(gatherInds[h], val);
       }
       if v { writeln("Permuted long inds in %t seconds".format(getCurrentTime() - tl)); stdout.flush(); }
     }
@@ -125,8 +126,7 @@ module SegStringSort {
       const l = lengths[i];
       var buf: [0..#(l+1)] uint(8);
       buf[{0..#l}] = va[{oa[i]..#l}];
-      si[0] = try! createStringWithBorrowedBuffer(c_ptrTo(buf), l, l+1);
-      si[1] = i;
+      si = (try! createStringWithBorrowedBuffer(c_ptrTo(buf), l, l+1), i);
     }
     return stringsWithInds;
   }
@@ -161,36 +161,37 @@ module SegStringSort {
     inline proc copyDigit(ref k: state, const off: int, const len: int, const rank: int, const right: int) {
       // TODO can we only use the aggregated version?
       use UnorderedCopy;
+      ref (k0,k1,k2,k3,k4) = k;
       if (right > 0) {
         if (len >= right) {
-          unorderedCopy(k[0], values[off+right-2]);
-          unorderedCopy(k[1], values[off+right-1]);
+          unorderedCopy(k0, values[off+right-2]);
+          unorderedCopy(k1, values[off+right-1]);
         } else if (len == right - 1) {
-          unorderedCopy(k[0], values[off+right-2]);
-          unorderedCopy(k[1], 0: uint(8));
+          unorderedCopy(k0, values[off+right-2]);
+          unorderedCopy(k1, 0: uint(8));
         } else {
-          unorderedCopy(k[0], 0: uint(8));
-          unorderedCopy(k[1], 0: uint(8));
+          unorderedCopy(k0, 0: uint(8));
+          unorderedCopy(k1, 0: uint(8));
         }
       }
-      unorderedCopy(k[2], off);
-      unorderedCopy(k[3], len);
-      unorderedCopy(k[4], rank);
+      unorderedCopy(k2, off);
+      unorderedCopy(k3, len);
+      unorderedCopy(k4, rank);
     }
 
     inline proc copyDigit(ref k1: state, ref k0: state, const right: int, ref aggregator) {
-      const off = k0[2];
-      const len = k0[3];
+      const (_,_,off,len,_) = k0;
+      ref (ka,kb,_,_,_) = k0;
       if (right > 0) {
         if (len >= right) {
-          k0[0] = values[off+right-2];
-          k0[1] = values[off+right-1];
+          ka = values[off+right-2];
+          kb = values[off+right-1];
         } else if (len == right - 1) {
-          k0[0] = values[off+right-2];
-          k0[1] = 0;
+          ka = values[off+right-2];
+          kb = 0;
         } else {
-          k0[0] = 0: uint(8);
-          k0[1] = 0: uint(8);
+          ka = 0: uint(8);
+          kb = 0: uint(8);
         }
       }
       aggregator.copy(k1, k0);
@@ -224,7 +225,9 @@ module SegStringSort {
             var tD = calcBlock(task, lD.low, lD.high);
             // count digits in this task's part of the array
             for i in tD {
-              var bucket = (kr0[i][0]:int << 8) | (kr0[i][1]:int); // calc bucket from key
+              var kr0i0, kr0i1: int;
+              (kr0i0, kr0i1 , _, _, _) = kr0[i];
+              var bucket = (kr0i0 << 8) | (kr0i1); // calc bucket from key
               taskBucketCounts[bucket] += 1;
             }
             // write counts in to global counts in transposed order
@@ -265,7 +268,9 @@ module SegStringSort {
             {
               var aggregator = newDstAggregator(state);
               for i in tD {
-                var bucket = (kr0[i][0]:int << 8) | (kr0[i][1]:int); // calc bucket from key
+                var kr0i0, kr0i1: int;
+                (kr0i0, kr0i1, _, _, _) = kr0[i];
+                var bucket = (kr0i0:int << 8) | (kr0i1:int); // calc bucket from key
                 var pos = taskBucketPos[bucket];
                 taskBucketPos[bucket] += 1;
                 copyDigit(kr1[pos], kr0[i], pivot - rshift, aggregator);

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -328,7 +328,7 @@ module SegmentedArray {
           var sortedHashes = [i in iv] hashes[i];
           var diffs = sortedHashes[(iv.domain.low+1)..#(iv.size-1)] - sortedHashes[(iv.domain.low)..#(iv.size-1)];
           printAry("diffs = ", diffs);
-          var nonDecreasing = [d in diffs] ((d[1] > 0) || ((d[1] == 0) && (d[2] >= 0)));
+          var nonDecreasing = [d in diffs] ((d[0] > 0) || ((d[0] == 0) && (d[1] >= 0)));
           writeln("Are hashes sorted? ", && reduce nonDecreasing);
         }
         return iv;

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -328,7 +328,7 @@ module SegmentedArray {
           var sortedHashes = [i in iv] hashes[i];
           var diffs = sortedHashes[(iv.domain.low+1)..#(iv.size-1)] - sortedHashes[(iv.domain.low)..#(iv.size-1)];
           printAry("diffs = ", diffs);
-          var nonDecreasing = [d in diffs] ((d[0] > 0) || ((d[0] == 0) && (d[1] >= 0)));
+          var nonDecreasing = [(d0,d1) in diffs] ((d0 > 0) || ((d0 == 0) && (d1 >= 0)));
           writeln("Are hashes sorted? ", && reduce nonDecreasing);
         }
         return iv;

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -202,8 +202,7 @@ module SegmentedMsg {
       var name2 = st.nextName();
       var hash2 = st.addEntry(name2, hashes.size, int);
       forall (h, h1, h2) in zip(hashes, hash1.a, hash2.a) {
-        h1 = h[0]:int;
-        h2 = h[1]:int;
+        (h1,h2) = h:(int,int);
       }
       return "created " + st.attrib(name1) + "+created " + st.attrib(name2);
     }

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -202,8 +202,8 @@ module SegmentedMsg {
       var name2 = st.nextName();
       var hash2 = st.addEntry(name2, hashes.size, int);
       forall (h, h1, h2) in zip(hashes, hash1.a, hash2.a) {
-        h1 = h[1]:int;
-        h2 = h[2]:int;
+        h1 = h[0]:int;
+        h2 = h[1]:int;
       }
       return "created " + st.attrib(name1) + "+created " + st.attrib(name2);
     }

--- a/src/SipHash.chpl
+++ b/src/SipHash.chpl
@@ -65,7 +65,7 @@ module SipHash {
   
   proc sipHash64(msg: [] uint(8), D): uint(64) {
     var res = computeSipHashLocalized(msg, D, 8);
-    return res[1];
+    return res[0];
   }
 
   proc sipHash128(msg: [] uint(8), D): 2*uint(64) {
@@ -211,7 +211,7 @@ module SipHash {
 
     b = v0 ^ v1 ^ v2 ^ v3;
     var res: 2*uint(64);
-    res[1] = byte_reverse(b);
+    res[0] = byte_reverse(b);
 
     if (outlen == 8) {
         return res;
@@ -225,7 +225,7 @@ module SipHash {
     }
     
     b = v0 ^ v1 ^ v2 ^ v3;
-    res[2] = byte_reverse(b);
+    res[1] = byte_reverse(b);
 
     return res;
   }

--- a/src/SipHash.chpl
+++ b/src/SipHash.chpl
@@ -64,8 +64,8 @@ module SipHash {
   }
   
   proc sipHash64(msg: [] uint(8), D): uint(64) {
-    var res = computeSipHashLocalized(msg, D, 8);
-    return res[0];
+    var (res,_) = computeSipHashLocalized(msg, D, 8);
+    return res;
   }
 
   proc sipHash128(msg: [] uint(8), D): 2*uint(64) {
@@ -210,11 +210,10 @@ module SipHash {
     }
 
     b = v0 ^ v1 ^ v2 ^ v3;
-    var res: 2*uint(64);
-    res[0] = byte_reverse(b);
+    const res0 = byte_reverse(b);
 
     if (outlen == 8) {
-        return res;
+        return (res0, 0:uint(64));
     }
 
     v1 ^= 0xdd;
@@ -225,8 +224,7 @@ module SipHash {
     }
     
     b = v0 ^ v1 ^ v2 ^ v3;
-    res[1] = byte_reverse(b);
 
-    return res;
+    return  (res0, byte_reverse(b));
   }
 }


### PR DESCRIPTION
This PR changes Arkouda to avoid relying on 0- or 1-based indexing for tuples.  The motivation for this is that Chapel 1.22 will switch from 1-based tuple indexing to 0-based tuple indexing.  This PR uses Chapel's de-tupling syntax to avoid baking either 0- or 1-based assumptions about indexing into the code, making it compatible with Chapel 1.20, 1.21, or 1.22.

I didn't always have good intuition for what the meaning of the variables or tuples I was working with were, so this PR could almost certainly benefit from naming improvements.  I'd be happy to implement other name changes if someone wants to provide guidance.

[I should also note that I haven't done any performance testing of this branch; I'd like to think these changes will not impact performance significantly in either direction, but just wanted to make clear that I haven't checked]