### PR TITLE
Re-add mac CI testing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,6 +42,29 @@ jobs:
          ./benchmarks/run_benchmarks.py --correctness-only
          ./benchmarks/run_benchmarks.py --size=100 --gen-graphs
 
+  arkouda_tests_mac:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: |
+        brew install hdf5 zeromq
+        # brew install chapel@1.22.0 (except that isn't actually supported, so use sha with 1.22.0)
+        brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f305658fa8/Formula/chapel.rb
+    - name: Build/Install Arkouda
+      run: |
+        make
+        python3 -m pip install -e .[test]
+    - name: Arkouda make check
+      run: |
+        make check
+    - name: Arkouda unit tests
+      run: |
+        make test-python
+    - name: Arkouda benchmark --correctness-only
+      run: |
+         ./benchmarks/run_benchmarks.py --correctness-only
+
   unit_tests_linux:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
It was removed in #300 because the infrastructure seemed unstable, but
this might have caught portability issues in #406, so re-enable it to see
how stable things are.

I couldn't find an easy way to install a specific version with homebrew,
and so to pin to chapel 1.22.0 I followed this article:
https://itnext.io/how-to-install-an-older-brew-package-add141e58d32