### PR TITLE
Improve intersect1d memory usage and performance

### DIFF
--- a/src/ArraySetops.chpl
+++ b/src/ArraySetops.chpl
@@ -37,21 +37,25 @@ module ArraySetops
       return intersect1dHelper(a,b);
     }
 
-    // Get intersect of 2 arrays
-    // first concatenates the 2 arrays, then
-    // sorts arrays and removes all values that
-    // only occur once
-    proc intersect1dHelper(a: [] ?t, b: [] t) {
+    proc intersect1dHelper(a: [?D] ?t, b: [] t) {
       var aux = radixSortLSD_keys(concatset(a,b));
 
-      var head = sliceHead(aux);
-      var mask = head == sliceTail(aux);
-      
-      var int1d = boolIndexer(head, mask);
+      // All elements except the last
+      const ref head = aux[..D.high-1];
+
+      // All elements except the first
+      const ref tail = aux[D.low+1..];
+      var mask = head == tail;
+
+      var int1d;
+      // Extra scope to clean up temporary array
+      {
+        int1d = boolIndexer(aux[..D.high-1], mask);
+      }
 
       return int1d;
     }
-
+    
     // returns the exclusive-or of 2 arrays
     proc setxor1d(a: [] int, b: [] int, assume_unique: bool) {
       //if not unique, unique sort arrays then perform operation

--- a/src/ArraySetops.chpl
+++ b/src/ArraySetops.chpl
@@ -45,13 +45,9 @@ module ArraySetops
 
       // All elements except the first
       const ref tail = aux[D.low+1..];
-      var mask = head == tail;
+      const mask = head == tail;
 
-      var int1d;
-      // Extra scope to clean up temporary array
-      {
-        int1d = boolIndexer(aux[..D.high-1], mask);
-      }
+      const int1d = boolIndexer(head, mask);
 
       return int1d;
     }


### PR DESCRIPTION
Add refs and extra scope to intersect1d which has the following impacts:

Memory: significant improvements to the high mark of memory
`Memory.memoryUsed()` with 10,000 elements on a single locale 
| time of measure | master | improvement |
| ----------- | -----: | ----: |
| mem at beginning     | 310280 | 310280 |
| mem high mark   | 924285 | 618815 |

Performance: slight speed increase
Execution time of 1,00,000,000 elements on 16 locales in seconds (lower is better)
|  | master | improvement |
| ----------- | -----: | ----: |
| execution time (s) | 2.53 | 2.31 |