### PR TITLE
Track the emitted code size in nightly perf graphs

### DIFF
--- a/benchmarks/graph_infra/arkouda-comp.graph
+++ b/benchmarks/graph_infra/arkouda-comp.graph
@@ -3,3 +3,9 @@ graphkeys: Compile Time
 files: comp-time.dat
 graphtitle: Build Time
 ylabel: Time (sec)
+
+perfkeys: Statements emitted:
+graphkeys: Statements Emitted
+files: emitted-code-size.dat
+graphtitle:  Emitted Code Size
+ylabel: Statements

--- a/benchmarks/graph_infra/emitted-code-size.perfkeys
+++ b/benchmarks/graph_infra/emitted-code-size.perfkeys
@@ -1,0 +1,1 @@
+Statements emitted:

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -125,6 +125,11 @@ def main():
             with open (comp_file, 'r') as f:
                 out = f.read()
             add_to_dat('comp-time', out, config_dat_dir, args.graph_infra)
+        emitted_code_file = os.getenv('ARKOUDA_EMITTED_CODE_SIZE_FILE', '')
+        if os.path.isfile(emitted_code_file):
+            with open (emitted_code_file, 'r') as f:
+                out = f.read()
+            add_to_dat('emitted-code-size', out, config_dat_dir, args.graph_infra)
         generate_graphs(args)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Track how many statements the compiler is generating. Similar to #342,
but instead of tracking build time, track how much code is generated.