### PR TITLE
Lower union1d memory usage

### DIFF
--- a/src/ArraySetops.chpl
+++ b/src/ArraySetops.chpl
@@ -123,13 +123,11 @@ module ArraySetops
     // sorts resulting array and ensures that
     // values are unique
     proc union1d(a: [] int, b: [] int) {
-      var a1  = uniqueSort(a, false);
-      var b1  = uniqueSort(b, false);
-
-      var aux = concatset(a1, b1);
-
-      var ret = uniqueSort(aux, false);
-      
-      return ret;
+      var aux: [] int;
+      // Artificial scope to clean up temporary arrays
+      {
+        aux = concatset(uniqueSort(a,false), uniqueSort(b,false));
+      }
+      return uniqueSort(aux, false);
     }
 }

--- a/src/ArraySetops.chpl
+++ b/src/ArraySetops.chpl
@@ -123,7 +123,7 @@ module ArraySetops
     // sorts resulting array and ensures that
     // values are unique
     proc union1d(a: [] int, b: [] int) {
-      var aux: [] int;
+      var aux;
       // Artificial scope to clean up temporary arrays
       {
         aux = concatset(uniqueSort(a,false), uniqueSort(b,false));


### PR DESCRIPTION
High memory mark now significantly lower than previously, here are some figures gathered with array sizes of 10,000:

| time of measure | master | improvement |
| ----------- | -----: | ----: |
| mem at beginning     | 164592 | 164592 |
| mem high mark   | 588648 | 456232 |