### PR TITLE
Capture stderr in lshdfMsg

### DIFF
--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -125,7 +125,6 @@ module GenSymIO {
   }
 
   proc lshdfMsg(cmd: string, payload: bytes, st: borrowed SymTab): string throws {
-    write("In lsdhdfMsg()");
     // reqMsg: "lshdf [<json_filename>]"
     use Spawn;
     const tmpfile = "/tmp/arkouda.lshdf.output";
@@ -151,7 +150,7 @@ module GenSymIO {
       if exists(tmpfile) {
         remove(tmpfile);
       }
-      var cmd = try! "h5ls \"%s\" > \"%s\"".format(filename, tmpfile);
+      var cmd = try! "h5ls \"%s\" > \"%s\" 2>&1".format(filename, tmpfile);
       var sub = spawnshell(cmd);
       // sub.stdout.readstring(repMsg);
       sub.wait();


### PR DESCRIPTION
Previously, lshdfMsg was doing something like `h5ls in_file > out_file`
so stderr was lost, which made it hard to identify failures in our
nightly testing. Update it so that stderr is written to the output file
as well and then if there are errors we'll report them back to the user.

In our nightly testing we used to just see `Error:` and now we get
`Error: /bin/sh: h5ls: command not found` (which helps us figure out
that the error is on our end with h5ls not being in our PATH)