### PR TITLE
Remove tricks to keep 1.20 working while preserving 1.21 and 1.22 compatibility

### DIFF
--- a/src/SegStringSort.chpl
+++ b/src/SegStringSort.chpl
@@ -15,18 +15,15 @@ module SegStringSort {
   private config const SSS_MEMFACTOR = 5;
   private const MEMFACTOR = SSS_MEMFACTOR;
 
-  // This is a trick to determine what the default low bound of
-  // arrays and tuples is to keep this code backwards-compatible
-  // through 1.20.  It could be removed and simplified once Arkouda
-  // is no longer interested in supporting Chapel 1.20.
-  //
-  private const DefaultArr = [1,2];
-  private const defaultLow = DefaultArr.domain.low;
-
   record StringIntComparator {
     proc keyPart((a0,_): (string, int), in i: int) {
       var len = a0.numBytes;
-      if defaultLow == 0 then { len -= 1; i -= 1; }
+      // This uses .indices to make this code work with Chapel 1.21 or 1.22;
+      // If/when we want to hard-code to 1.22+, we can remove the following
+      // statement and change the a0.byte(i) expression below to a0.byte(i-1).
+      // Though Chapel issue #15419 suggests making keyPart() routines 0-based
+      // as well, at which point, it could remain a0.byte(i)...
+      if a0.indices.low == 0 then { len -= 1; i -= 1; }
       var section = if i <= len then 0:int(8) else -1:int(8);
       var part = if i <= len then a0.byte(i) else 0:uint(8);
       return (section, part);

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -152,27 +152,19 @@ module ServerConfig
         }
     }
 
-    // This is a trick to determine what the default low bound of
-    // arrays and tuples is to keep this code backwards-compatible
-    // through 1.20.  It could be removed and simplified once Arkouda
-    // is no longer interested in supporting Chapel 1.20.
-    //
-    private const DefaultArr = [1,2];
-    private const defaultLow = DefaultArr.domain.low;
-
     proc string.splitMsgToTuple(param numChunks: int) {
       var tup: numChunks*string;
-      var count = 0;
+      var count = tup.indices.low;
 
       // fill in the initial tuple elements defined by split()
       for s in this.split(numChunks-1) {
-        tup(defaultLow+count) = s;
+        tup(count) = s;
         count += 1;
       }
       // if split() had fewer items than the tuple, fill in the rest
       if (count < numChunks) {
         for i in count..numChunks-1 {
-          tup(defaultLow+i) = "";
+          tup(i) = "";
         }
       }
       return tup;
@@ -180,17 +172,17 @@ module ServerConfig
 
     proc string.splitMsgToTuple(sep: string, param numChunks: int) {
       var tup: numChunks*string;
-      var count = 0;
+      var count = tup.indices.low;
 
       // fill in the initial tuple elements defined by split()
       for s in this.split(sep, numChunks-1) {
-        tup(defaultLow+count) = s;
+        tup(count) = s;
         count += 1;
       }
       // if split() had fewer items than the tuple, fill in the rest
       if (count < numChunks) {
         for i in count..numChunks-1 {
-          tup(defaultLow+i) = "";
+          tup(i) = "";
         }
       }
       return tup;
@@ -198,17 +190,17 @@ module ServerConfig
 
     proc bytes.splitMsgToTuple(param numChunks: int) {
       var tup: numChunks*bytes;
-      var count = 0;
+      var count = tup.indices.low;
 
       // fill in the initial tuple elements defined by split()
       for s in this.split(numChunks-1) {
-        tup(defaultLow+count) = s;
+        tup(count) = s;
         count += 1;
       }
       // if split() had fewer items than the tuple, fill in the rest
       if (count < numChunks) {
         for i in count..numChunks-1 {
-          tup(defaultLow+i) = b"";
+          tup(i) = b"";
         }
       }
       return tup;


### PR DESCRIPTION
This removes the ugly tricks I used in PR #351 and #352 to make Arkouda work across versions 1.20–1.22 and results in code that works for either 1.21 or 1.22.  Specifically, in those PRs, I used a trick to determine what the default low bound of a tuple or array literal is while here, I lean more on features introduced in Chapel 1.21, notably the .indices query.