### PR TITLE
Improve comm=none build and execution speed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,10 @@ CHPL_FLAGS += $(patsubst %,-L%,$(strip $(subst :, ,$(LD_LIBRARY_PATH))))
 endif
 
 .PHONY: check-deps
-check-deps: check-zmq check-hdf5
+ifndef ARKOUDA_SKIP_CHECK_DEPS
+CHECK_DEPS = check-zmq check-hdf5
+endif
+check-deps: $(CHECK_DEPS)
 
 ZMQ_CHECK = $(DEP_INSTALL_DIR)/checkZMQ.chpl
 check-zmq: $(ZMQ_CHECK)

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,12 @@ ifeq ("$(shell chpl --version | sed -n "s/chpl version 1\.\([0-9]*\).*/\1/p")", 
 endif
 
 CHPL_DEBUG_FLAGS += --print-passes
-ifndef ARKOUDA_DEVELOPER
-CHPL_FLAGS += --fast
-else
+ifdef ARKOUDA_DEVELOPER
 CHPL_FLAGS += --ccflags="-O1"
+else ifdef ARKOUDA_QUICK_COMPILE
+CHPL_FLAGS += --no-checks --no-loop-invariant-code-motion --ccflags="-O0"
+else
+CHPL_FLAGS += --fast
 endif
 # need this to avoid a slew of warnings from HDF5 on some platforms
 # --ccflags="-Wno-incompatible-pointer-types"

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -555,9 +555,9 @@ module GenSymIO {
     return (subdoms, (+ reduce lengths));
   }
 
-  /* This function gets called when A is a BlockDist array. */
+  /* This function gets called when A is a BlockDist or DefaultRectangular array. */
   proc read_files_into_distributed_array(A, filedomains: [?FD] domain(1), filenames: [FD] string, dsetName: string)
-    where (MyDmap == Dmap.blockDist) {
+    where (MyDmap == Dmap.blockDist || MyDmap == Dmap.defaultRectangular) {
     if GenSymIO_DEBUG {
       writeln("entry.a.targetLocales() = ", A.targetLocales()); try! stdout.flush();
       writeln("Filedomains: ", filedomains); try! stdout.flush();

--- a/src/SymArrayDmap.chpl
+++ b/src/SymArrayDmap.chpl
@@ -4,9 +4,15 @@ module SymArrayDmap
     /*
      Available domain maps. Cyclic isn't regularly tested and may not work.
      */
-    enum Dmap {blockDist, cyclicDist};
+    enum Dmap {defaultRectangular, blockDist, cyclicDist};
 
-    config param MyDmap:Dmap = Dmap.blockDist;
+    private param defaultDmap = if CHPL_COMM == "none" then Dmap.defaultRectangular
+                                                       else Dmap.blockDist;
+    /*
+    How domains/arrays are distributed. Defaults to :enum:`Dmap.defaultRectangular` if
+    :param:`CHPL_COMM=none`, otherwise defaults to :enum:`Dmap.blockDist`.
+    */
+    config param MyDmap:Dmap = defaultDmap;
 
     public use CyclicDist;
     public use BlockDist;
@@ -20,6 +26,9 @@ module SymArrayDmap
     proc makeDistDom(size:int) {
         select MyDmap
         {
+            when Dmap.defaultRectangular {
+                return {0..#size};
+            }
             when Dmap.blockDist {
                 if size > 0 {
                     return {0..#size} dmapped Block(boundingBox={0..#size});


### PR DESCRIPTION
This is primarily motivated by faster build/compile times to make development easier, but there are some nice execution performance improvements too. When building locally with comm=none and setting `ARKOUDA_QUICK_COMPILE=true` my build times drop from 9 minutes to 3 minutes. This makes a few changes: 

 - Default to DefaultRectangular (local array) for comm=none. BlockDist has some overheads that are unnecessary for comm=none builds (block dist has locality checks, loops over the locales array, and other things that aren't needed for comm=none.) We're looking to optimize this in the future, but in the meantime this will improve compilation and execution performance for single node builds.
 - Add `ARKOUDA_SKIP_CHECK_DEPS` to skip zmq/hdf5 dependency checks. This saves a little time during a debug/develop cycle.
 - Add `ARKOUDA_QUICK_COMPILE` to try and compile as quickly as possible (disable slow Chapel optimizations, disable back-end optimizations, disable runtime checks.) This will hurt execution performance, but it makes development and debugging significantly faster.

Performance on the 24-core server that nightly single-node perf testing runs on is below.

Build time improvements:
---

| config                                                      | build time |
| ----------------------------------------------------------- | ---------- |
| -sMyDmap=Dmap.blockDist                                     | 580s       |
| -sMyDmap=Dmap.defaultRectangular                            | 425s       |
| -sMyDmap=Dmap.defaultRectangular ARKOUDA_QUICK_COMPILE=true | 190s       |

Execution performance improvements:
---

| benchmark | BlockDist    | DefaultRect  |
| --------- | -----------: | -----------: |
| argsort   |   0.34 GiB/s |   0.38 GiB/s |
| gather    |   6.40 GiB/s |   7.55 GiB/s |
| reduce    | 104.20 GiB/s | 105.30 GiB/s |
| scan      |   5.05 GiB/s |   6.90 GiB/s |
| scatter   |   4.35 GiB/s |  11.45 GiB/s |
| stream    |   14.0 GiB/s |  21.30 GiB/s |

This also helps superdome performance, though releasing those numbers is harder. The impact isn't as significant since the extra parallelism hides the overheads, but there's 10% improvement for gather/scatter.