### PR TITLE
Improve behavior of extrema_test.py when there's a runtime error

### DIFF
--- a/tests/extrema_test.py
+++ b/tests/extrema_test.py
@@ -56,6 +56,7 @@ def run_test(runMin=True, isInd=True, verbose=True):
                 npres = np.sort(aka.to_ndarray())[-K:] # last K elements from sorted array
     except RuntimeError as E:
         if verbose: print("Arkouda error: ", E)
+        return 1
 
     failures += compare_results(akres, npres)
     


### PR DESCRIPTION
Previously, it would report the error, but then try to use undefined
vars in compare_results.