### PR TITLE
Fix some bugs in the mink/maxk implementation

### DIFF
--- a/src/Extremas.chpl
+++ b/src/Extremas.chpl
@@ -47,30 +47,26 @@ to increase the efficiency of the merge step.
     // it is an encountered extreme
     proc push(val: (eltType, int)) {
 
-      // Common case where _data is a heap
-      if !isSorted {
-        const shouldAdd = if isMinReduction then val(0)<_data[0](0) else val(0)>_data[0](0);
-        const shouldAddEmpty = (numEmpty>0) && if isMinReduction then
-          _data[0](0)==max(eltType) else _data[0](0)==min(eltType);
-
-        if shouldAddEmpty {
-          _data[numEmpty+1] = val;
-          numEmpty-=1;
-        } else if shouldAdd {
-          _data[0] = val;
-          heapifyDown();
-        }
-      } else {
-        // Uncommon for an accumulate to be called after combining, so does not
-        // need to be very fast/optimized.
-        if isMinReduction && val < _data[dom.high] {
-          _data[dom.high] = val;
-          sort(_data);
-        } else if !isMinReduction && val > _data[dom.low] {
-          _data[dom.low] = val;
-          sort(_data);
-        }
+      // Accumulate/push can be called after combine/merge. This routine
+      // expects the data to be a heap and not sorted, so it would fail if we
+      // tried to insert now. The way Arkouda uses this, val will be the
+      // identity values, so we can ignore it.
+      if isSorted {
+        const identity = if isMinReduction then (max(eltType), -1) else (min(eltType), -1);
+        assert(val == identity);
         return;
+      }
+
+      const shouldAdd = if isMinReduction then val(0)<_data[0](0) else val(0)>_data[0](0);
+      const shouldAddEmpty = (numEmpty>0) && if isMinReduction then
+        _data[0](0)==max(eltType) else _data[0](0)==min(eltType);
+
+      if shouldAddEmpty {
+        _data[numEmpty+1] = val;
+        numEmpty-=1;
+      } else if shouldAdd {
+        _data[0] = val;
+        heapifyDown();
       }
     }
 

--- a/src/Extremas.chpl
+++ b/src/Extremas.chpl
@@ -46,16 +46,31 @@ to increase the efficiency of the merge step.
     // instance, only pushes a value if
     // it is an encountered extreme
     proc push(val: (eltType, int)) {
-      const shouldAdd = if isMinReduction then val(0)<_data[0](0) else val(0)>_data[0](0);
-      const shouldAddEmpty = (numEmpty>0) && if isMinReduction then
-        _data[0](0)==max(eltType) else _data[0](0)==min(eltType);
 
-      if shouldAddEmpty {
-        _data[numEmpty+1] = val;
-        numEmpty-=1;
-      } else if shouldAdd {
-        _data[0] = val;
-        heapifyDown();
+      // Common case where _data is a heap
+      if !isSorted {
+        const shouldAdd = if isMinReduction then val(0)<_data[0](0) else val(0)>_data[0](0);
+        const shouldAddEmpty = (numEmpty>0) && if isMinReduction then
+          _data[0](0)==max(eltType) else _data[0](0)==min(eltType);
+
+        if shouldAddEmpty {
+          _data[numEmpty+1] = val;
+          numEmpty-=1;
+        } else if shouldAdd {
+          _data[0] = val;
+          heapifyDown();
+        }
+      } else {
+        // Uncommon for an accumulate to be called after combining, so does not
+        // need to be very fast/optimized.
+        if isMinReduction && val < _data[dom.high] {
+          _data[dom.high] = val;
+          sort(_data);
+        } else if !isMinReduction && val > _data[dom.low] {
+          _data[dom.low] = val;
+          sort(_data);
+        }
+        return;
       }
     }
 

--- a/src/KReduce.chpl
+++ b/src/KReduce.chpl
@@ -67,6 +67,7 @@ module KReduce {
     }
 
     proc generate() {
+      v.doSort();
       return v;
     }
 

--- a/src/KReduce.chpl
+++ b/src/KReduce.chpl
@@ -67,7 +67,7 @@ module KReduce {
     }
 
     proc generate() {
-      v.doSort();
+      if !v.isSorted then v.doSort();
       return v;
     }
 


### PR DESCRIPTION
The mink/maxk code maintains a heap while accumulating reduction values
and then as an optimization at the end it gets rid of the heap and sorts
to improve how quickly different tasks can merge their mink/maxk data.
However, it's possible for some accumulation to happen after combining, so we
need to handle that case. For arkouda's use case it's only ever doing final
accumulations with the identity value, so we can just ignore them.

See https://github.com/chapel-lang/chapel/issues/16459 for more context