### PR TITLE
fixed command to build ak py package

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ brew install python3
 # install the version of the arkouda python package which came with the arkouda_server
 # if you plan on editing the arkouda python package use the -e flag
 # from the local arkouda repo/directory run...
-pip3 install -e ./arkouda
+pip3 install -e .
 #
 # these packages are nice but not a requirement
 pip3 install pandas


### PR DESCRIPTION
Built chapel 1.20.0 and arkouda from scratch on mac
Followed guide on README.md
Encountered issue when building the arkouda python package (from within arkouda directory):

"pip3 install -e ./arkouda" generated error: ERROR: File "setup.py" not found. Directory cannot be installed in editable mode

I changed the command to "pip3 install -e ." and it fixed it.
Minor change. Figured I'd submit for future newbies trying to build.

(the build instructions told you to be in the repo, but the command assumed you were in parent directory)