### PR TITLE
Allow hdf5 and zeromq paths to be specified by environment variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,13 @@ endef
 #                               ^ no space after comma
 -include Makefile.paths # Add entries to this file.
 
+ifdef ARKOUDA_ZMQ_PATH
+$(eval $(call add-path,$(ARKOUDA_ZMQ_PATH)))
+endif
+ifdef ARKOUDA_HDF5_PATH
+$(eval $(call add-path,$(ARKOUDA_HDF5_PATH)))
+endif
+
 .PHONY: install-deps
 install-deps: install-zmq install-hdf5
 


### PR DESCRIPTION
This makes it easier to specify hdf5 and zeromq installation
directories. This is primarily motivated by not wanting to have to
rebuild hdf5/zeromq for nightly performance testing, but I also find
this useful for myself while developing. I run on a bunch of systems and
have a couple concurrent arkouda builds for different performance
experiments and setting the env var once is simpler than creating
Makefile.paths manually every time.