### PR TITLE
Enhance Set Operations memory usage and performance

### DIFF
--- a/src/ArraySetops.chpl
+++ b/src/ArraySetops.chpl
@@ -80,7 +80,7 @@ module ArraySetops
     proc setxor1dHelper(a: [] ?t, b: [] t) {
       var aux = radixSortLSD_keys(concatset(a,b));
 
-      var sliceComp = sliceTail(aux) != sliceHead(aux);
+      var sliceComp = aux[aux.domain.interior(aux.domain.size-1)] != aux[aux.domain#(aux.domain.size-1)];
       
       // Concatenate a `true` onto each end of the array
       var flag = makeDistArray((sliceComp.size + 2), bool);
@@ -89,7 +89,7 @@ module ArraySetops
       flag[{1..#(sliceComp.size)}] = sliceComp;
       flag[sliceComp.size + 1] = true;
 
-      var mask = sliceTail(flag) & sliceHead(flag);
+      var mask = flag[flag.domain#(flag.size-1)] & flag[flag.domain.interior(flag.domain.size-1)]; 
 
       var ret = boolIndexer(aux, mask);
 

--- a/src/ArraySetops.chpl
+++ b/src/ArraySetops.chpl
@@ -80,7 +80,7 @@ module ArraySetops
     proc setxor1dHelper(a: [] ?t, b: [] t) {
       var aux = radixSortLSD_keys(concatset(a,b));
 
-      var sliceComp = aux[aux.domain.interior(aux.domain.size-1)] != aux[aux.domain#(aux.domain.size-1)];
+      var sliceComp = sliceHead(aux) != sliceTail(aux);
       
       // Concatenate a `true` onto each end of the array
       var flag = makeDistArray((sliceComp.size + 2), bool);
@@ -89,7 +89,7 @@ module ArraySetops
       flag[{1..#(sliceComp.size)}] = sliceComp;
       flag[sliceComp.size + 1] = true;
 
-      var mask = flag[flag.domain#(flag.size-1)] & flag[flag.domain.interior(flag.domain.size-1)]; 
+      var mask = sliceHead(flag) & sliceTail(flag); 
 
       var ret = boolIndexer(aux, mask);
 

--- a/src/ArraySetops.chpl
+++ b/src/ArraySetops.chpl
@@ -133,13 +133,16 @@ module ArraySetops
     // sorts resulting array and ensures that
     // values are unique
     proc union1d(a: [] int, b: [] int) {
-      var a1  = uniqueSort(a, false);
-      var b1  = uniqueSort(b, false);
-
-      var aux = concatset(a1, b1);
+      var aux;
+      // create a temporary scope to clean up temp arrays
+      {
+        var a1  = uniqueSort(a, false);
+        var b1  = uniqueSort(b, false);
+        aux = concatset(a1, b1);
+      }
 
       var ret = uniqueSort(aux, false);
-      
+
       return ret;
     }
 }

--- a/src/Indexing.chpl
+++ b/src/Indexing.chpl
@@ -14,7 +14,7 @@ module Indexing {
     use CommAggregation;
     
     // Return a slice of array `a` from `start` to `stop` by `stride`
-    proc sliceIndex(a: [?aD] ?t, start: int, stop: int, stride: int) {
+    proc sliceIndex(a: [] ?t, start: int, stop: int, stride: int) {
       var slice: range(stridable=true);
       
       slice = start..(stop-1) by stride;
@@ -26,17 +26,17 @@ module Indexing {
     }
 
     // helper to get an array without the first element
-    proc sliceTail(a: [?aD] ?t) {
+    proc sliceTail(a: [] ?t) {
       return sliceIndex(a, 1, a.size, 1);
     }
 
     // helper to get an array without the last element
-    proc sliceHead(a: [?aD] ?t) {
+    proc sliceHead(a: [] ?t) {
       return sliceIndex(a, 0, a.size - 1, 1);
     }
 
     // return an array of all values from array a whose index corresponds to a true value in array truth
-    proc boolIndexer(a: [?aD] ?t, truth: [aD] bool) {
+    proc boolIndexer(a: [] ?t, truth: [] bool) {
         var iv: [truth.domain] int = (+ scan truth);
         var pop = iv[iv.size-1];
         var ret = makeDistArray(pop, int);
@@ -50,7 +50,7 @@ module Indexing {
     }
 
     // concatenate 2 distributed arrays and return the result
-    proc concatset(a: [?aD] ?t, b: [?bD] t) {
+    proc concatset(a: [] ?t, b: [] t) {
       var ret = makeDistArray((a.size + b.size), t);
       
       ret[{0..#a.size}] = a;

--- a/test/SetopsSpeedTest.chpl
+++ b/test/SetopsSpeedTest.chpl
@@ -1,0 +1,77 @@
+use TestBase;
+
+use ArraySetops;
+
+config const NINPUTS = 10_000;
+config const MAX_VAL = 50_000;
+
+proc testIntersect1d(n:int) {
+  var d: Diags;
+  var a = makeDistArray(n, int);
+  var b = makeDistArray(n, int);
+  fillInt(a, 0, MAX_VAL);
+  fillInt(b, 0, MAX_VAL);
+
+  d.start();
+  var in1d = intersect1d(a,b,false);
+  d.stop(printTime=false);
+  return d.elapsed();
+}
+
+proc testSetDiff1d(n:int) {
+  var d: Diags;
+  var a = makeDistArray(n, int);
+  var b = makeDistArray(n, int);
+  fillInt(a, 0, MAX_VAL);
+  fillInt(b, 0, MAX_VAL);
+
+  d.start();
+  setdiff1d(a,b,false);
+  d.stop(printTime=false);
+  return d.elapsed();
+}
+
+proc testSetXor1d(n:int) {
+  var d: Diags;
+  var a = makeDistArray(n, int);
+  var b = makeDistArray(n, int);
+  fillInt(a, 0, MAX_VAL);
+  fillInt(b, 0, MAX_VAL);
+
+  d.start();
+  setxor1d(a,b,false);
+  d.stop(printTime=false);
+  return d.elapsed();
+}
+proc testUnion1d(n:int) {
+  var d: Diags;
+  var a = makeDistArray(n, int);
+  var b = makeDistArray(n, int);
+  fillInt(a, 0, MAX_VAL);
+  fillInt(b, 0, MAX_VAL);
+
+  d.start();
+  union1d(a,b);
+  d.stop(printTime=false);
+  return d.elapsed();
+}
+
+proc main() {
+  var a = makeDistArray(NINPUTS, int);
+  var b = makeDistArray(NINPUTS, int);
+  fillInt(a, 0, MAX_VAL);
+  fillInt(b, 0, MAX_VAL);
+
+  const elapsedIntersect = testIntersect1d(NINPUTS);
+  const elapsedDiff = testSetDiff1d(NINPUTS);
+  const elapsedXor = testSetXor1d(NINPUTS);
+  const elapsedUnion = testUnion1d(NINPUTS);
+
+  const MB:real = byteToMB(NINPUTS*8.0);
+  if printTimes {
+    writeln("intersect1d on %i elements (%.1dr MB) in %.2dr seconds (%.2dr MB/s)".format(NINPUTS, MB, elapsedIntersect, MB/elapsedIntersect));
+    writeln("setdiff1d on %i elements (%.1dr MB) in %.2dr seconds (%.2dr MB/s)".format(NINPUTS, MB, elapsedDiff, MB/elapsedDiff));
+    writeln("setxor1d on %i elements (%.1dr MB) in %.2dr seconds (%.2dr MB/s)".format(NINPUTS, MB, elapsedXor, MB/elapsedXor));
+    writeln("union1d on %i elements (%.1dr MB) in %.2dr seconds (%.2dr MB/s)".format(NINPUTS, MB, elapsedUnion, MB/elapsedUnion));
+  }
+}


### PR DESCRIPTION
Includes improvements to the changes that came in #392 and adds a speed test to test the performance of the set operations without having to remake Arkouda.
Improves speed of `intersect1d` by moving to an explicit `coforall` loop. Also, cuts down on memory usage in intersect1d, union1d, and setxor1d by accessing indices or arrays rather than creating temporary arrays to hold those copies and changes `Indexing.chpl` to reflect these changes as well.