### PR TITLE
Adjust benchmarks to run all supported types in correctness mode

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,9 +39,7 @@ jobs:
         make test-python
     - name: Arkouda benchmark --correctness-only
       run: |
-         ./benchmarks/run_benchmarks.py --correctness-only --dtype=int64
-         ./benchmarks/run_benchmarks.py --correctness-only --dtype=float64
-         ./benchmarks/run_benchmarks.py --correctness-only --dtype=bool scatter gather
+         ./benchmarks/run_benchmarks.py --correctness-only
 
   unit_tests_linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,6 +40,7 @@ jobs:
     - name: Arkouda benchmark --correctness-only
       run: |
          ./benchmarks/run_benchmarks.py --correctness-only
+         ./benchmarks/run_benchmarks.py --size=100 --gen-graphs
 
   unit_tests_linux:
     runs-on: ubuntu-latest

--- a/benchmarks/argsort.py
+++ b/benchmarks/argsort.py
@@ -4,6 +4,8 @@ import time, argparse
 import numpy as np
 import arkouda as ak
 
+TYPES = ('int64', 'float64')
+
 def time_ak_argsort(N_per_locale, trials, dtype):
     print(">>> arkouda argsort")
     cfg = ak.get_config()
@@ -63,7 +65,7 @@ def create_parser():
     parser.add_argument('port', type=int, help='Port of arkouda server')
     parser.add_argument('-n', '--size', type=int, default=10**8, help='Problem size: length of array to argsort')
     parser.add_argument('-t', '--trials', type=int, default=3, help='Number of times to run the benchmark')
-    parser.add_argument('-d', '--dtype', default='int64', help='Dtype of array (int64 or float64)')
+    parser.add_argument('-d', '--dtype', default='int64', help='Dtype of array ({})'.format(', '.join(TYPES)))
     parser.add_argument('--numpy', default=False, action='store_true', help='Run the same operation in NumPy to compare performance.')
     parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')
     return parser
@@ -72,13 +74,14 @@ if __name__ == "__main__":
     import sys
     parser = create_parser()
     args = parser.parse_args()
-    if args.dtype not in ('int64', 'float64'):
-        raise ValueError("Dtype must be either int64 or float64, not {}".format(args.dtype))
+    if args.dtype not in TYPES:
+        raise ValueError("Dtype must be {}, not {}".format('/'.join(TYPES), args.dtype))
     ak.verbose = False
     ak.connect(args.hostname, args.port)
 
     if args.correctness_only:
-        check_correctness(args.dtype)
+        for dtype in TYPES:
+            check_correctness(dtype)
         sys.exit(0)
     
     print("array size = {:,}".format(args.size))

--- a/benchmarks/coargsort.py
+++ b/benchmarks/coargsort.py
@@ -4,6 +4,8 @@ import time, argparse
 import numpy as np
 import arkouda as ak
 
+TYPES = ('int64', 'float64')
+
 def time_ak_coargsort(N_per_locale, trials, dtype):
     print(">>> arkouda coargsort")
     cfg = ak.get_config()
@@ -75,7 +77,7 @@ def create_parser():
     parser.add_argument('port', type=int, help='Port of arkouda server')
     parser.add_argument('-n', '--size', type=int, default=10**8, help='Problem size: total length of all arrays to coargsort')
     parser.add_argument('-t', '--trials', type=int, default=1, help='Number of times to run the benchmark')
-    parser.add_argument('-d', '--dtype', default='int64', help='Dtype of array (int64 or float64)')
+    parser.add_argument('-d', '--dtype', default='int64', help='Dtype of array ({})'.format(', '.join(TYPES)))
     parser.add_argument('--numpy', default=False, action='store_true', help='Run the same operation in NumPy to compare performance.')
     parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')
     return parser
@@ -84,13 +86,14 @@ if __name__ == "__main__":
     import sys
     parser = create_parser()
     args = parser.parse_args()
