### PR TITLE
Improve setxor1d memory usage and performance

### DIFF
--- a/src/ArraySetops.chpl
+++ b/src/ArraySetops.chpl
@@ -68,16 +68,18 @@ module ArraySetops
     // sorts and removes all values that occur
     // more than once
     proc setxor1dHelper(a: [] ?t, b: [] t) {
-      var aux = radixSortLSD_keys(concatset(a,b));
+      const aux = radixSortLSD_keys(concatset(a,b));
+      const D = aux.domain;
 
-      var sliceComp = sliceTail(aux) != sliceHead(aux);
+      const sliceComp = aux[..D.high-1] != aux[D.low+1..];
       
       // Concatenate a `true` onto each end of the array
       var flag = makeDistArray((sliceComp.size + 2), bool);
+      const fD = flag.domain;
       
-      flag[0] = true;
-      flag[{1..#(sliceComp.size)}] = sliceComp;
-      flag[sliceComp.size + 1] = true;
+      flag[fD.low] = true;
+      flag[fD.low+1..#fD.high-1] = sliceComp;
+      flag[fD.high] = true;
 
       var mask = sliceTail(flag) & sliceHead(flag);
 

--- a/src/ArraySetops.chpl
+++ b/src/ArraySetops.chpl
@@ -69,16 +69,14 @@ module ArraySetops
     // more than once
     proc setxor1dHelper(a: [] ?t, b: [] t) {
       const aux = radixSortLSD_keys(concatset(a,b));
-      const D = aux.domain;
+      const ref D = aux.domain;
 
-      const sliceComp = aux[..D.high-1] != aux[D.low+1..];
-      
       // Concatenate a `true` onto each end of the array
-      var flag = makeDistArray((sliceComp.size + 2), bool);
-      const fD = flag.domain;
+      var flag = makeDistArray(aux.size+1, bool);
+      const ref fD = flag.domain;
       
       flag[fD.low] = true;
-      flag[fD.low+1..#fD.high-1] = sliceComp;
+      flag[fD.low+1..fD.high-1] = aux[..D.high-1] != aux[D.low+1..];
       flag[fD.high] = true;
 
       var mask;

--- a/src/ArraySetops.chpl
+++ b/src/ArraySetops.chpl
@@ -81,7 +81,10 @@ module ArraySetops
       flag[fD.low+1..#fD.high-1] = sliceComp;
       flag[fD.high] = true;
 
-      var mask = sliceTail(flag) & sliceHead(flag);
+      var mask;
+      {
+        mask = sliceTail(flag) & sliceHead(flag);
+      }
 
       var ret = boolIndexer(aux, mask);
 


### PR DESCRIPTION
Added some changes to the slicing used in `setxor1d` and added an extra scope to improve performance and memory usage and also moved `var` to `const` where possible.

Memory: significant improvements to the high mark of memory
`Memory.memoryUsed()` with 10,000 elements on a single locale 
| time of measure | master | improvement |
| ----------- | -----: | ----: |
| memory created in function | 793763 | 447371 |

Performance: slight speed increase
Execution time of 1,000,000,000 elements on 16 locales in seconds (lower is better)
|  | master | improvement |
| ----------- | -----: | ----: |
| execution time (s) | 2.61 | 2.38 |