### PR TITLE
Fix brew install of Chapel 1.22 in mac CI testing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -64,7 +64,9 @@ jobs:
       run: |
         brew install hdf5 zeromq
         # brew install chapel@1.22.0 (except that isn't actually supported, so use sha with 1.22.0)
-        brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f305658fa8/Formula/chapel.rb
+        CHAPEL_FORMULA=$(mktemp -d)/chapel.rb
+        curl -fsSL https://raw.githubusercontent.com/Homebrew/homebrew-core/f305658fa8/Formula/chapel.rb -o $CHAPEL_FORMULA
+        brew install $CHAPEL_FORMULA
     - name: Build/Install Arkouda
       run: |
         make


### PR DESCRIPTION
There's no direct way to install a specific version of software with
brew that I can find, but we want to pin to Chapel 1.22.0 in order to
test with the Chapel release Arkouda officially supports. Brew used to
be able to install the 1.22.0 formula directly from a URL, but that is
longer supported for security reasons, so instead `curl` the file
locally and do a local install.