### PR TITLE
Make MyDmap an enum

### DIFF
--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -565,7 +565,8 @@ module GenSymIO {
   }
 
   /* This function gets called when A is a BlockDist array. */
-  proc read_files_into_distributed_array(A, filedomains: [?FD] domain(1), filenames: [FD] string, dsetName: string) where (MyDmap == 1) {
+  proc read_files_into_distributed_array(A, filedomains: [?FD] domain(1), filenames: [FD] string, dsetName: string)
+    where (MyDmap == Dmap.blockDist) {
     if GenSymIO_DEBUG {
       writeln("entry.a.targetLocales() = ", A.targetLocales()); try! stdout.flush();
       writeln("Filedomains: ", filedomains); try! stdout.flush();
@@ -622,7 +623,8 @@ module GenSymIO {
   }
 
   /* This function is called when A is a CyclicDist array. */
-  proc read_files_into_distributed_array(A, filedomains: [?FD] domain(1), filenames: [FD] string, dsetName: string) where (MyDmap == 0) {
+  proc read_files_into_distributed_array(A, filedomains: [?FD] domain(1), filenames: [FD] string, dsetName: string)
+    where (MyDmap == Dmap.cyclicDist) {
     use CyclicDist;
     // Distribute filenames across locales, and ensure single-threaded reads on each locale
     var fileSpace: domain(1) dmapped Cyclic(startIdx=FD.low, dataParTasksPerLocale=1) = FD;

--- a/src/SymArrayDmap.chpl
+++ b/src/SymArrayDmap.chpl
@@ -2,43 +2,36 @@
 module SymArrayDmap
 {
     /*
-    Configure MyDmap on compile line by "-s MyDmap=0" or "-s MyDmap=1"
-    0 = Cyclic, 1 = Block. Cyclic may not work; we haven't tested it in a while.
-    BlockDist is the default.
-    */
-    config param MyDmap = 1;
+     Available domain maps. Cyclic isn't regularly tested and may not work.
+     */
+    enum Dmap {blockDist, cyclicDist};
+
+    config param MyDmap:Dmap = Dmap.blockDist;
 
     public use CyclicDist;
     public use BlockDist;
 
     /* 
-    Uses the MyDmap config param in ServerConfig.chpl::
-        *if MyDmap == 0 {return (type CyclicDom(1,int(64),false));}* 
-
-        *if MyDmap == 1 {return (type BlockDom(1,int(64),false,unmanaged DefaultDist));}*
+    Makes a domain distributed according to :param:`MyDmap`.
 
     :arg size: size of domain
     :type size: int
-
-    **Note**: if MyDmap does not evaluate to 0 or 1, Cyclic Distribution will be selected. 
-    Cyclic Distribution is currently not fully supported.
-    **Note 2**: MyDmap is by default set to 1 in ServerConfig.chpl
     */
     proc makeDistDom(size:int) {
         select MyDmap
         {
-            when 0 { // Cyclic distribution
-                return {0..#size} dmapped Cyclic(startIdx=0);
-            }
-            when 1 { // Block Distribution
+            when Dmap.blockDist {
                 if size > 0 {
                     return {0..#size} dmapped Block(boundingBox={0..#size});
                 }
                 // fix the annoyance about boundingBox being enpty
                 else {return {0..#0} dmapped Block(boundingBox={0..0});}
             }
-            otherwise { // default to cyclic distribution
+            when Dmap.cyclicDist {
                 return {0..#size} dmapped Cyclic(startIdx=0);
+            }
+            otherwise {
+                halt("Unsupported distribution " + MyDmap:string);
             }
         }
     }


### PR DESCRIPTION
Use an enum for MyDmap instead of hard-coding integer literals.