-    if args.dtype not in ('int64', 'float64'):
-        raise ValueError("Dtype must be either int64 or float64, not {}".format(args.dtype))
+    if args.dtype not in TYPES:
+        raise ValueError("Dtype must be {}, not {}".format('/'.join(TYPES), args.dtype))
     ak.verbose = False
     ak.connect(args.hostname, args.port)
 
     if args.correctness_only:
-        check_correctness(args.dtype)
+        for dtype in TYPES:
+            check_correctness(dtype)
         sys.exit(0)
 
     print("array size = {:,}".format(args.size))

--- a/benchmarks/contributing.rst
+++ b/benchmarks/contributing.rst
@@ -19,6 +19,8 @@ Example
      import numpy as np
      import arkouda as ak
 
+     TYPES = ('int64', 'float64')
+
      def time_ak_argsort(N_per_locale, trials, dtype):
          print(">>> arkouda argsort") #Name of method to be tested
          cfg = ak.get_config()
@@ -47,15 +49,15 @@ Example
          parser.add_argument('port', type=int, help='Port of arkouda server')
          parser.add_argument('-n', '--size', type=int, default=10**8, help='Problem size: length of array to argsort')
          parser.add_argument('-t', '--trials', type=int, default=3, help='Number of times to run the benchmark')
-         parser.add_argument('-d', '--dtype', default='int64', help='Dtype of array (int64 or float64)')
+         parser.add_argument('-d', '--dtype', default='int64', help='Dtype of array ({})'.format(', '.join(TYPES)))
          return parser
 
      if __name__ == "__main__":
          import sys
          parser = create_parser()
          args = parser.parse_args()
-         if args.dtype not in ('int64', 'float64'):
-             raise ValueError("Dtype must be either int64 or float64, not {}".format(args.dtype))
+         if args.dtype not in TYPES:
+             raise ValueError("Dtype must be {}, not {}".format('/'.join(TYPES), args.dtype))
          ak.verbose = False
          ak.connect(args.hostname, args.port)
 
@@ -122,13 +124,14 @@ Once everything is working here, correctness testing and numpy testing should be
     import sys
     parser = create_parser()
     args = parser.parse_args()
-    if args.dtype not in ('int64', 'float64'):
-        raise ValueError("Dtype must be either int64 or float64, not {}".format(args.dtype))
+    if args.dtype not in TYPES:
+        raise ValueError("Dtype must be {}, not {}".format('/'.join(TYPES), args.dtype))
     ak.verbose = False
     ak.connect(args.hostname, args.port)
 
     if args.correctness_only:
-        check_correctness(args.dtype)
+        for dtype in TYPES:
+            check_correctness(dtype)
         sys.exit(0)
     
     print("array size = {:,}".format(args.size))

--- a/benchmarks/gather.py
+++ b/benchmarks/gather.py
@@ -4,6 +4,8 @@ import time, argparse
 import numpy as np
 import arkouda as ak
 
+TYPES = ('int64', 'float64', 'bool')
+
 def time_ak_gather(isize, vsize, trials, dtype, random):
     print(">>> arkouda gather")
     cfg = ak.get_config()
@@ -82,7 +84,7 @@ def create_parser():
     parser.add_argument('-i', '--index-size', type=int, help='Length of index array (number of gathers to perform)')
     parser.add_argument('-v', '--value-size', type=int, help='Length of array from which values are gathered')
     parser.add_argument('-t', '--trials', type=int, default=6, help='Number of times to run the benchmark')
-    parser.add_argument('-d', '--dtype', default='int64', help='Dtype of value array (int64, float64, or bool)')
+    parser.add_argument('-d', '--dtype', default='int64', help='Dtype of value array ({})'.format(', '.join(TYPES)))
     parser.add_argument('-r', '--randomize', default=False, action='store_true', help='Use random values instead of ones')
     parser.add_argument('--numpy', default=False, action='store_true', help='Run the same operation in NumPy to compare performance.')
     parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')
@@ -94,13 +96,14 @@ if __name__ == "__main__":
     args = parser.parse_args()
     args.index_size = args.size if args.index_size is None else args.index_size
     args.value_size = args.size if args.value_size is None else args.value_size
