### PR TITLE
Optimize aggregators by yielding more often

### DIFF
--- a/src/CommAggregation.chpl
+++ b/src/CommAggregation.chpl
@@ -2,11 +2,10 @@ module CommAggregation {
   use SysCTypes;
   use CPtr;
   use UnorderedCopy;
-  private use CommPrimitives;
+  use CommPrimitives;
 
-  // TODO these parameters need to be tuned and size should be user-settable at
-  // creation time. iters before yield should be based on numLocales & buffSize
-  private config const maxItersBeforeYield = 4096;
+  // TODO should tune these values at startup
+  private config const yieldFrequency = getEnvInt("ARKOUDA_SERVER_AGGREGATION_YIELD_FREQUENCY", 1024);
   private config const dstBuffSize = getEnvInt("ARKOUDA_SERVER_AGGREGATION_DST_BUFF_SIZE", 4096);
   private config const srcBuffSize = getEnvInt("ARKOUDA_SERVER_AGGREGATION_SRC_BUFF_SIZE", 4096);
 
@@ -77,7 +76,7 @@ module CommAggregation {
       // flushing their buffers.
       if bufferIdx == bufferSize {
         _flushBuffer(loc, bufferIdx, freeData=false);
-      } else if itersSinceYield % maxItersBeforeYield == 0 {
+      } else if itersSinceYield % yieldFrequency == 0 {
         chpl_task_yield();
         itersSinceYield = 0;
       }
@@ -180,7 +179,7 @@ module CommAggregation {
 
       if bufferIdx == bufferSize {
         _flushBuffer(loc, bufferIdx, freeData=false);
-      } else if itersSinceYield % maxItersBeforeYield == 0 {
+      } else if itersSinceYield % yieldFrequency == 0 {
         chpl_task_yield();
         itersSinceYield = 0;
       }

--- a/src/CommAggregation.chpl
+++ b/src/CommAggregation.chpl
@@ -38,7 +38,7 @@ module CommAggregation {
     type aggType = (c_ptr(elemType), elemType);
     const bufferSize = dstBuffSize;
     const myLocaleSpace = LocaleSpace;
-    var itersSinceYield: int;
+    var opsUntilYield = yieldFrequency;
     var lBuffers: [myLocaleSpace] [0..#bufferSize] aggType;
     var rBuffers: [myLocaleSpace] remoteBuffer(aggType);
     var bufferIdxs: [myLocaleSpace] int;
@@ -76,11 +76,13 @@ module CommAggregation {
       // flushing their buffers.
       if bufferIdx == bufferSize {
         _flushBuffer(loc, bufferIdx, freeData=false);
-      } else if itersSinceYield % yieldFrequency == 0 {
+        opsUntilYield = yieldFrequency;
+      } else if opsUntilYield == 0 {
         chpl_task_yield();
-        itersSinceYield = 0;
+        opsUntilYield = yieldFrequency;
+      } else {
+        opsUntilYield -= 1;
       }
-      itersSinceYield += 1;
     }
 
     proc _flushBuffer(loc: int, ref bufferIdx, freeData) {
@@ -139,7 +141,7 @@ module CommAggregation {
     type aggType = c_ptr(elemType);
     const bufferSize = srcBuffSize;
     const myLocaleSpace = LocaleSpace;
-    var itersSinceYield: int;
+    var opsUntilYield = yieldFrequency;
     var dstAddrs: [myLocaleSpace][0..#bufferSize] aggType;
     var lSrcAddrs: [myLocaleSpace][0..#bufferSize] aggType;
     var lSrcVals: [myLocaleSpace][0..#bufferSize] elemType;
@@ -179,11 +181,13 @@ module CommAggregation {
 
       if bufferIdx == bufferSize {
         _flushBuffer(loc, bufferIdx, freeData=false);
-      } else if itersSinceYield % yieldFrequency == 0 {
+        opsUntilYield = yieldFrequency;
+      } else if opsUntilYield == 0 {
         chpl_task_yield();
-        itersSinceYield = 0;
+        opsUntilYield = yieldFrequency;
+      } else {
+        opsUntilYield -= 1;
       }
-      itersSinceYield += 1;
     }
 
     proc _flushBuffer(loc: int, ref bufferIdx, freeData) {


### PR DESCRIPTION
Yield every 1024 operations instead of 4096. We yield occasionally so
we're not blocking other tasks from flushing their buffers. Chapel will
yield while doing on-statements, so this is just an optimization to help
remote tasks make progress sooner. The old value was tuned a while back
and some recent aggregation optimizations mean yielding more often
benefits performance.

This improves gather and scatter benchmarks by ~5% or so. Longer term we
should probably autotune the buffer sizes and yield frequency, but for
now this is a better default.