### PR TITLE
Stop throwing -Wno-incompatible-pointer-types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,6 @@ CHPL_FLAGS += --no-checks --no-loop-invariant-code-motion --no-fast-followers --
 else
 CHPL_FLAGS += --fast
 endif
-# need this to avoid a slew of warnings from HDF5 on some platforms
-# --ccflags="-Wno-incompatible-pointer-types"
-CHPL_FLAGS += --ccflags="-Wno-incompatible-pointer-types"
 CHPL_FLAGS += -smemTrack=true
 CHPL_FLAGS += -lhdf5 -lhdf5_hl -lzmq
 


### PR DESCRIPTION
This is added automatically by Chapel in 1.21/1.22, so we don't need to
add it manually.

(Added in https://github.com/chapel-lang/chapel/pull/14446)