### PR TITLE
Improve filename extension detection in write1DDistArray

### DIFF
--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -1,6 +1,7 @@
 module GenSymIO {
   use HDF5;
   use IO;
+  use Path;
   use MultiTypeSymbolTable;
   use MultiTypeSymEntry;
   use ServerErrorStrings;
@@ -697,7 +698,7 @@ module GenSymIO {
     const fields = filename.split(".");
     var prefix:string;
     var extension:string;
-    if fields.size == 1 {
+    if fields.size == 1 || fields[fields.domain.high].count(pathSep) > 0 {
       prefix = filename;
       extension = "";
     } else {


### PR DESCRIPTION
Previously, the code was just splitting on `.` and assuming anything to
the right of that delimiter was an extension, but that's not always
true. In particular in some of our nightly testing we have directories
with `.` in them, so update the check to not consider something an
extension if it has a path separator in it.

For example our nightly testing path to arkouda is something like
`performance-test-perf.chapcs.arkouda/test/studies/arkouda/arkouda`,
where the `.` in `performance-test-perf.chapcs.arkouda` was skewing this
check previously.