### PR TITLE
Make SegStringSort.chpl compatible with Chapel 1.20-1.22

### DIFF
--- a/src/SegStringSort.chpl
+++ b/src/SegStringSort.chpl
@@ -15,9 +15,18 @@ module SegStringSort {
   private config const SSS_MEMFACTOR = 5;
   private const MEMFACTOR = SSS_MEMFACTOR;
 
+  // This is a trick to determine what the default low bound of
+  // arrays and tuples is to keep this code backwards-compatible
+  // through 1.20.  It could be removed and simplified once Arkouda
+  // is no longer interested in supporting Chapel 1.20.
+  //
+  private const DefaultArr = [1,2];
+  private const defaultLow = DefaultArr.domain.low;
+
   record StringIntComparator {
-    proc keyPart((a0,_): (string, int), i: int) {
+    proc keyPart((a0,_): (string, int), in i: int) {
       var len = a0.numBytes;
+      if defaultLow == 0 then { len -= 1; i -= 1; }
       var section = if i <= len then 0:int(8) else -1:int(8);
       var part = if i <= len then a0.byte(i) else 0:uint(8);
       return (section, part);


### PR DESCRIPTION
This seems to be the final change required for me to run
Arkouda against check.py, groupby_test.py, and string.py
on Chapel 1.20-1.22.  Like my change in PR #351, it relies on
playing a game that I'm not proud of, and which could be
much cleaner once we stop worrying about supporting 1.20.
Namely, I use a little code snippet to infer whether the
current compiler is using 0- or 1-based indexing and then
adjusts some numerical values depending on what it finds.
Better would be to rely on the `.indices` query introduced in
Chapel 1.21 and compare against its `.high` bound rather
than `.size` in deciding whether something is out of bounds
or not (though we'd still need to adjust the value of `i`
because of the following paragraph).

This routine was also slightly disheartening to work on
because one of the final known things that was _not_
converted to 0-based counting in 1.22 is the "part" sent
to keyPart() routines for Sort (see issue
https://github.com/chapel-lang/chapel/issues/15419),
suggesting that this routine may need another tweak for
1.23...