### PR TITLE
Add tunneling support

### DIFF
--- a/arkouda/client.py
+++ b/arkouda/client.py
@@ -69,6 +69,10 @@ def connect(server = "localhost", port = 5555):
 
     # "protocol://server:port"
     pspStr = "tcp://{}:{}".format(server,port)
+    tunnel_server = os.getenv('ARKOUDA_TUNNEL_SERVER')
+    if tunnel_server:
+        from zmq import ssh
+        (pspStr, _) = ssh.tunnel.open_tunnel(pspStr, tunnel_server)
     if verbose: print("psp = ",pspStr);
 
     # setup connection to arkouda server

--- a/setup.py
+++ b/setup.py
@@ -149,7 +149,7 @@ setup(
     extras_require={  # Optional
         'doc': ['Sphinx', 'sphinx-argparse'],
         'dev': ['h5py'],
-        'test': ['pandas'],
+        'test': ['pandas', 'pexpect'],
     },
     # replace orginal install command with version that also builds
     # chapel and the arkouda server.


### PR DESCRIPTION
Use PyZMQs ssh tunneling to support tunneling zeromq connections. Note
that PyZMQ tunneling requires pexpect, so I have added that as a test
dependency for now.

This makes it easy to run client programs on a machine not directly
connected to the server. For instance, I can run a server on a Cray XC
or CS and run clients on my laptop. This also enables running from a
Cray XC elogin (external login) node, which was the original motivation
for this. In nightly performance testing I want to build/launch from an
elogin node since they have more memory and a physical disk, but the
elogin can't talk directly to the compute nodes so we need to proxy
through the login node. elogin nodes are physically close to the login
node so this does not add much latency.

For more info on pyzmq ssh tunneling see:
 - https://pyzmq.readthedocs.io/en/latest/ssh.html
 - https://pyzmq.readthedocs.io/en/latest/api/zmq.ssh.tunnel.html