### PR TITLE
improve union1d memory usage

### DIFF
--- a/src/ArraySetops.chpl
+++ b/src/ArraySetops.chpl
@@ -123,13 +123,6 @@ module ArraySetops
     // sorts resulting array and ensures that
     // values are unique
     proc union1d(a: [] int, b: [] int) {
-      var a1  = uniqueSort(a, false);
-      var b1  = uniqueSort(b, false);
-
-      var aux = concatset(a1, b1);
-
-      var ret = uniqueSort(aux, false);
-      
-      return ret;
+      return uniqueSort(concatset(uniqueSort(a,false), uniqueSort(b,false)), false);
     }
 }


### PR DESCRIPTION
Remove all temporary arrays from union1d to lower the memory usage