### PR TITLE
Fix TestBase uses in some chapel unit tests

### DIFF
--- a/test/StringGatherSpeedTest.chpl
+++ b/test/StringGatherSpeedTest.chpl
@@ -1,4 +1,4 @@
-use Testbase;
+use TestBase;
 
 use RadixSortLSD;
 

--- a/test/UnitTestMerge.chpl
+++ b/test/UnitTestMerge.chpl
@@ -1,4 +1,4 @@
-use Testbase;
+use TestBase;
 
 use Merge;
 use RadixSortLSD;


### PR DESCRIPTION
`Testbase` -> `TestBase` -- I didn't run into this on my mac because
filenames are case insensitive on mac, but that's not true on linux.

See https://github.com/chapel-lang/chapel/issues/11139 for more info.

Resolves https://github.com/mhmerrill/arkouda/issues/379