### PR TITLE
Fix intersect bug using the wrong domain

### DIFF
--- a/src/ArraySetops.chpl
+++ b/src/ArraySetops.chpl
@@ -37,19 +37,17 @@ module ArraySetops
       return intersect1dHelper(a,b);
     }
 
-    proc intersect1dHelper(a: [?D] ?t, b: [] t) {
+    proc intersect1dHelper(a: [] ?t, b: [] t) {
       var aux = radixSortLSD_keys(concatset(a,b));
 
       // All elements except the last
-      const ref head = aux[..D.high-1];
+      const ref head = aux[..aux.domain.high-1];
 
       // All elements except the first
-      const ref tail = aux[D.low+1..];
+      const ref tail = aux[aux.domain.low+1..];
       const mask = head == tail;
 
-      const int1d = boolIndexer(head, mask);
-
-      return int1d;
+      return boolIndexer(head, mask);
     }
     
     // returns the exclusive-or of 2 arrays


### PR DESCRIPTION
This bug would cause the call of `[..D.high-1]` to use only the elements of one less than the `a` parameter, when it needed to be checking to be 1 less than `aux` which is the concatenation of the two, so it was using the wrong domain.

This bug slipped through the current testing, but this should fix it. Also, I have a branch with updated set operations testing that I will open a PR for when I am fully confident in it, also was hoping to get this in first because the current main will fail vs my updated testing as is.