### PR TITLE
Require Chapel 1.21/1.22

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,7 +4,6 @@ on: [push, pull_request]
 
 env:
   ARKOUDA_QUICK_COMPILE: true
-  CHPL_RT_OVERSUBSCRIBED: yes # limit contention on limited CI hardware
 
 jobs:
   lint:
@@ -21,7 +20,7 @@ jobs:
       matrix:
         image: [chapel, chapel-gasnet]
     container:
-      image: chapel/${{matrix.image}}:1.20.0
+      image: chapel/${{matrix.image}}:1.22.0
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
@@ -50,7 +49,7 @@ jobs:
       matrix:
         image: [chapel, chapel-gasnet]
     container:
-      image: chapel/${{matrix.image}}:1.20.0
+      image: chapel/${{matrix.image}}:1.22.0
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,13 @@ endif
 ifndef ARKOUDA_SKIP_CHECK_DEPS
 CHECK_DEPS = check-zmq check-hdf5
 endif
+
+CHPL_MINOR := $(shell chpl --version | sed -n "s/chpl version 1\.\([0-9]*\).*/\1/p")
+CHPL_TOO_OLD := $(shell test $(CHPL_MINOR) -lt 21 && echo yes)
 check-deps: $(CHECK_DEPS)
+ifeq ($(CHPL_TOO_OLD),yes)
+	$(error Chapel 1.22.0 or newer is required)
+endif
 
 ZMQ_CHECK = $(DEP_INSTALL_DIR)/checkZMQ.chpl
 check-zmq: $(ZMQ_CHECK)

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ CHPL_DEBUG_FLAGS += --print-passes
 ifdef ARKOUDA_DEVELOPER
 CHPL_FLAGS += --ccflags="-O1"
 else ifdef ARKOUDA_QUICK_COMPILE
-CHPL_FLAGS += --no-checks --no-loop-invariant-code-motion --ccflags="-O0"
+CHPL_FLAGS += --no-checks --no-loop-invariant-code-motion --no-fast-followers --ccflags="-O0"
 else
 CHPL_FLAGS += --fast
 endif

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ interactive session.
 ## Installation
 
 ### Requirements:
- * requires chapel 1.20.0
+ * requires chapel 1.22.0
  * requires zeromq version >= 4.2.5, tested with 4.2.5 and 4.3.1
  * requires hdf5 
  * requires python 3.6 or greater
@@ -106,7 +106,7 @@ If it is preferred to build Chapel instead of using the brew install, the proces
 ```bash
 
 # on my mac build chapel in my home directory with these settings...
-export CHPL_HOME=~/chapel/chapel-1.20.0
+export CHPL_HOME=~/chapel/chapel-1.22.0
 source $CHPL_HOME/util/setchplenv.bash
 export CHPL_COMM=gasnet
 export CHPL_COMM_SUBSTRATE=smp
@@ -133,9 +133,9 @@ sudo apt-get update
 sudo apt-get install gcc g++ m4 perl python python-dev python-setuptools bash make mawk git pkg-config
 
 # Download latest Chapel release, explode archive, and navigate to source root directory
-wget https://github.com/chapel-lang/chapel/releases/download/1.20.0/chapel-1.20.0.tar.gz
-tar xvf chapel-1.20.0.tar.gz
-cd chapel-1.20.0/
+wget https://github.com/chapel-lang/chapel/releases/download/1.22.0/chapel-1.22.0.tar.gz
+tar xvf chapel-1.22.0.tar.gz
+cd chapel-1.22.0/
 
 # Set CHPL_HOME
 export CHPL_HOME=$PWD

--- a/pydoc/setup/prerequisites.rst
+++ b/pydoc/setup/prerequisites.rst
@@ -7,7 +7,7 @@ Prerequisites
 *******************
 Chapel
 *******************
-(version 1.20.0 or greater)
+(version 1.22.0 or greater)
 
 The arkouda server application is written in Chapel_, a productive and performant parallel programming language. In order to use arkouda, you must first `download the current version of Chapel`_ and build it according to the instructions_ for your platform(s). Below are tips for building Chapel to support arkouda.
 


### PR DESCRIPTION
Chapel 1.21/1.22 have some significant performance improvements that
benefit Arkouda, especially at scale. Additionally, there are a number
of code cleanups that can be made if we can use 1.21/1.22 so we want to
require this instead of just suggesting it.

I've updated the documentation to say 1.22 is required, and added an
error if 1.20 or older is used. The motivation for allowing 1.21 but
documenting 1.22 is to encourage new users to use 1.22, but allow users
with other Chapel code that aren't ready for 1.22 to build Arkouda
still.

Closes https://github.com/mhmerrill/arkouda/issues/363