### PR TITLE
Fix setops benchmark graph generation errors

### DIFF
--- a/benchmarks/graph_infra/arkouda.graph
+++ b/benchmarks/graph_infra/arkouda.graph
@@ -40,7 +40,7 @@ files: reduce.dat, reduce.dat, reduce.dat, reduce.dat
 graphtitle: Reduce Performance
 ylabel: Performance (GiB/s)
 
-perfkeys: intersect1d Average rate =, union1d Average rate =, setxor1d Average rate=, setdiff1d Average rate=
+perfkeys: intersect1d Average rate =, union1d Average rate =, setxor1d Average rate =, setdiff1d Average rate =
 graphkeys: Intersect GiB/s, Union GiB/s, Xor GiB/s, Diff GiB/s
 files: setops.dat, setops.dat, setops.dat, setops.dat
 graphtitle: Set Operations Performance

--- a/benchmarks/graph_infra/arkouda.graph
+++ b/benchmarks/graph_infra/arkouda.graph
@@ -40,7 +40,7 @@ files: reduce.dat, reduce.dat, reduce.dat, reduce.dat
 graphtitle: Reduce Performance
 ylabel: Performance (GiB/s)
 
-perfkeys: intersect Average rate =, union Average rate =, xor Average rate=, diff Average rate=
+perfkeys: intersect1d Average rate =, union1d Average rate =, setxor1d Average rate=, setdiff1d Average rate=
 graphkeys: Intersect GiB/s, Union GiB/s, Xor GiB/s, Diff GiB/s
 files: setops.dat, setops.dat, setops.dat, setops.dat
 graphtitle: Set Operations Performance

--- a/benchmarks/setops.py
+++ b/benchmarks/setops.py
@@ -78,7 +78,7 @@ def create_parser():
     parser.add_argument('hostname', help='Hostname of arkouda server')
     parser.add_argument('port', type=int, help='Port of arkouda server')
     parser.add_argument('-n', '--size', type=int, default=10**8, help='Problem size: length of arrays A and B')
-    parser.add_argument('-t', '--trials', type=int, default=3, help='Number of times to run the benchmark')
+    parser.add_argument('-t', '--trials', type=int, default=1, help='Number of times to run the benchmark')
     parser.add_argument('-d', '--dtype', default='int64', help='Dtype of arrays (int64)')
     parser.add_argument('--numpy', default=False, action='store_true', help='Run the same operation in NumPy to compare performance.')
     parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')


### PR DESCRIPTION
When I had submitted my previous PR, I didn't know how to test the graphs locally so they had an error, but Elliot helped me figure that out. Also, changed the number of internal trials of the setops benchmark to 1 to reduce the likelihood of it timing out.