### PR TITLE
Make Arkouda's use of split() calls index-neutral

### DIFF
--- a/pydoc/contributing.rst
+++ b/pydoc/contributing.rst
@@ -136,9 +136,8 @@ Then, define your argument parsing and function logic in ``src/FooMsg.chpl`` in 
        */
        proc FooMsg(reqMsg: string, st: borrowed SymTab): string {
            var repMsg: string; // response message
-           var fields = reqMsg.split(); // split request into fields
-           var cmd = fields[1];
-           var name = fields[2];
+           // split request into fields
+           var (cmd, name) = reqMsg.splitMsgToTuple(2);
            // get next symbol name
            var rname = st.nextName();
         

--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -434,12 +434,12 @@ module ArgSortMsg
     proc coargsortMsg(reqMsg: string, st: borrowed SymTab) throws {
       param pn = Reflection.getRoutineName();
       var repMsg: string;
-      var (cmd, nstr, _) = reqMsg.splitMsgToTuple(3);
+      var (cmd, nstr, rest) = reqMsg.splitMsgToTuple(3);
       var n = nstr:int; // number of arrays to sort
-      var fields = reqMsg.split();
+      var fields = rest.split();
       // Check that fields contains the stated number of arrays
-      if (fields.size != (2*n + 2)) { return try! incompatibleArgumentsError(pn, "Expected %i arrays but got %i".format(n, fields.size/2 - 1)); }
-      const low = fields.domain.low + 2;
+      if (fields.size != 2*n) { return try! incompatibleArgumentsError(pn, "Expected %i arrays but got %i".format(n, fields.size/2 - 1)); }
+      const low = fields.domain.low;
       var names = fields[low..#n];
       var types = fields[low+n..#n];
       /* var arrays: [0..#n] borrowed GenSymEntry; */
@@ -495,14 +495,12 @@ module ArgSortMsg
     }
     
     proc argsortDefault(A:[?D] ?t):[D] int {
-      writeln("argsort input: ", A);
       var t1 = Time.getCurrentTime();
       //var AI = [(a, i) in zip(A, D)] (a, i);
       //Sort.TwoArrayRadixSort.twoArrayRadixSort(AI);
       //var iv = [(a, i) in AI] i;
       var iv = radixSortLSD_ranks(A);
       if v {writeln("argsort time = ", Time.getCurrentTime() - t1); try! stdout.flush();}
-      writeln("argsort output: ", iv);
       return iv;
     }
     

--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -434,12 +434,12 @@ module ArgSortMsg
     proc coargsortMsg(reqMsg: string, st: borrowed SymTab) throws {
       param pn = Reflection.getRoutineName();
       var repMsg: string;
-      var (cmd, nstr, rest) = reqMsg.splitMsgToTuple(3);
+      var (cmd, nstr, _) = reqMsg.splitMsgToTuple(3);
       var n = nstr:int; // number of arrays to sort
-      var fields = rest.split();
+      var fields = reqMsg.split();
       // Check that fields contains the stated number of arrays
       if (fields.size != (2*n + 2)) { return try! incompatibleArgumentsError(pn, "Expected %i arrays but got %i".format(n, fields.size/2 - 1)); }
-      const low = fields.domain.low;
+      const low = fields.domain.low + 2;
       var names = fields[low..#n];
       var types = fields[low+n..#n];
       /* var arrays: [0..#n] borrowed GenSymEntry; */
@@ -495,12 +495,14 @@ module ArgSortMsg
     }
     
     proc argsortDefault(A:[?D] ?t):[D] int {
+      writeln("argsort input: ", A);
       var t1 = Time.getCurrentTime();
       //var AI = [(a, i) in zip(A, D)] (a, i);
       //Sort.TwoArrayRadixSort.twoArrayRadixSort(AI);
       //var iv = [(a, i) in AI] i;
       var iv = radixSortLSD_ranks(A);
       if v {writeln("argsort time = ", Time.getCurrentTime() - t1); try! stdout.flush();}
+      writeln("argsort output: ", iv);
       return iv;
     }
     

--- a/src/ConcatenateMsg.chpl
+++ b/src/ConcatenateMsg.chpl
@@ -19,13 +19,13 @@ module ConcatenateMsg
     proc concatenateMsg(reqMsg: string, st: borrowed SymTab) throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string;
-        var (cmd, nstr, objtype, _) = reqMsg.splitMsgToTuple(4);
+        var (cmd, nstr, objtype, rest) = reqMsg.splitMsgToTuple(4);
         var n = try! nstr:int; // number of arrays to sort
-        var fields = reqMsg.split();
-        const low = fields.domain.low + 3;
+        var fields = rest.split();
+        const low = fields.domain.low;
         var names = fields[low..];
         // Check that fields contains the stated number of arrays
-        if (n != names.size) { return try! incompatibleArgumentsError(pn, "B: Expected %i arrays but got %i".format(n, names.size)); }
+        if (n != names.size) { return try! incompatibleArgumentsError(pn, "Expected %i arrays but got %i".format(n, names.size)); }
         /* var arrays: [0..#n] borrowed GenSymEntry; */
         var size: int = 0;
         var nbytes: int = 0;          

--- a/src/ConcatenateMsg.chpl
+++ b/src/ConcatenateMsg.chpl
@@ -19,13 +19,13 @@ module ConcatenateMsg
     proc concatenateMsg(reqMsg: string, st: borrowed SymTab) throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string;
+        var (cmd, nstr, objtype, _) = reqMsg.splitMsgToTuple(4);
+        var n = try! nstr:int; // number of arrays to sort
         var fields = reqMsg.split();
-        var cmd = fields[1];
-        var n = try! fields[2]:int; // number of arrays to sort
-        var objtype = fields[3];
-        var names = fields[4..];
+        const low = fields.domain.low + 3;
+        var names = fields[low..];
         // Check that fields contains the stated number of arrays
-        if (n != names.size) { return try! incompatibleArgumentsError(pn, "Expected %i arrays but got %i".format(n, names.size)); }
+        if (n != names.size) { return try! incompatibleArgumentsError(pn, "B: Expected %i arrays but got %i".format(n, names.size)); }
         /* var arrays: [0..#n] borrowed GenSymEntry; */
         var size: int = 0;
         var nbytes: int = 0;          
@@ -36,9 +36,8 @@ module ConcatenateMsg
             var name: string;
             select objtype {
                 when "str" {
-                    var nameFields = rawName.split('+');
-                    name = nameFields[1];
-                    var valName = nameFields[2];
+                    var valName: string;
+                    (name, valName) = rawName.splitMsgToTuple('+', 2);
                     var gval = st.lookup(valName);
                     nbytes += gval.size;
                 }
@@ -71,10 +70,10 @@ module ConcatenateMsg
                 var segStart = 0;
                 var valStart = 0;
                 for (rawName, i) in zip(names, 1..) {
-                    var nameFields = rawName.split('+');
-                    var thisSegs = toSymEntry(st.lookup(nameFields[1]), int);
+                    var (segName, valName) = rawName.splitMsgToTuple('+', 2);
+                    var thisSegs = toSymEntry(st.lookup(segName), int);
                     var newSegs = thisSegs.a + valStart;
-                    var thisVals = toSymEntry(st.lookup(nameFields[2]), uint(8));
+                    var thisVals = toSymEntry(st.lookup(valName), uint(8));
                     forall (i, s) in zip(newSegs.domain, newSegs) with (var agg = newDstAggregator(int)) {
                         agg.copy(esa[i+segStart], s);
                     }

--- a/src/EfuncMsg.chpl
+++ b/src/EfuncMsg.chpl
@@ -32,10 +32,8 @@ module EfuncMsg
     proc efuncMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var fields = reqMsg.split(); // split request into fields
-        var cmd = fields[1];
-        var efunc = fields[2];
-        var name = fields[3];
+        // split request into fields
+        var (cmd, efunc, name) = reqMsg.splitMsgToTuple(3);
         var rname = st.nextName();
         if v {try! writeln("%s %s %s : %s".format(cmd,efunc,name,rname));try! stdout.flush();}
 
@@ -151,12 +149,8 @@ module EfuncMsg
     proc efunc3vvMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var fields = reqMsg.split(); // split request into fields
-        var cmd = fields[1];
-        var efunc = fields[2];
-        var name1 = fields[3];
-        var name2 = fields[4];
-        var name3 = fields[5];
+        // split request into fields
+        var (cmd, efunc, name1, name2, name3) = reqMsg.splitMsgToTuple(5);
         var rname = st.nextName();
         if v {try! writeln("%s %s %s %s %s %s : %s".format(cmd,efunc,name1,name2,name3,rname));try! stdout.flush();}
 
@@ -223,13 +217,9 @@ module EfuncMsg
     proc efunc3vsMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var fields = reqMsg.split(); // split request into fields
-        var cmd = fields[1];
-        var efunc = fields[2];
-        var name1 = fields[3];
-        var name2 = fields[4];
-        var dtype = str2dtype(fields[5]);
-        var value = fields[6];
+        var (cmd, efunc, name1, name2, dtypestr, value)
+              = reqMsg.splitMsgToTuple(6); // split request into fields
+        var dtype = str2dtype(dtypestr);
         var rname = st.nextName();
         if v {try! writeln("%s %s %s %s %s %s %s : %s".format(cmd,efunc,name1,name2,dtype,value,rname));try! stdout.flush();}
 
@@ -295,13 +285,9 @@ module EfuncMsg
     proc efunc3svMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var fields = reqMsg.split(); // split request into fields
-        var cmd = fields[1];
-        var efunc = fields[2];
-        var name1 = fields[3];
-        var dtype = str2dtype(fields[4]);
-        var value = fields[5];
-        var name2 = fields[6];
+        var (cmd, efunc, name1, dtypestr, value, name2)
+              = reqMsg.splitMsgToTuple(6); // split request into fields
+        var dtype = str2dtype(dtypestr);
         var rname = st.nextName();
         if v {try! writeln("%s %s %s %s %s %s %s : %s".format(cmd,efunc,name1,dtype,value,name2,rname));try! stdout.flush();}
 
@@ -367,14 +353,10 @@ module EfuncMsg
     proc efunc3ssMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var fields = reqMsg.split(); // split request into fields
-        var cmd = fields[1];
-        var efunc = fields[2];
-        var name1 = fields[3];
-        var dtype1 = str2dtype(fields[4]);
-        var value1 = fields[5];
-        var dtype2 = str2dtype(fields[6]);
-        var value2 = fields[7];
+        var (cmd, efunc, name1, dtype1str, value1, dtype2str, value2)
+              = reqMsg.splitMsgToTuple(7); // split request into fields
+        var dtype1 = str2dtype(dtype1str);
+        var dtype2 = str2dtype(dtype2str);
         var rname = st.nextName();
         if v {try! writeln("%s %s %s %s %s %s %s %s : %s".format(cmd,efunc,name1,dtype1,value1,dtype2,value2,rname));try! stdout.flush();}
 

--- a/src/FindSegmentsMsg.chpl
+++ b/src/FindSegmentsMsg.chpl
@@ -31,13 +31,11 @@ module FindSegmentsMsg
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
         // split request into fields
-        var (cmd, pname, nkeysStr, _) = reqMsg.splitMsgToTuple(4);
-        writeln("nkeysStr = ", nkeysStr);
+        var (cmd, pname, nkeysStr, rest) = reqMsg.splitMsgToTuple(4);
         var nkeys = nkeysStr:int; // number of key arrays
-        var fields = reqMsg.split(); // split request into fields
-        if (fields.size != (2*nkeys + 3)) { return incompatibleArgumentsError(pn, "Expected %i arrays but got %i".format(nkeys, (fields.size - 3)/2));}
-        var low = fields.domain.low + 3;
-        writeln("low = ", low);
+        var fields = rest.split(); // split request into fields
+        if (fields.size != 2*nkeys) { return incompatibleArgumentsError(pn, "Expected %i arrays but got %i".format(nkeys, (fields.size - 3)/2));}
+        var low = fields.domain.low;
         var knames = fields[low..#nkeys]; // key arrays
         var ktypes = fields[low+nkeys..#nkeys]; // objtypes
         var size: int;

--- a/src/FindSegmentsMsg.chpl
+++ b/src/FindSegmentsMsg.chpl
@@ -31,11 +31,13 @@ module FindSegmentsMsg
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
         // split request into fields
-        var (cmd, pname, nkeysStr, rest) = reqMsg.splitMsgToTuple(4);
+        var (cmd, pname, nkeysStr, _) = reqMsg.splitMsgToTuple(4);
+        writeln("nkeysStr = ", nkeysStr);
         var nkeys = nkeysStr:int; // number of key arrays
-        var fields = rest.split();
-        if (fields.size != (2*nkeys)) { return incompatibleArgumentsError(pn, "Expected %i arrays but got %i".format(nkeys, (fields.size)/2));}
-        var low = fields.domain.low;
+        var fields = reqMsg.split(); // split request into fields
+        if (fields.size != (2*nkeys + 3)) { return incompatibleArgumentsError(pn, "Expected %i arrays but got %i".format(nkeys, (fields.size - 3)/2));}
+        var low = fields.domain.low + 3;
+        writeln("low = ", low);
         var knames = fields[low..#nkeys]; // key arrays
         var ktypes = fields[low+nkeys..#nkeys]; // objtypes
         var size: int;
@@ -102,7 +104,6 @@ module FindSegmentsMsg
         }
         when "str" {
           var (myNames1,myNames2) = name.splitMsgToTuple('+', 2);
-          var myNames = name.split('+');
           var str = new owned SegString(myNames1, myNames2, st);
           var (permOffsets, permVals) = str[pa];
           const ref D = permOffsets.domain;

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -16,10 +16,11 @@ module GenSymIO {
 
   proc arrayMsg(reqMsg: bytes, st: borrowed SymTab): string {
     var repMsg: string;
-    var (cmdstr, dtypestr, sizestr, data) = reqMsg.splitMsgToTuple(4);
-    var cmd = try! cmdstr.decode();
-    var dtype = str2dtype(try! dtypestr.decode());
-    var size = try! sizestr:int;
+    var (cmdBytes, dtypeBytes, sizeBytes, data) = reqMsg.splitMsgToTuple(4);
+    writeln("data length = ", data.size);
+    var cmd = try! cmdBytes.decode();
+    var dtype = str2dtype(try! dtypeBytes.decode());
+    var size = try! sizeBytes:int;
     var tmpf:file;
     try {
       tmpf = openmem();
@@ -55,7 +56,7 @@ module GenSymIO {
       } else {
         tmpr.close();
         tmpf.close();
-        return try! "Error: Unhandled data type %s".format(dtypestr);
+        return try! "Error: Unhandled data type %s".format(dtypeBytes);
       }
       tmpr.close();
       tmpf.close();

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -16,11 +16,10 @@ module GenSymIO {
 
   proc arrayMsg(reqMsg: bytes, st: borrowed SymTab): string {
     var repMsg: string;
-    var fields = reqMsg.split(3);
-    var cmd = try! fields[1].decode();
-    var dtype = str2dtype(try! fields[2].decode());
-    var size = try! fields[3]:int;
-    var data = fields[4];
+    var (cmdstr, dtypestr, sizestr, data) = reqMsg.splitMsgToTuple(4);
+    var cmd = try! cmdstr.decode();
+    var dtype = str2dtype(try! dtypestr.decode());
+    var size = try! sizestr:int;
     var tmpf:file;
     try {
       tmpf = openmem();
@@ -56,7 +55,7 @@ module GenSymIO {
       } else {
         tmpr.close();
         tmpf.close();
-        return try! "Error: Unhandled data type %s".format(fields[2]);
+        return try! "Error: Unhandled data type %s".format(dtypestr);
       }
       tmpr.close();
       tmpf.close();
@@ -68,8 +67,8 @@ module GenSymIO {
 
   proc tondarrayMsg(reqMsg: string, st: borrowed SymTab): bytes throws {
     var arrayBytes: bytes;
-    var fields = reqMsg.split();
-    var entry = st.lookup(fields[2]);
+    var (_, entryStr) = reqMsg.splitMsgToTuple(2);
+    var entry = st.lookup(entryStr);
     var tmpf: file;
     try {
       tmpf = openmem();
@@ -133,9 +132,7 @@ module GenSymIO {
     use Spawn;
     const tmpfile = "/tmp/arkouda.lshdf.output";
     var repMsg: string;
-    var fields = reqMsg.split(1);
-    var cmd = fields[1];
-    var jsonfile = fields[2];
+    var (cmd, jsonfile) = reqMsg.splitMsgToTuple(2);
     var filename: string;
     try {
       filename = decode_json(jsonfile, 1)[0];
@@ -182,11 +179,8 @@ module GenSymIO {
   proc readhdfMsg(reqMsg: string, st: borrowed SymTab): string throws {
     var repMsg: string;
     // reqMsg = "readhdf <dsetName> <nfiles> [<json_filenames>]"
-    var fields = reqMsg.split(3);
-    var cmd = fields[1];
-    var dsetName = fields[2];
-    var nfiles = try! fields[3]:int;
-    var jsonfiles = fields[4];
+    var (cmd, dsetName, nfilesStr, jsonfiles) = reqMsg.splitMsgToTuple(4);
+    var nfiles = try! nfilesStr:int;
     var filelist: [0..#nfiles] string;
     try {
       filelist = decode_json(jsonfiles, nfiles);
@@ -311,13 +305,10 @@ module GenSymIO {
     // reqMsg = "readAllHdf <ndsets> <nfiles> [<json_dsetname>] | [<json_filenames>]"
     var repMsg: string;
     // May need a more robust delimiter then " | "
-    var fields = reqMsg.split(3);
-    var arrays = fields[4].split(" | ",1);
-    var cmd = fields[1];
-    var ndsets = try! fields[2]:int;
-    var nfiles = try! fields[3]:int;
-    var jsondsets = arrays[1];
-    var jsonfiles = arrays[2];
+    var (cmd, ndsetsStr, nfilesStr, arraysStr) = reqMsg.splitMsgToTuple(4);
+    var (jsondsets, jsonfiles) = arraysStr.splitMsgToTuple(" | ",2);
+    var ndsets = try! ndsetsStr:int;
+    var nfiles = try! nfilesStr:int;
     var dsetlist: [0..#ndsets] string;
     var filelist: [0..#nfiles] string;
     try {
@@ -652,12 +643,9 @@ module GenSymIO {
 
   proc tohdfMsg(reqMsg, st: borrowed SymTab): string throws {
     // reqMsg = "tohdf <arrayName> <dsetName> <mode> [<json_filename>]"
-    var fields = reqMsg.split(4);
-    var cmd = fields[1];
-    var arrayName = fields[2];
-    var dsetName = fields[3];
-    var mode = try! fields[4]: int;
-    var jsonfile = fields[5];
+    var (cmd, arrayName, dsetName, modeStr, jsonfile)
+          = reqMsg.splitMsgToTuple(5);
+    var mode = try! modeStr: int;
     var filename: string;
     try {
       filename = decode_json(jsonfile, 1)[0];
@@ -714,8 +702,8 @@ module GenSymIO {
       prefix = filename;
       extension = "";
     } else {
-      prefix = ".".join(fields[1..fields.size-1]);
-      extension = "." + fields[fields.size];
+      prefix = ".".join(fields#(fields.size-1)); // take all but the last
+      extension = "." + fields[fields.domain.high];
     }
     var filenames: [0..#A.targetLocales().size] string;
     for i in 0..#A.targetLocales().size {

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -17,7 +17,6 @@ module GenSymIO {
   proc arrayMsg(reqMsg: bytes, st: borrowed SymTab): string {
     var repMsg: string;
     var (cmdBytes, dtypeBytes, sizeBytes, data) = reqMsg.splitMsgToTuple(4);
-    writeln("data length = ", data.size);
     var cmd = try! cmdBytes.decode();
     var dtype = str2dtype(try! dtypeBytes.decode());
     var size = try! sizeBytes:int;

--- a/src/HistogramMsg.chpl
+++ b/src/HistogramMsg.chpl
@@ -17,10 +17,9 @@ module HistogramMsg
     proc histogramMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var fields = reqMsg.split(); // split request into fields
-        var cmd = fields[1];
-        var name = fields[2];
-        var bins = try! fields[3]:int;
+        // split request into fields
+        var (cmd, name, binsStr) = reqMsg.splitMsgToTuple(3);
+        var bins = try! binsStr:int;
         
         // get next symbol name
         var rname = st.nextName();

--- a/src/In1dMsg.chpl
+++ b/src/In1dMsg.chpl
@@ -30,14 +30,12 @@ module In1dMsg
     proc in1dMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var fields = reqMsg.split(); // split request into fields
-        var cmd = fields[1];
-        var name = fields[2];
-        var sname = fields[3];
+        // split request into fields
+        var (cmd, name, sname, flag) = reqMsg.splitMsgToTuple(4);
         var invert: bool;
-        if fields[4] == "True" {invert = true;}
-        else if fields[4] == "False" {invert = false;}
-        else {return try! "Error: %s: %s".format(pn,fields[4]);}
+        if flag == "True" {invert = true;}
+        else if flag == "False" {invert = false;}
+        else {return try! "Error: %s: %s".format(pn,flag);}
 
         // get next symbol name
         var rname = st.nextName();

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -14,10 +14,9 @@ module IndexingMsg
     proc intIndexMsg(reqMsg: string, st: borrowed SymTab):string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var fields = reqMsg.split(); // split request into fields
-        var cmd = fields[1];
-        var name = fields[2];
-        var idx = try! fields[3]:int;
+        // split request into fields
+        var (cmd, name, idxStr) = reqMsg.splitMsgToTuple(3);
+        var idx = try! idxStr:int;
         if v {try! writeln("%s %s %i".format(cmd, name, idx));try! stdout.flush();}
 
          var gEnt: borrowed GenSymEntry = st.lookup(name);
@@ -46,12 +45,11 @@ module IndexingMsg
     proc sliceIndexMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var fields = reqMsg.split(); // split request into fields
-        var cmd = fields[1];
-        var name = fields[2];
-        var start = try! fields[3]:int;
-        var stop = try! fields[4]:int;
-        var stride = try! fields[5]:int;
+        var (cmd, name, startStr, stopStr, strideStr)
+              = reqMsg.splitMsgToTuple(5); // split request into fields
+        var start = try! startStr:int;
+        var stop = try! stopStr:int;
+        var stride = try! strideStr:int;
         var slice: range(stridable=true);
 
         // convert python slice to chapel slice
@@ -98,10 +96,8 @@ module IndexingMsg
     proc pdarrayIndexMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var fields = reqMsg.split(); // split request into fields
-        var cmd = fields[1];
-        var name = fields[2];
-        var iname = fields[3];
+        // split request into fields
+        var (cmd, name, iname) = reqMsg.splitMsgToTuple(3);
 
         // get next symbol name
         var rname = st.nextName();
@@ -188,12 +184,10 @@ module IndexingMsg
     proc setIntIndexToValueMsg(reqMsg: string, st: borrowed SymTab):string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var fields = reqMsg.split(); // split request into fields
-        var cmd = fields[1];
-        var name = fields[2];
-        var idx = try! fields[3]:int;
-        var dtype = str2dtype(fields[4]);
-        var value = fields[5];
+        // split request into fields
+        var (cmd, name, idxStr, dtypeStr, value) = reqMsg.splitMsgToTuple(5);
+        var idx = try! idxStr:int;
+        var dtype = str2dtype(dtypeStr);
         if v {try! writeln("%s %s %i %s %s".format(cmd, name, idx, dtype2str(dtype), value));try! stdout.flush();}
 
          var gEnt: borrowed GenSymEntry = st.lookup(name);
@@ -262,12 +256,9 @@ module IndexingMsg
     proc setPdarrayIndexToValueMsg(reqMsg: string, st: borrowed SymTab):string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var fields = reqMsg.split(); // split request into fields
-        var cmd = fields[1];
-        var name = fields[2];
-        var iname = fields[3];
-        var dtype = str2dtype(fields[4]);
-        var value = fields[5];
+        // split request into fields
+        var (cmd, name, iname, dtypeStr, value) = reqMsg.splitMsgToTuple(5);
+        var dtype = str2dtype(dtypeStr);
 
         if v {try! writeln("%s %s %s %s %s".format(cmd, name, iname, dtype2str(dtype), value));try! stdout.flush();}
 
@@ -345,11 +336,8 @@ module IndexingMsg
     proc setPdarrayIndexToPdarrayMsg(reqMsg: string, st: borrowed SymTab):string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var fields = reqMsg.split(); // split request into fields
-        var cmd = fields[1];
-        var name = fields[2];
-        var iname = fields[3];
-        var yname = fields[4];
+        // split request into fields
+        var (cmd, name, iname, yname) = reqMsg.splitMsgToTuple(4);
 
         if v {try! writeln("%s %s %s %s".format(cmd, name, iname, yname));try! stdout.flush();}
 
@@ -431,14 +419,12 @@ module IndexingMsg
     proc setSliceIndexToValueMsg(reqMsg: string, st: borrowed SymTab):string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var fields = reqMsg.split(); // split request into fields
-        var cmd = fields[1];
-        var name = fields[2];
-        var start = try! fields[3]:int;
-        var stop = try! fields[4]:int;
-        var stride = try! fields[5]:int;
-        var dtype = str2dtype(fields[6]);
-        var value = fields[7];
+        var (cmd, name, startStr, stopStr, strideStr, dtypeStr, value)
+              = reqMsg.splitMsgToTuple(7); // split request into fields
+        var start = try! startStr:int;
+        var stop = try! stopStr:int;
+        var stride = try! strideStr:int;
+        var dtype = str2dtype(dtypeStr);
         var slice: range(stridable=true);
 
         // convert python slice to chapel slice
@@ -517,13 +503,11 @@ module IndexingMsg
     proc setSliceIndexToPdarrayMsg(reqMsg: string, st: borrowed SymTab):string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var fields = reqMsg.split(); // split request into fields
-        var cmd = fields[1];
-        var name = fields[2];
-        var start = try! fields[3]:int;
-        var stop = try! fields[4]:int;
-        var stride = try! fields[5]:int;
-        var yname = fields[6];
+        var (cmd, name, startStr, stopStr, strideStr, yname)
+              = reqMsg.splitMsgToTuple(6); // split request into fields
+        var start = try! startStr:int;
+        var stop = try! stopStr:int;
+        var stride = try! strideStr:int;
         var slice: range(stridable=true);
 
         // convert python slice to chapel slice

--- a/src/JoinEqWithDTMsg.chpl
+++ b/src/JoinEqWithDTMsg.chpl
@@ -208,17 +208,11 @@ module JoinEqWithDTMsg
     proc joinEqWithDTMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var fields = reqMsg.split(); // split request into fields
-        var cmd = fields[1];
-        var a1_name = fields[2];
-        var g2Seg_name = fields[3];
-        var g2Ukeys_name = fields[4];
-        var g2Perm_name = fields[5];
-        var t1_name = fields[6];
-        var t2_name = fields[7];
-        var dt = try! fields[8]:int;
-        var pred = fields[9]:int;
-        var resLimit = try! fields[10]:int;
+        var (cmd, a1_name, g2Seg_name, g2Ukeys_name, g2Perm_name, t1_name,
+             t2_name, dtStr, predStr, resLimitStr) = reqMsg.splitMsgToTuple(10);
+        var dt = try! dtStr:int;
+        var pred = predStr:int;
+        var resLimit = try! resLimitStr:int;
         
         // get next symbol names for results
         var resI_name = st.nextName();

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -27,11 +27,8 @@ module OperatorMsg
     proc binopvvMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var fields = reqMsg.split(); // split request into fields
-        var cmd = fields[1];
-        var op = fields[2];
-        var aname = fields[3];
-        var bname = fields[4];
+        // split request into fields
+        var (cmd, op, aname, bname) = reqMsg.splitMsgToTuple(4);
         var rname = st.nextName();
         if v {try! writeln("%s %s %s %s : %s".format(cmd,op,aname,bname,rname));try! stdout.flush();}
 
@@ -440,12 +437,9 @@ module OperatorMsg
     proc binopvsMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string = ""; // response message
-        var fields = reqMsg.split(); // split request into fields
-        var cmd = fields[1];
-        var op = fields[2];
-        var aname = fields[3];
-        var dtype = str2dtype(fields[4]);
-        var value = fields[5];
+        // split request into fields
+        var (cmd, op, aname, dtypeStr, value) = reqMsg.splitMsgToTuple(5);
+        var dtype = str2dtype(dtypeStr);
         var rname = st.nextName();
         if v {try! writeln("%s %s %s %s %s : %s".format(cmd,op,aname,dtype2str(dtype),value,rname));try! stdout.flush();}
 
@@ -830,12 +824,9 @@ module OperatorMsg
     proc binopsvMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string = ""; // response message
-        var fields = reqMsg.split(); // split request into fields
-        var cmd = fields[1];
-        var op = fields[2];
-        var dtype = str2dtype(fields[3]);
-        var value = fields[4];
-        var aname = fields[5];
+        // split request into fields
+        var (cmd, op, dtypeStr, value, aname) = reqMsg.splitMsgToTuple(5);
+        var dtype = str2dtype(dtypeStr);
         var rname = st.nextName();
         if v {try! writeln("%s %s %s %s %s : %s".format(cmd,op,dtype2str(dtype),value,aname,rname));try! stdout.flush();}
 
@@ -1220,11 +1211,8 @@ module OperatorMsg
     proc opeqvvMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var fields = reqMsg.split(); // split request into fields
-        var cmd = fields[1];
-        var op = fields[2];
-        var aname = fields[3];
-        var bname = fields[4];
+        // split request into fields
+        var (cmd, op, aname, bname) = reqMsg.splitMsgToTuple(4);
         if v {try! writeln("%s %s %s %s".format(cmd,op,aname,bname));try! stdout.flush();}
         
         var left: borrowed GenSymEntry = st.lookup(aname);
@@ -1356,12 +1344,9 @@ module OperatorMsg
     proc opeqvsMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var fields = reqMsg.split(); // split request into fields
-        var cmd = fields[1];
-        var op = fields[2];
-        var aname = fields[3];
-        var dtype = str2dtype(fields[4]);
-        var value = fields[5];
+        // split request into fields
+        var (cmd, op, aname, dtypeStr, value) = reqMsg.splitMsgToTuple(5);
+        var dtype = str2dtype(dtypeStr);
         if v {try! writeln("%s %s %s %s %s".format(cmd,op,aname,dtype2str(dtype),value));try! stdout.flush();}
 
         var left: borrowed GenSymEntry = st.lookup(aname);

--- a/src/RandMsg.chpl
+++ b/src/RandMsg.chpl
@@ -20,20 +20,20 @@ module RandMsg
     proc randintMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var fields = reqMsg.split(); // split request into fields
-        var cmd = fields[1];     
-        var len = fields[2]:int;
-        var dtype = str2dtype(fields[3]);
+        // split request into fields
+        var (cmd,lenStr,dtypeStr,aMinStr,aMaxStr) = reqMsg.splitMsgToTuple(5);
+        var len = lenStr:int;
+        var dtype = str2dtype(dtypeStr);
 
         // get next symbol name
         var rname = st.nextName();
         
         // if verbose print action
-        if v {try! writeln("%s %i %s %s %s: %s".format(cmd,len,dtype2str(dtype),rname,fields[4],fields[5])); try! stdout.flush();}
+        if v {try! writeln("%s %i %s %s %s: %s".format(cmd,len,dtype2str(dtype),rname,aMinStr,aMaxStr)); try! stdout.flush();}
         select (dtype) {
             when (DType.Int64) {
-                var aMin = fields[4]:int;
-                var aMax = fields[5]:int;
+                var aMin = aMinStr:int;
+                var aMax = aMaxStr:int;
                 var t1 = Time.getCurrentTime();
                 var e = st.addEntry(rname, len, int);
                 if v {writeln("alloc time = ",Time.getCurrentTime() - t1,"sec"); try! stdout.flush();}
@@ -43,8 +43,8 @@ module RandMsg
                 if v {writeln("compute time = ",Time.getCurrentTime() - t1,"sec"); try! stdout.flush();}
             }
             when (DType.UInt8) {
-                var aMin = fields[4]:int;
-                var aMax = fields[5]:int;
+                var aMin = aMinStr:int;
+                var aMax = aMaxStr:int;
                 var t1 = Time.getCurrentTime();
                 var e = st.addEntry(rname, len, uint(8));
                 if v {writeln("alloc time = ",Time.getCurrentTime() - t1,"sec"); try! stdout.flush();}
@@ -54,8 +54,8 @@ module RandMsg
                 if v {writeln("compute time = ",Time.getCurrentTime() - t1,"sec"); try! stdout.flush();}
             }
             when (DType.Float64) {
-                var aMin = fields[4]:real;
-                var aMax = fields[5]:real;
+                var aMin = aMinStr:real;
+                var aMax = aMaxStr:real;
                 var t1 = Time.getCurrentTime();
                 var e = st.addEntry(rname, len, real);
                 if v {writeln("alloc time = ",Time.getCurrentTime() - t1,"sec"); try! stdout.flush();}
@@ -81,9 +81,8 @@ module RandMsg
 
     proc randomNormalMsg(reqMsg: string, st: borrowed SymTab): string throws {
       var pn = Reflection.getRoutineName();
-      var fields = reqMsg.split();
-      var cmd = fields[1];
-      var len = fields[2]:int;
+      var (cmd, lenStr) = reqMsg.splitMsgToTuple(2);
+      var len = lenStr:int;
       // Result + 2 scratch arrays
       overMemLimit(3*8*len);
       var rname = st.nextName();

--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -25,10 +25,8 @@ module ReductionMsg
     proc reductionMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var fields = reqMsg.split(); // split request into fields
-        var cmd = fields[1];
-        var reductionop = fields[2];
-        var name = fields[3];
+        // split request into fields
+        var (cmd, reductionop, name) = reqMsg.splitMsgToTuple(3);
         if v {try! writeln("%s %s %s".format(cmd,reductionop,name));try! stdout.flush();}
 
         var gEnt: borrowed GenSymEntry = st.lookup(name);
@@ -196,10 +194,9 @@ module ReductionMsg
     proc countReductionMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
       // reqMsg: segmentedReduction values segments operator
-      var fields = reqMsg.split();
-      var cmd = fields[1];
-      var segments_name = fields[2]; // segment offsets
-      var size = try! fields[3]:int;
+      // 'segments_name' describes the segment offsets
+      var (cmd, segments_name, sizeStr) = reqMsg.splitMsgToTuple(3);
+      var size = try! sizeStr:int;
       var rname = st.nextName();
       if v {try! writeln("%s %s %s".format(cmd,segments_name, size));try! stdout.flush();}
 
@@ -230,10 +227,10 @@ module ReductionMsg
         param pn = Reflection.getRoutineName();
       // reqMsg: countLocalRdx segments
       // segments.size = numLocales * numKeys
-      var fields = reqMsg.split();
-      var cmd = fields[1];
-      var segments_name = fields[2]; // segment offsets
-      var size = try! fields[3]:int; // size of original keys array
+      // 'segments_name' describes the segment offsets
+      // 'size[Str]' is the size of the original keys array
+      var (cmd, segments_name, sizeStr) = reqMsg.splitMsgToTuple(3);
+      var size = try! sizeStr:int; // size of original keys array
       var rname = st.nextName();
       if v {try! writeln("%s %s %s".format(cmd,segments_name, size));try! stdout.flush();}
 
@@ -264,11 +261,10 @@ module ReductionMsg
     proc segmentedReductionMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
       // reqMsg: segmentedReduction values segments operator
-      var fields = reqMsg.split();
-      var cmd = fields[1];
-      var values_name = fields[2];   // segmented array of values to be reduced
-      var segments_name = fields[3]; // segment offsets
-      var operator = fields[4];      // reduction operator
+      // 'values_name' is the segmented array of values to be reduced
+      // 'segments_name' is the sement offsets
+      // 'operator' is the reduction operator
+      var (cmd, values_name, segments_name, operator) = reqMsg.splitMsgToTuple(4);
       var rname = st.nextName();
       if v {try! writeln("%s %s %s %s".format(cmd,values_name,segments_name,operator));try! stdout.flush();}
       var gVal: borrowed GenSymEntry = st.lookup(values_name);
@@ -378,12 +374,10 @@ module ReductionMsg
     proc segmentedLocalRdxMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
       // reqMsg: segmentedReduction keys values segments operator
-      var fields = reqMsg.split();
-      var cmd = fields[1];
-      var keys_name = fields[2];
-      var values_name = fields[3];   // segmented array of values to be reduced
-      var segments_name = fields[4]; // segment offsets
-      var operator = fields[5];      // reduction operator
+      // 'values_name' is the segmented array of values to be reduced
+      // 'segments_name' is the segmented offsets
+      // 'operator' is the reduction operator
+      var (cmd, keys_name, values_name, segments_name, operator) = reqMsg.splitMsgToTuple(5);
       var rname = st.nextName();
       if v {try! writeln("%s %s %s %s %s".format(cmd,keys_name,values_name,segments_name,operator));try! stdout.flush();}
 

--- a/src/RegistrationMsg.chpl
+++ b/src/RegistrationMsg.chpl
@@ -23,10 +23,8 @@ module RegistrationMsg
     */
     proc registerMsg(reqMsg: string, st: borrowed SymTab): string throws {
         var repMsg: string; // response message
-        var fields = reqMsg.split(); // split request into fields
-        var cmd = fields[1];
-        var name = fields[2];
-        var userDefinedName = fields[3];
+        // split request into fields
+        var (cmd, name, userDefinedName) = reqMsg.splitMsgToTuple(3);
 
         // if verbose print action
         if v {try! writeln("%s %s %s".format(cmd,name,userDefinedName)); try! stdout.flush();}
@@ -51,9 +49,8 @@ module RegistrationMsg
     */
     proc attachMsg(reqMsg: string, st: borrowed SymTab): string throws {
         var repMsg: string; // response message
-        var fields = reqMsg.split(); // split request into fields
-        var cmd = fields[1];
-        var name = fields[2];
+        // split request into fields
+        var (cmd, name) = reqMsg.splitMsgToTuple(2);
 
         // if verbose print action
         if v {try! writeln("%s %s".format(cmd,name)); try! stdout.flush();}
@@ -78,9 +75,8 @@ module RegistrationMsg
     */
     proc unregisterMsg(reqMsg: string, st: borrowed SymTab): string throws {
         var repMsg: string; // response message
-        var fields = reqMsg.split(); // split request into fields
-        var cmd = fields[1];
-        var name = fields[2];
+        // split request into fields
+        var (cmd, name) = reqMsg.splitMsgToTuple(2);
 
         // if verbose print action
         if v {try! writeln("%s %s".format(cmd,name)); try! stdout.flush();}

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -13,18 +13,17 @@ module SegmentedMsg {
 
   proc randomStringsMsg(reqMsg: string, st: borrowed SymTab): string throws {
     var pn = Reflection.getRoutineName();
-    var fields = reqMsg.split();
-    var cmd = fields[1];
-    var len = fields[2]: int;
-    var dist = fields[3];
-    var charset = str2CharSet(fields[4]);
+    var (cmd, lenStr, dist, charsetStr, arg1str, arg2str)
+          = reqMsg.splitMsgToTuple(6);
+    var len = lenStr: int;
+    var charset = str2CharSet(charsetStr);
     var segName = st.nextName();
     var valName = st.nextName();
     var repMsg: string;
     select dist.toLower() {
       when "uniform" {
-        var minLen = fields[5]:int;
-        var maxLen = fields[6]:int;
+        var minLen = arg1str:int;
+        var maxLen = arg2str:int;
         // Lengths + 2*segs + 2*vals (copied to SymTab)
         overMemLimit(8*len + 16*len + (maxLen + minLen)*len);
         var (segs, vals) = newRandStringsUniformLength(len, minLen, maxLen, charset);
@@ -35,8 +34,8 @@ module SegmentedMsg {
         repMsg = 'created ' + st.attrib(segName) + '+created ' + st.attrib(valName);
       }
       when "lognormal" {
-        var logMean = fields[5]:real;
-        var logStd = fields[6]:real;
+        var logMean = arg1str:real;
+        var logStd = arg2str:real;
         // Lengths + 2*segs + 2*vals (copied to SymTab)
         overMemLimit(8*len + 16*len + exp(logMean + (logStd**2)/2):int*len);
         var (segs, vals) = newRandStringsLogNormalLength(len, logMean, logStd, charset);
@@ -53,11 +52,7 @@ module SegmentedMsg {
 
   proc segmentLengthsMsg(reqMsg: string, st: borrowed SymTab): string throws {
     var pn = Reflection.getRoutineName();
-    var fields = reqMsg.split();
-    var cmd = fields[1];
-    var objtype = fields[2];
-    var segName = fields[3];
-    var valName = fields[4];
+    var (cmd, objtype, segName, valName) = reqMsg.splitMsgToTuple(4);
     var rname = st.nextName();
     select objtype {
       when "str" {
@@ -74,20 +69,14 @@ module SegmentedMsg {
   proc segmentedEfuncMsg(reqMsg: string, st: borrowed SymTab): string throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
-    var fields = reqMsg.split(10);
-    var cmd = fields[1];
-    var subcmd = fields[2];
-    var objtype = fields[3];
-    var segName = fields[4];
-    var valName = fields[5];
-    var valtype = fields[6];
-    // var val = fields[7];
+    var (cmd, subcmd, objtype, segName, valName, valtype, valStr,
+         idStr, kpStr, lStr, jsonStr) = reqMsg.splitMsgToTuple(11);
     select (objtype, valtype) {
     when ("str", "str") {
       var strings = new owned SegString(segName, valName, st);
       select subcmd {
         when "contains" {
-          var json = decode_json(fields[7], 1);
+          var json = decode_json(valStr, 1);
           var val = json[json.domain.low];
           var rname = st.nextName();
           var truth = st.addEntry(rname, strings.size, bool);
@@ -95,7 +84,7 @@ module SegmentedMsg {
           repMsg = "created "+st.attrib(rname);
         }
         when "startswith" {
-          var json = decode_json(fields[7], 1);
+          var json = decode_json(valStr, 1);
           var val = json[json.domain.low];
           var rname = st.nextName();
           var truth = st.addEntry(rname, strings.size, bool);
@@ -103,7 +92,7 @@ module SegmentedMsg {
           repMsg = "created "+st.attrib(rname);
         }
         when "endswith" {
-          var json = decode_json(fields[7], 1);
+          var json = decode_json(valStr, 1);
           var val = json[json.domain.low];
           var rname = st.nextName();
           var truth = st.addEntry(rname, strings.size, bool);
@@ -111,11 +100,11 @@ module SegmentedMsg {
           repMsg = "created "+st.attrib(rname);
         }
         when "peel" {
-          var times = fields[7]:int;
-          var includeDelimiter = (fields[8].toLower() == "true");
-          var keepPartial = (fields[9].toLower() == "true");
-          var left = (fields[10].toLower() == "true");
-          var json = decode_json(fields[11], 1);
+          var times = valStr:int;
+          var includeDelimiter = (idStr.toLower() == "true");
+          var keepPartial = (kpStr.toLower() == "true");
+          var left = (lStr.toLower() == "true");
+          var json = decode_json(jsonStr, 1);
           var val = json[json.domain.low];
           var loname = st.nextName();
           var lvname = st.nextName();
@@ -188,11 +177,7 @@ module SegmentedMsg {
   proc segmentedHashMsg(reqMsg: string, st: borrowed SymTab): string throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
-    var fields = reqMsg.split();
-    var cmd = fields[1];
-    var objtype = fields[2];
-    var segName = fields[3];
-    var valName = fields[4];
+    var (cmd, objtype, segName, valName) = reqMsg.splitMsgToTuple(4);
     select objtype {
     when "str" {
       var strings = new owned SegString(segName, valName, st);
@@ -213,11 +198,11 @@ module SegmentedMsg {
   proc segmentedIndexMsg(reqMsg: string, st: borrowed SymTab): string throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
-    var fields = reqMsg.split();
-    var cmd = fields[1];
-    var subcmd = fields[2]; // type of indexing to perform
-    var objtype = fields[3]; // what kind of segmented array
-    var args: [1..#(fields.size-3)] string = fields[4..]; // parsed by subroutines
+    // 'subcmd' is the type of indexing to perform
+    // 'objtype' is the type of segmented array
+    var (cmd, subcmd, objtype, argStr) = reqMsg.splitMsgToTuple(4);
+    var fields = argStr.split();
+    var args: [1..#fields.size] string = fields; // parsed by subroutines
     try {
       select subcmd {
         when "intIndex" {
@@ -347,17 +332,12 @@ module SegmentedMsg {
   proc segBinopvvMsg(reqMsg: string, st: borrowed SymTab): string throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
-    var fields = reqMsg.split(9);
-    var cmd = fields[1];
-    var op = fields[2];
-    // Type and attrib names of left segmented array
-    var ltype = fields[3];   
-    var lsegName = fields[4];
-    var lvalName = fields[5];
-    // Type and attrib names of right segmented array 
-    var rtype = fields[6];
-    var rsegName = fields[7];
-    var rvalName = fields[8];
+    var (cmd, op,
+         // Type and attrib names of left segmented array
+         ltype, lsegName, lvalName,
+         // Type and attrib names of right segmented array
+         rtype, rsegName, rvalName, leftStr, jsonStr)
+           = reqMsg.splitMsgToTuple(10);
     select (ltype, rtype) {
     when ("str", "str") {
       var lstrings = new owned SegString(lsegName, lvalName, st);
@@ -376,8 +356,8 @@ module SegmentedMsg {
           repMsg = "created " + st.attrib(rname);
         }
         when "stick" {
-          var left = (fields[9].toLower() != "false");
-          var json = decode_json(fields[10], 1);
+          var left = (leftStr.toLower() != "false");
+          var json = decode_json(jsonStr, 1);
           const delim = json[json.domain.low];
           var oname = st.nextName();
           var vname = st.nextName();
@@ -404,14 +384,8 @@ module SegmentedMsg {
   proc segBinopvsMsg(reqMsg: string, st: borrowed SymTab): string throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
-    var fields = reqMsg.split(6);
-    var cmd = fields[1];
-    var op = fields[2];
-    var objtype = fields[3];
-    var segName = fields[4];
-    var valName = fields[5];
-    var valtype = fields[6];
-    var encodedVal = fields[7];
+    var (cmd, op, objtype, segName, valName, valtype, encodedVal)
+          = reqMsg.splitMsgToTuple(7);
     var json = decode_json(encodedVal, 1);
     var value = json[json.domain.low];
     var rname = st.nextName();
@@ -438,18 +412,12 @@ module SegmentedMsg {
   proc segIn1dMsg(reqMsg: string, st: borrowed SymTab): string throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
-    var fields = reqMsg.split();
-    var cmd = fields[1];
-    var mainObjtype = fields[2];
-    var mainSegName = fields[3];
-    var mainValName = fields[4];
-    var testObjtype = fields[5];
-    var testSegName = fields[6];
-    var testValName = fields[7];
+    var (cmd, mainObjtype, mainSegName, mainValName, testObjtype, testSegName,
+         testValName, invertStr) = reqMsg.splitMsgToTuple(8);
     var invert: bool;
-    if fields[8] == "True" {invert = true;}
-    else if fields[8] == "False" {invert = false;}
-    else {return "Error: Invalid argument in %s: %s (expected True or False)".format(pn, fields[8]);}
+    if invertStr == "True" {invert = true;}
+    else if invertStr == "False" {invert = false;}
+    else {return "Error: Invalid argument in %s: %s (expected True or False)".format(pn, invertStr);}
     
     var rname = st.nextName();
     select (mainObjtype, testObjtype) {
@@ -470,11 +438,7 @@ module SegmentedMsg {
 
   proc segGroupMsg(reqMsg: string, st: borrowed SymTab): string throws {
     var pn = Reflection.getRoutineName();
-    var fields = reqMsg.split();
-    var cmd = fields[1];
-    var objtype = fields[2];
-    var segName = fields[3];
-    var valName = fields[4];
+    var (cmd, objtype, segName, valName) = reqMsg.splitMsgToTuple(4);
     var rname = st.nextName();
     select (objtype) {
     when "str" {

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -200,10 +200,9 @@ module SegmentedMsg {
     var repMsg: string;
     // 'subcmd' is the type of indexing to perform
     // 'objtype' is the type of segmented array
-    var (cmd, subcmd, objtype, _) = reqMsg.splitMsgToTuple(4);
-    var fields = reqMsg.split();
-    const low = fields.domain.low;
-    var args: [1..#fields.size] string = fields[low+3..]; // parsed by subroutines
+    var (cmd, subcmd, objtype, rest) = reqMsg.splitMsgToTuple(4);
+    var fields = rest.split();
+    var args: [1..#fields.size] string = fields; // parsed by subroutines
     try {
       select subcmd {
         when "intIndex" {

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -200,9 +200,10 @@ module SegmentedMsg {
     var repMsg: string;
     // 'subcmd' is the type of indexing to perform
     // 'objtype' is the type of segmented array
-    var (cmd, subcmd, objtype, argStr) = reqMsg.splitMsgToTuple(4);
-    var fields = argStr.split();
-    var args: [1..#fields.size] string = fields; // parsed by subroutines
+    var (cmd, subcmd, objtype, _) = reqMsg.splitMsgToTuple(4);
+    var fields = reqMsg.split();
+    const low = fields.domain.low;
+    var args: [1..#fields.size] string = fields[low+3..]; // parsed by subroutines
     try {
       select subcmd {
         when "intIndex" {

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -152,4 +152,29 @@ module ServerConfig
         }
     }
 
+    
+    proc string.splitMsgToTuple(param numChunks: int) {
+        var tup: numChunks*string;
+        for (t,s) in zip(tup, this.split(numChunks)) {
+            t = s;
+        }
+        return tup;
+    }
+
+    proc string.splitMsgToTuple(sep: string, param numChunks: int) {
+        var tup: numChunks*string;
+        for (t,s) in zip(tup, this.split(sep, numChunks)) {
+            t = s;
+        }
+        return tup;
+    }
+
+    proc bytes.splitMsgToTuple(param numChunks: int) {
+        var tup: numChunks*bytes;
+        for (t,s) in zip(tup, this.split(numChunks)) {
+            t = s;
+        }
+        return tup;
+    }
+
 }

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -159,7 +159,7 @@ module ServerConfig
     //
     private const DefaultArr = [1,2];
     private const defaultLow = DefaultArr.domain.low;
-    
+
     proc string.splitMsgToTuple(param numChunks: int) {
       var tup: numChunks*string;
       var count = 0;

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -152,29 +152,66 @@ module ServerConfig
         }
     }
 
+    // This is a trick to determine what the default low bound of
+    // arrays and tuples is to keep this code backwards-compatible
+    // through 1.20.  It could be removed and simplified once Arkouda
+    // is no longer interested in supporting Chapel 1.20.
+    //
+    private const DefaultArr = [1,2];
+    private const defaultLow = DefaultArr.domain.low;
     
     proc string.splitMsgToTuple(param numChunks: int) {
-        var tup: numChunks*string;
-        for (t,s) in zip(tup, this.split(numChunks)) {
-            t = s;
+      var tup: numChunks*string;
+      var count = 0;
+
+      // fill in the initial tuple elements defined by split()
+      for s in this.split(numChunks-1) {
+        tup(defaultLow+count) = s;
+        count += 1;
+      }
+      // if split() had fewer items than the tuple, fill in the rest
+      if (count < numChunks) {
+        for i in count..numChunks-1 {
+          tup(defaultLow+i) = "";
         }
-        return tup;
+      }
+      return tup;
     }
 
     proc string.splitMsgToTuple(sep: string, param numChunks: int) {
-        var tup: numChunks*string;
-        for (t,s) in zip(tup, this.split(sep, numChunks)) {
-            t = s;
+      var tup: numChunks*string;
+      var count = 0;
+
+      // fill in the initial tuple elements defined by split()
+      for s in this.split(sep, numChunks-1) {
+        tup(defaultLow+count) = s;
+        count += 1;
+      }
+      // if split() had fewer items than the tuple, fill in the rest
+      if (count < numChunks) {
+        for i in count..numChunks-1 {
+          tup(defaultLow+i) = "";
         }
-        return tup;
+      }
+      return tup;
     }
 
     proc bytes.splitMsgToTuple(param numChunks: int) {
-        var tup: numChunks*bytes;
-        for (t,s) in zip(tup, this.split(numChunks)) {
-            t = s;
+      var tup: numChunks*bytes;
+      var count = 0;
+
+      // fill in the initial tuple elements defined by split()
+      for s in this.split(numChunks-1) {
+        tup(defaultLow+count) = s;
+        count += 1;
+      }
+      // if split() had fewer items than the tuple, fill in the rest
+      if (count < numChunks) {
+        for i in count..numChunks-1 {
+          tup(defaultLow+i) = b"";
         }
-        return tup;
+      }
+      return tup;
     }
 
 }

--- a/src/SortMsg.chpl
+++ b/src/SortMsg.chpl
@@ -24,9 +24,7 @@ module SortMsg
     proc sortMsg(reqMsg: string, st: borrowed SymTab): string throws {
       param pn = Reflection.getRoutineName();
       var repMsg: string; // response message
-      var fields = reqMsg.split(); // split request into fields
-      var cmd = fields[1];
-      var name = fields[2];
+      var (cmd, name) = reqMsg.splitMsgToTuple(2);
 
       // get next symbol name
       var sortedName = st.nextName();

--- a/src/UniqueMsg.chpl
+++ b/src/UniqueMsg.chpl
@@ -27,16 +27,14 @@ module UniqueMsg
     proc uniqueMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var fields = reqMsg.split(); // split request into fields
-        var cmd = fields[1];
-        var objtype = fields[2];
-        var name = fields[3];
+        // split request into fields
+        var (cmd, objtype, name, returnCountsStr) = reqMsg.splitMsgToTuple(4);
         // flag to return counts of each unique value
         // same size as unique array
         var returnCounts: bool;
-        if fields[4] == "True" {returnCounts = true;}
-        else if fields[4] == "False" {returnCounts = false;}
-        else {return try! "Error: %s: %s".format(pn,fields[4]);}
+        if returnCountsStr == "True" {returnCounts = true;}
+        else if returnCountsStr == "False" {returnCounts = false;}
+        else {return try! "Error: %s: %s".format(pn,returnCountsStr);}
         select objtype {
           when "pdarray" {
             // get next symbol name for unique
@@ -91,8 +89,8 @@ module UniqueMsg
           when "str" {
             var offsetName = st.nextName();
             var valueName = st.nextName();
-            var names = name.split('+');
-            var str = new owned SegString(names[1], names[2], st);
+            var (names1,names2) = name.splitMsgToTuple('+', 2);
+            var str = new owned SegString(names1, names2, st);
             // the upper limit here is the similar to argsort/radixSortLSD_keys, but with a few more scratch arrays
             // check and throw if over memory limit
             overMemLimit((8 * str.size * 8)
@@ -116,9 +114,8 @@ module UniqueMsg
     proc value_countsMsg(reqMsg: string, st: borrowed SymTab): string throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var fields = reqMsg.split(); // split request into fields
-        var cmd = fields[1];
-        var name = fields[2];
+        // split request into fields
+        var (cmd, name) = reqMsg.splitMsgToTuple(2);
 
         // get next symbol name
         var vname = st.nextName();

--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -80,8 +80,7 @@ proc main() {
             break;
         }
 
-        const fieldsRaw = reqMsgRaw.split(1);
-        const cmdRaw = fieldsRaw[1];
+        const (cmdRaw, _) = reqMsgRaw.splitMsgToTuple(2);
         // parse requests, execute requests, format responses
         try {
             // first handle the case where we received arbitrary data
@@ -108,8 +107,7 @@ proc main() {
                     sendRepMsg(unknownError(""));
                 }
 
-                const fields = reqMsg.split(1);
-                const cmd = fields[1];
+                const (cmd,_) = reqMsg.splitMsgToTuple(2);
 
                 if logging {
                     writeln("reqMsg: ", reqMsg);


### PR DESCRIPTION
By way of introduction:  This started out as a branch in which I got Arkouda working with next week's Chapel 1.22 release (whose theme is switching from 1- to 0-based indexing) where the main stumbling block is with the `var fields = reqMsg.split(...);` pattern.  Getting a 1.22-compatible version of Arkouda working was fairly simple.  Then I decided to push harder on the index-neutral theme that I started in #334 to see if I could create something similar for split() that would work with Chapel 1.20, 1.21, or 1.22.  This turned out to be a fair amount more challenging, though it could've been less challenging to give up on 1.20 and just focus on 1.21 and 1.22 (or, simplest of all, to just focus on 1.22).

So, I'd suggest approaching this PR with the mindset of "Is the style taken here one that we like and would like to adopt in Arkouda?" (in which case it _may_ be worth merging) or "This is all well and good, but let's just change over to using 0-based indexing and stick with the previous style" (in which case we should close this PR and I'll open one for one of the more straightforward branches).

The approach I took here was to create variations of `split()` which would return a tuple so that I could use Chapel's de-tupling syntax to grab the fields out of them.  Thus, code that used to look like this:

```chapel
var fields = reqMsg.split(...);
var a = fields[1];
var b = fields[2];
var c = fields[3];
```

now looks like this:

```chapel
var (a, b, c) = reqMsg.splitMsgToTuple(...);
```

(where the name `splitMsgToTuple()` is completely open to negotiation).  Cases that require casting to different types I've written as:

```chapel
var (aStr, bStr, cStr) = reqMsg.splitMsgToTuple(...);
var a = aStr: int;
var b = bStr: real;
var c = cStr: bool;
```

And cases that are varargs-like I've written as:

```chapel
var (a, b, rest) = reqMsg.splitMsgToTuple(...);
var fields = rest.split();
...play some tricks with fields.domain.low...
```

The routines are defined at the bottom of ServerConfig.chpl though there may be a more appropriate place for them, and I'd be happy to move them.  It took me a few tries to get them right where the main challenge related to getting the behavior right for splits that had too many or two few fields.

Have I broken anything?  I've tested this by running `tests/check.py`, `tests/groupby_test.py`, and `tests/string.py`, but the last doesn't always work as Elliot has pointed out [elsewhere](https://github.com/mhmerrill/arkouda/pull/320#issuecomment-596625401), so while I have seen it work under this change, I'm not fully confident that I haven't broken it in new ways.  I also worry about code paths that aren't covered by the above tests.

I started on a similar effort to update the unit test directory, before realizing that many of them currently don't work on Arkouda master either (alluded to by issue #214).  So this PR does not contain similar updates for them, though I have a start on it in my local directory if Arkouda did want to continue in this vein.