### PR TITLE
Make the aggregation buffer size selectable with an env var

### DIFF
--- a/src/CommAggregation.chpl
+++ b/src/CommAggregation.chpl
@@ -6,8 +6,8 @@ module CommAggregation {
   // TODO these parameters need to be tuned and size should be user-settable at
   // creation time. iters before yield should be based on numLocales & buffSize
   private config const maxItersBeforeYield = 4096;
-  private config const dstBuffSize = 4096;
-  private config const srcBuffSize = 4096;
+  private config const dstBuffSize = getEnvInt("ARKOUDA_SERVER_AGGREGATION_DST_BUFF_SIZE", 4096);
+  private config const srcBuffSize = getEnvInt("ARKOUDA_SERVER_AGGREGATION_SRC_BUFF_SIZE", 4096);
 
 
   /* Creates a new destination aggregator (dst/lhs will be remote). */
@@ -240,5 +240,12 @@ module CommAggregation {
       compilerWarning("Missing optimized unorderedCopy for " + dst.type:string);
       dst = src;
     }
+  }
+
+  proc getEnvInt(name: string, default: int): int {
+    extern proc getenv(name : c_string) : c_string;
+    var strval = getenv(name.localize().c_str()): string;
+    if strval.isEmpty() { return default; }
+    return try! strval: int;
   }
 }


### PR DESCRIPTION
Add support for `ARKOUDA_SERVER_AGGREGATION_DST_BUFF_SIZE` and
`ARKOUDA_SERVER_AGGREGATION_SRC_BUFF_SIZE` to allow setting the buffer
size as an environment variable instead of a command line option. This
makes it easier to experiment with buffer sizes when using the
testing/benchmarking infrastructure.