### PR TITLE
Add some explicit uses of CPtr module

### DIFF
--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -6,6 +6,8 @@ module ArgSortMsg
 {
     use ServerConfig;
     
+    use CPtr;
+
     use Time only;
     use Math only;
     use Sort only;

--- a/src/CommAggregation.chpl
+++ b/src/CommAggregation.chpl
@@ -1,5 +1,6 @@
 module CommAggregation {
   use SysCTypes;
+  use CPtr;
   use UnorderedCopy;
   private use CommPrimitives;
 

--- a/src/CommPrimitives.chpl
+++ b/src/CommPrimitives.chpl
@@ -1,4 +1,6 @@
 module CommPrimitives {
+  use CPtr;
+
   inline proc getAddr(const ref p): c_ptr(p.type) {
     // TODO can this use c_ptrTo?
     return __primitive("_wide_get_addr", p): c_ptr(p.type);

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -1,6 +1,7 @@
 module GenSymIO {
     use HDF5;
     use IO;
+    use CPtr;
     use Path;
     use MultiTypeSymbolTable;
     use MultiTypeSymEntry;

--- a/src/RadixSortLSD.chpl
+++ b/src/RadixSortLSD.chpl
@@ -21,6 +21,7 @@ module RadixSortLSD
     use AryUtil;
     use CommAggregation;
     use IO;
+    use CPtr;
 
     inline proc getBitWidth(a: [?aD] int): (int, bool) {
       var aMin = min reduce a;

--- a/src/SegStringSort.chpl
+++ b/src/SegStringSort.chpl
@@ -3,6 +3,7 @@ module SegStringSort {
   use Sort;
   use Time;
   use IO;
+  use CPtr;
   use CommAggregation;
   use PrivateDist;
 

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -1,5 +1,6 @@
 module SegmentedArray {
   use AryUtil;
+  use CPtr;
   use MultiTypeSymbolTable;
   use MultiTypeSymEntry;
   use CommAggregation;

--- a/src/SipHash.chpl
+++ b/src/SipHash.chpl
@@ -1,6 +1,7 @@
 module SipHash {
   private use CommPrimitives;
   private use AryUtil;
+  private use CPtr;
   
   param cROUNDS = 2;
   param dROUNDS = 4;


### PR DESCRIPTION
We are making some rearrangements in Chapel modules to stop leaking the `CPtr` symbol into the user's code. This would mean modules that needs stuff from it need to `use`/`import` it. This PR adds `use CPtr` to several modules.

Those changes in Chapel haven't been merged yet, we'll wait for this PR to go in so that we don't get noise from the nightlies. PR against Chapel upstream: https://github.com/chapel-lang/chapel/pull/16451

This PR builds on my branch of Chapel locally with ARKOUDA_QUICK_COMPILE