### PR TITLE
Use SysError explicitly in Errors.chpl

### DIFF
--- a/src/Errors.chpl
+++ b/src/Errors.chpl
@@ -1,5 +1,7 @@
 module Errors {
 
+    use SysError;
+
     /*
      * Generates an error message that provides a fuller context to the error
      * by including the line number, proc name, and module name from which the 


### PR DESCRIPTION
https://github.com/mhmerrill/arkouda/pull/513 started using `FileNotFoundError`,
however didn't add a `use SysError`. We need to have that `use` with Chapel
1.23, because of https://github.com/chapel-lang/chapel/pull/16451.

This caused some nightly failures.

I am able to build Arkouda with quick compile with Chapel master with this PR.
