### PR TITLE
initial implementation of the ak.clear() function and a test for it

### DIFF
--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -6,7 +6,7 @@ from arkouda.dtypes import *
 from arkouda.dtypes import structDtypeCodes, NUMBER_FORMAT_STRINGS
 from arkouda.logger import getArkoudaLogger
 
-__all__ = ["pdarray", "info", "any", "all", "is_sorted", "sum", "prod", 
+__all__ = ["pdarray", "info", "clear", "any", "all", "is_sorted", "sum", "prod", 
            "min", "max", "argmin", "argmax", "mean", "var", "std", "mink", 
            "maxk", "argmink", "argmaxk"]
 
@@ -969,6 +969,21 @@ def info(pda : Union[pdarray, str]) -> str:
         return generic_msg("info {}".format(pda))
     else:
         raise TypeError("info: must be pdarray or string {}".format(pda))
+
+def clear() -> None:
+    """
+    Send a no-op message just to gather round trip time
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------  
+    RuntimeError
+        Raised if there is a server-side error in executing clear request
+    """
+    generic_msg("clear")
 
 def any(pda : 'pdarray') -> bool:
     """

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -972,7 +972,7 @@ def info(pda : Union[pdarray, str]) -> str:
 
 def clear() -> None:
     """
-    Send a no-op message just to gather round trip time
+    Send a clear message to clear all unregistered data from the server symbol table
 
     Returns
     -------

--- a/arkouda/registration.py
+++ b/arkouda/registration.py
@@ -4,7 +4,7 @@ from arkouda.pdarrayclass import pdarray, create_pdarray
 
 global verbose
 
-__all__ = ["register_pda","attach_pda","unregister_pda"]
+__all__ = ["register_pda", "attach_pda", "unregister_pda"]
 
 def register_pda(pda : pdarray, user_defined_name : str) -> pdarray:
     """

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,7 @@ testpaths =
     tests/client_test.py
     tests/coargsort_test.py
     tests/compare_test.py
+    tests/clear_test.py
     tests/dtypes_tests.py
     tests/groupby_test.py
     tests/nan_test.py

--- a/src/MsgProcessing.chpl
+++ b/src/MsgProcessing.chpl
@@ -83,6 +83,25 @@ module MsgProcessing
     }
 
     /* 
+    Clear all unregistered symbols and associated data from sym table
+    
+    :arg reqMsg: request containing (cmd)
+    :type reqMsg: string 
+
+    :arg st: SymTab to act on
+    :type st: borrowed SymTab 
+
+    :returns: (string)
+     */
+    proc clearMsg(cmd: string, payload: bytes, st: borrowed SymTab): string throws {
+        var repMsg: string; // response message
+        var (_) = payload.decode().splitMsgToTuple(1); // split request into fields
+        if v {try! writeln("%s".format(cmd));try! stdout.flush();}
+        st.clear();
+        return "success";
+    }
+
+    /* 
     Takes the name of data referenced in a msg and searches for the name in the provided sym table.
     Returns a string of info for the sym entry that is mapped to the provided name.
 

--- a/src/MultiTypeSymbolTable.chpl
+++ b/src/MultiTypeSymbolTable.chpl
@@ -146,6 +146,14 @@ module MultiTypeSymbolTable
                 if (v) {writeln("deleteEntry: unkown symbol ",name);try! stdout.flush();}
             }
         }
+
+        /*
+        Clears all unregistered entries from the symTable
+        */
+        proc clear() {
+            for n in tab { deleteEntry(n); }
+        }
+
         
         /*
         Returns the sym entry associated with the provided name, if the sym entry exists

--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -261,6 +261,7 @@ proc main() {
                 when "register"          {repMsg = registerMsg(cmd, payload, st);}
                 when "attach"            {repMsg = attachMsg(cmd, payload, st);}
                 when "unregister"        {repMsg = unregisterMsg(cmd, payload, st);}
+                when "clear"             {repMsg = clearMsg(cmd, payload, st);}
                 when "connect" {
                     if authenticate {
                         repMsg = "connected to arkouda server tcp://*:%t as user %s with token %s".format(ServerPort,user,token);

--- a/tests/clear_test.py
+++ b/tests/clear_test.py
@@ -1,0 +1,39 @@
+from context import arkouda as ak
+from base_test import ArkoudaTest
+
+SIZE = 10
+
+def run_test() -> int:
+    a = ak.ones(SIZE,dtype=ak.float64)
+    b = ak.ones(SIZE,dtype=ak.int64)
+    d = ak.register_pda(a,'test_float64')
+    e = ak.register_pda(b,'test_int64')
+    ak.clear()
+
+    # will get decremented to 0 if test is successful
+    result = 2
+
+    try:
+        a+b
+    except:
+        result -= 1
+
+    try:
+        d+e
+        result -= 1
+    except:
+        result = 100
+
+    ak.unregister_pda(d)
+    ak.unregister_pda(e)
+    return result
+
+class ClearTest(ArkoudaTest):
+    def test_clear(self):
+        '''
+        Executes run_test and asserts whether there are any errors
+        
+        :return: None
+        :raise: AssertionError if there are any errors encountered in run_test for set operations
+        '''
+        self.assertEqual(0, run_test())


### PR DESCRIPTION
Fixes #499 
This PR implements the `ak.clear()` function which clears the server symbol table of all unregistered data.