### PR TITLE
Use ARKOUDA_QUICK_COMPILE for CI testing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request]
 
 env:
-  ARKOUDA_DEVELOPER: true # faster compilation, and enable checks
+  ARKOUDA_QUICK_COMPILE: true
   CHPL_RT_OVERSUBSCRIBED: yes # limit contention on limited CI hardware
 
 jobs:


### PR DESCRIPTION
The gasnet CI testing has been hitting out-of-memory conditions recently
and takes a while to compile. This should reduce the memory footprint
(because the backend is using O0 instead of O1) and reduce gasnet build
times from ~30 minutes to ~15 minutes. Total gasnet CI testing time is
around 40 minutes still (25 to run tests) but I'm hoping to lower that
with some upcoming PRs.