### PR TITLE
Enable SrcAggregator under ugni

### DIFF
--- a/src/CommAggregation.chpl
+++ b/src/CommAggregation.chpl
@@ -22,8 +22,7 @@ module CommAggregation {
 
   /* Creates a new source aggregator (src/rhs will be remote). */
   proc newSrcAggregator(type elemType, param useUnorderedCopy=false) {
-    // SrcAggregator is not currently optimized for ugni
-    if CHPL_COMM == "none" || CHPL_COMM =="ugni" || useUnorderedCopy {
+    if CHPL_COMM == "none" || useUnorderedCopy {
       return new SrcUnorderedAggregator(elemType);
     } else {
       return new SrcAggregator(elemType);
@@ -312,7 +311,6 @@ module CommAggregation {
         assert(lArr.domain.low == 0);
         assert(lArr.locale.id == here.id);
       }
-      // TODO align up to 8-byte boundary to avoid misaligned comm perf hit
       const byte_size = size:size_t * c_sizeof(elemType);
       CommPrimitives.PUT(c_ptrTo(lArr[0]), loc, data, byte_size);
     }
@@ -324,7 +322,6 @@ module CommAggregation {
         assert(lArr.domain.low == 0);
         assert(lArr.locale.id == here.id);
       }
-      // TODO align up to 8-byte boundary to avoid misaligned comm perf hit
       const byte_size = size:size_t * c_sizeof(elemType);
       CommPrimitives.GET(c_ptrTo(lArr[0]), loc, data, byte_size);
     }


### PR DESCRIPTION
Previously, the SrcAggregator was not used under ugni because of memory
pressure at scale. Those issues were resolved in #503.

At 256 nodes for the default problem size (3/4 GiB arrays) this improves
the performance for gathers of int/real by ~1.5x, and gathers of bools
by ~25x. Previously, we were just using unorderedCopy which offers good
performance on XC, but aggregation is better now. For the bool case,
even though we were calling unorderedCopy the Aries NIC can't do RDMA on
things that aren't 4-byte aligned, so we had to fall back to a slow path
that used ordered bounce-buffers. Because of this aggregation offers a
much more significant improvement for bools.

There may still be unaligned comm for the last flush of the bool
aggregation buffer, but the common case will be aligned and it's a bulk
transfer anyway so the performance hit isn't very noticeable. For that
reason I just removed some TODOs to align the flush, instead of rounding
the transfer up.

Perf results for gather on 256 nodes using the default problem size (3/4
GiB arrays):

| type  | before      | after       |
| ----- | ----------: | ----------: |
| bool  |   2.1 GiB/s |  55.3 GiB/s |
| int64 | 271.7 GiB/s | 398.8 GiB/s |

Note that the time for bool/int gather is the same now, the bool rate is
just lower since we're transferring 1/8 as much data.

Scalability graphs for int64 gather:
---

<details> 

![ak-gather-perf-xc](https://user-images.githubusercontent.com/1588337/94954794-9c230880-04b7-11eb-985b-41653380086c.png)
![ak-gather-perf-xc-lg](https://user-images.githubusercontent.com/1588337/94954801-9deccc00-04b7-11eb-8456-1e0101030137.png)

</details>

Resolves #318