### PR TITLE
Build documentation as part of CI testing     

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,20 @@ jobs:
       run: |
         ! git --no-pager grep -n $'\t' -- '*.chpl'
 
+  docs:
+    runs-on: ubuntu-latest
+    container:
+      image: chapel/chapel:1.22.0
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: |
+        apt-get update && apt-get install -y python3-pip
+        python3 -m pip install -e .[dev]
+    - name: Arkouda make doc
+      run: |
+        make doc
+
   arkouda_tests_linux:
     runs-on: ubuntu-latest
     strategy:

--- a/src/Extremas.chpl
+++ b/src/Extremas.chpl
@@ -8,7 +8,7 @@ module Extremas {
   use Sort;
 
 /*
-:record: `KExtreme` data structure that is used
+:record:`KExtreme` data structure that is used
 to track the minimum or maximum ``size``
 values that are in an array. Acts similar
 to a heap data structure, but can be

--- a/src/KReduce.chpl
+++ b/src/KReduce.chpl
@@ -2,7 +2,7 @@ module KReduce {
   use Extremas;
 
  /*
-    :class: `KReduce` is a user defined reduction. 
+    :class:`KReduce` is a user defined reduction.
     Returns array of the k extreme values of an array of type eltType.
     Whether it will be the max or min values is specified through the "isMin" field (true gives min values, false gives max values).
    


### PR DESCRIPTION
 Run `make doc` as part of CI testing and fix some spacing that caused the server doc build to fail.