-    if args.dtype not in ('int64', 'float64', 'bool'):
-        raise ValueError("Dtype must be either int64, float64, or bool, not {}".format(args.dtype))
+    if args.dtype not in TYPES:
+        raise ValueError("Dtype must be {}, not {}".format('/'.join(TYPES), args.dtype))
     ak.verbose = False
     ak.connect(args.hostname, args.port)
 
     if args.correctness_only:
-        check_correctness(args.dtype, args.randomize)
+        for dtype in TYPES:
+            check_correctness(dtype, args.randomize)
         sys.exit(0)
     
     print("size of index array = {:,}".format(args.index_size))

--- a/benchmarks/reduce.py
+++ b/benchmarks/reduce.py
@@ -5,6 +5,7 @@ import numpy as np
 import arkouda as ak
 
 OPS = ('sum', 'prod', 'min', 'max')
+TYPES = ('int64', 'float64')
 
 def time_ak_reduce(N_per_locale, trials, dtype, random):
     print(">>> arkouda reduce")
@@ -96,7 +97,7 @@ def create_parser():
     parser.add_argument('port', type=int, help='Port of arkouda server')
     parser.add_argument('-n', '--size', type=int, default=10**8, help='Problem size: length of array to reduce')
     parser.add_argument('-t', '--trials', type=int, default=6, help='Number of times to run the benchmark')
-    parser.add_argument('-d', '--dtype', default='int64', help='Dtype of array (int64 or float64)')
+    parser.add_argument('-d', '--dtype', default='int64', help='Dtype of array ({})'.format(', '.join(TYPES)))
     parser.add_argument('-r', '--randomize', default=False, action='store_true', help='Fill array with random values instead of range')
     parser.add_argument('--numpy', default=False, action='store_true', help='Run the same operation in NumPy to compare performance.')
     parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')
@@ -106,13 +107,14 @@ if __name__ == "__main__":
     import sys
     parser = create_parser()
     args = parser.parse_args()
-    if args.dtype not in ('int64', 'float64'):
-        raise ValueError("Dtype must be either int64 or float64, not {}".format(args.dtype))
+    if args.dtype not in TYPES:
+        raise ValueError("Dtype must be {}, not {}".format('/'.join(TYPES), args.dtype))
     ak.verbose = False
     ak.connect(args.hostname, args.port)
 
     if args.correctness_only:
