### PR TITLE
Optimize SrcAggregator by caching remote allocations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,11 @@ ifneq ($(CHPL_VERSION_OK),yes)
 	$(error Chapel 1.22.0 or newer is required)
 endif
 
+CHPL_VERSION_122 := $(shell test $(CHPL_MINOR) -eq 22 && echo yes)
+ifeq ($(CHPL_VERSION_122),yes)
+CHPL_FLAGS += --instantiate-max 512
+endif
+
 ZMQ_CHECK = $(DEP_INSTALL_DIR)/checkZMQ.chpl
 check-zmq: $(ZMQ_CHECK)
 	@echo "Checking for ZMQ"


### PR DESCRIPTION
Optimize SrcAggregator by caching remote allocations

This is similar to #485. Previously, the SrcAggregator would allocate
remote arrays in the same on-stmt that would process the buffer. This
led to a lot of repeated array creation/destruction and significantly
increased the lifetime of the remote task. By separately allocating the
remote buffers and caching them, this reduces the amount of allocations
and reduces the lifetime of the remote task.

This results in some non-trivial performance improvements, especially on
high core count systems. We see a 7x improvement for 8 GiB gather on 32
nodes of a 128 core HDR IB system.

Scalability Graphs:
---

Benchmark results for gather were collected with Chapel 1.22 for the
default problem size (3/4 GiB arrays) and a large problem size (8 GiB
arrays) on 2 systems:
 - 32 node 56Gb/s FDR IB with 36 cores per node
 - 32 node 200Gb/s HDR IB with 128 cores per node

#### FDR IB:

Consistent improvements for small and large problem size. 

<details>

![ak-gather-perf-cs-fdr](https://user-images.githubusercontent.com/1588337/94833278-f26f4900-03dc-11eb-979a-ed522e6ea63a.png)
![ak-gather-perf-cs-fdr-lg](https://user-images.githubusercontent.com/1588337/94833284-f4d1a300-03dc-11eb-8eb7-8f490454b513.png)

</details>

#### HDR IB:

Consistent improvements for small and large problem size. The small
problem size still starts to flatline at 32 nodes, so there is almost
certainly more that can be optimized.

<details>

![ak-gather-perf-cs-hdr](https://user-images.githubusercontent.com/1588337/94833303-fac78400-03dc-11eb-80e7-638aafa6a953.png)
![ak-gather-perf-cs-hdr-lg](https://user-images.githubusercontent.com/1588337/94833312-fc914780-03dc-11eb-9c3e-bb660b814823.png)

</details>