-        check_correctness(args.dtype, args.randomize)
+        for dtype in TYPES:
+            check_correctness(dtype, args.randomize)
         sys.exit(0)
     
     print("array size = {:,}".format(args.size))

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -24,9 +24,12 @@ BENCHMARKS = ['stream', 'argsort', 'coargsort', 'gather', 'scatter', 'reduce', '
 def get_chpl_util_dir():
     """ Get the Chapel directory that contains graph generation utilities. """
     CHPL_HOME = os.getenv('CHPL_HOME')
+    if not CHPL_HOME:
+        logging.error('$CHPL_HOME not set')
+        sys.exit(1)
     chpl_util_dir = os.path.join(CHPL_HOME, 'util', 'test')
-    if not CHPL_HOME or not os.path.isdir(chpl_util_dir):
-        logging.error('$CHPL_HOME not set, or {} missing'.format(chpl_util_dir))
+    if not os.path.isdir(chpl_util_dir):
+        logging.error('{} does not exist'.format(chpl_util_dir))
         sys.exit(1)
     return chpl_util_dir
 

--- a/benchmarks/scan.py
+++ b/benchmarks/scan.py
@@ -5,6 +5,7 @@ import numpy as np
 import arkouda as ak
 
 OPS = ('cumsum', 'cumprod')
+TYPES = ('int64', 'float64')
 
 def time_ak_scan(N_per_locale, trials, dtype, random):
     print(">>> arkouda scan")
@@ -96,7 +97,7 @@ def create_parser():
     parser.add_argument('port', type=int, help='Port of arkouda server')
     parser.add_argument('-n', '--size', type=int, default=10**8, help='Problem size: length of array')
     parser.add_argument('-t', '--trials', type=int, default=6, help='Number of times to run the benchmark')
-    parser.add_argument('-d', '--dtype', default='int64', help='Dtype of array (int64 or float64)')
+    parser.add_argument('-d', '--dtype', default='int64', help='Dtype of array ({})'.format(', '.join(TYPES)))
     parser.add_argument('-r', '--randomize', default=False, action='store_true', help='Fill array with random values instead of range')
     parser.add_argument('--numpy', default=False, action='store_true', help='Run the same operation in NumPy to compare performance.')
     parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')
@@ -106,13 +107,14 @@ if __name__ == "__main__":
     import sys
     parser = create_parser()
     args = parser.parse_args()
-    if args.dtype not in ('int64', 'float64'):
-        raise ValueError("Dtype must be either int64 or float64, not {}".format(args.dtype))
+    if args.dtype not in TYPES:
+        raise ValueError("Dtype must be {}, not {}".format('/'.join(TYPES), args.dtype))
     ak.verbose = False
     ak.connect(args.hostname, args.port)
 
     if args.correctness_only:
-        check_correctness(args.dtype, args.randomize)
+        for dtype in TYPES:
+            check_correctness(dtype, args.randomize)
         sys.exit(0)
     
     print("array size = {:,}".format(args.size))

--- a/benchmarks/scatter.py
+++ b/benchmarks/scatter.py
@@ -4,6 +4,8 @@ import time, argparse
 import numpy as np
 import arkouda as ak
 
+TYPES = ('int64', 'float64', 'bool')
+
 def time_ak_scatter(isize, vsize, trials, dtype, random):
     print(">>> arkouda scatter")
     cfg = ak.get_config()
@@ -89,7 +91,7 @@ def create_parser():
     parser.add_argument('-i', '--index-size', type=int, help='Length of index array (number of scatters to perform)')
     parser.add_argument('-v', '--value-size', type=int, help='Length of array from which values are scattered')
     parser.add_argument('-t', '--trials', type=int, default=6, help='Number of times to run the benchmark')
-    parser.add_argument('-d', '--dtype', default='int64', help='Dtype of value array (int64, float64, or bool)')
+    parser.add_argument('-d', '--dtype', default='int64', help='Dtype of value array ({})'.format(', '.join(TYPES)))
     parser.add_argument('-r', '--randomize', default=False, action='store_true', help='Use random values instead of ones')
     parser.add_argument('--numpy', default=False, action='store_true', help='Run the same operation in NumPy to compare performance.')
     parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')
@@ -101,13 +103,14 @@ if __name__ == "__main__":
     args = parser.parse_args()
     args.index_size = args.size if args.index_size is None else args.index_size
     args.value_size = args.size if args.value_size is None else args.value_size
-    if args.dtype not in ('int64', 'float64', 'bool'):
-        raise ValueError("Dtype must be either int64, float64, or bool, not {}".format(args.dtype))
+    if args.dtype not in TYPES:
+        raise ValueError("Dtype must be {}, not {}".format('/'.join(TYPES), args.dtype))
     ak.verbose = False
     ak.connect(args.hostname, args.port)
 
     if args.correctness_only:
-        check_correctness(args.dtype, args.randomize)
+        for dtype in TYPES:
+            check_correctness(dtype, args.randomize)
         sys.exit(0)
     
     print("size of index array = {:,}".format(args.index_size))

--- a/benchmarks/setops.py
+++ b/benchmarks/setops.py
@@ -5,6 +5,7 @@ import numpy as np
 import arkouda as ak
 
 OPS = ('intersect1d', 'union1d', 'setxor1d', 'setdiff1d')
+TYPES = ('int64',)
 
 def time_ak_setops(N_per_locale, trials, dtype):
     print(">>> arkouda setops")
@@ -79,7 +80,7 @@ def create_parser():
     parser.add_argument('port', type=int, help='Port of arkouda server')
     parser.add_argument('-n', '--size', type=int, default=10**8, help='Problem size: length of arrays A and B')
     parser.add_argument('-t', '--trials', type=int, default=1, help='Number of times to run the benchmark')
-    parser.add_argument('-d', '--dtype', default='int64', help='Dtype of arrays (int64)')
+    parser.add_argument('-d', '--dtype', default='int64', help='Dtype of array ({})'.format(', '.join(TYPES)))
     parser.add_argument('--numpy', default=False, action='store_true', help='Run the same operation in NumPy to compare performance.')
     parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')
     return parser
@@ -88,17 +89,15 @@ if __name__ == "__main__":
     import sys
     parser = create_parser()
     args = parser.parse_args()
-    if args.dtype == 'float64':
-        args.dtype = 'int64'
-        print('float64 is not supported, using int64')
-    if args.dtype != 'int64':
-        raise ValueError("Dtype must be int64, not {}".format(args.dtype))
+    if args.dtype not in TYPES:
+        raise ValueError("Dtype must be {}, not {}".format('/'.join(TYPES), args.dtype))
 
     ak.verbose = False
     ak.connect(args.hostname, args.port)
 
     if args.correctness_only:
-        check_correctness(args.dtype)
+        for dtype in TYPES:
+            check_correctness(dtype)
         sys.exit(0)
     
     print("array size = {:,}".format(args.size))

--- a/benchmarks/stream.py
+++ b/benchmarks/stream.py
@@ -4,6 +4,8 @@ import time, argparse
 import numpy as np
 import arkouda as ak
 
+TYPES = ('int64', 'float64')
+
 def time_ak_stream(N_per_locale, trials, alpha, dtype, random):
     print(">>> arkouda stream")
     cfg = ak.get_config()
@@ -80,7 +82,7 @@ def create_parser():
     parser.add_argument('port', type=int, help='Port of arkouda server')
     parser.add_argument('-n', '--size', type=int, default=10**8, help='Problem size: length of arrays A and B')
     parser.add_argument('-t', '--trials', type=int, default=6, help='Number of times to run the benchmark')
-    parser.add_argument('-d', '--dtype', default='float64', help='Dtype of arrays (int64 or float64)')
+    parser.add_argument('-d', '--dtype', default='float64', help='Dtype of arrays ({})'.format(', '.join(TYPES)))
     parser.add_argument('-r', '--randomize', default=False, action='store_true', help='Fill arrays with random values instead of ones')
     parser.add_argument('-a', '--alpha', default=1.0, help='Scalar multiple')
     parser.add_argument('--numpy', default=False, action='store_true', help='Run the same operation in NumPy to compare performance.')
@@ -91,18 +93,16 @@ if __name__ == "__main__":
     import sys
     parser = create_parser()
     args = parser.parse_args()
-    if args.dtype == 'int64':
-        args.alpha = ak.int64(args.alpha)
-    elif args.dtype == 'float64':
-        args.alpha = ak.float64(args.alpha)
-    else:
-        raise ValueError("Dtype must be either int64 or float64, not {}".format(args.dtype))
-
+    if args.dtype not in TYPES:
+        raise ValueError("Dtype must be {}, not {}".format('/'.join(TYPES), args.dtype))
+    args.alpha = getattr(ak, args.dtype)()
     ak.verbose = False
     ak.connect(args.hostname, args.port)
 
     if args.correctness_only:
-        check_correctness(args.alpha, args.dtype, args.randomize)
+        for dtype in TYPES:
+            alpha = getattr(ak, dtype)()
+            check_correctness(alpha, dtype, args.randomize)
         sys.exit(0)
     
     print("array size = {:,}".format(args.size))


### PR DESCRIPTION
Previously the CI testing used to assume all benchmarks would work with
int/float and manually specified some that should work with bools.
However, the setops benchmark only works with ints and future benchmarks
may have varied types, so instead of hardcoding this, just let the
benchmarks maintain the list of types they support and run them all in
correctness mode.

Also ensure that graph generation works during CI testing. It can be
tricky for to get the graph keys/names right, so check it during CI.

Resolves https://github.com/mhmerrill/arkouda/issues/395