### PR TITLE
Remove parSafe from some lists that don't need it

### DIFF
--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -1169,7 +1169,7 @@ module GenSymIO {
                 if leadingSliceIndices[idx+1] > -1 || isLastLocale(idx+1) {
                     on Locales[idx+1] {
                         const locDom = A.localSubdomain();
-                        var sliceList: list(uint(8), parSafe=true);
+                        var sliceList: list(uint(8), parSafe=false);
 
                         /*
                          * Iterate through the local slice values for the next locale and add
@@ -1198,7 +1198,7 @@ module GenSymIO {
                 var leadingSliceIndex = leadingSliceIndices[idx]:int;
                 var trailingSliceIndex = trailingSliceIndices[idx]:int;
 
-                var valuesList: list(uint(8), parSafe=true);
+                var valuesList: list(uint(8), parSafe=false);
 
                 /*
                  * Verify if the current locale (idx) contains chars shuffled to the previous 
@@ -1838,8 +1838,8 @@ module GenSymIO {
      * a segments list representing starting indices for each string in the values list.
      */
     private proc sliceToValuesAndSegments(rawChars) {
-        var charList: list(uint(8), parSafe=true);
-        var indices: list(int, parSafe=true);
+        var charList: list(uint(8), parSafe=false);
+        var indices: list(int, parSafe=false);
 
         //initialize segments with index to first char in values
         indices.append(0);
@@ -1870,7 +1870,7 @@ module GenSymIO {
      */
     private proc adjustForLeadingSlice(sliceIndex : int,
                                    charList : list(uint(8))) {
-        var valuesList: list(uint(8), parSafe=true);
+        var valuesList: list(uint(8), parSafe=false);
         var indices: list(int);
         var i: int = 0;
         indices.append(0);
@@ -1904,7 +1904,7 @@ module GenSymIO {
      */
     private proc adjustForTrailingSlice(sliceIndex : int,
                                    charList : list(uint(8))) {
-        var valuesList: list(uint(8), parSafe=true);
+        var valuesList: list(uint(8), parSafe=false);
         var indices: list(int);
         var i: int = 0;
         indices.append(0);


### PR DESCRIPTION
Chapel is making some changes to the collection types to enable better
parallel-safety. One of those changes is that you can no longer use
`list.this(i)`/`list[i]` on parSafe lists. In Chapel 1.23 this produces a
warning, and it will be removed in future releases. The `adjustFor*Slice`
routines run into this in a slightly roundabout way. `charList` is
declared with `parSafe=true` and then those routines do something like:

```chpl
for value in charList(sliceIndex..charList.size-1) {
 ...
}
```

However lists don't support slicing, so that's promoted indexing. i.e.:

```chpl
for i in sliceIndex..charList.size-1 {
  var value = charList[i];
  ...
}
```

Where the `charList[i]` is the thing that generates the warning. So far as
I can tell these lists don't actually need to be `parSafe` since they are
never modified in parallel. Removing parSafe gets rid of the warning and
should be slightly faster (though these aren't used in very performance
critical codes anyways.)

The `[]` deprecation is meant to improve parallel safety by reducing the
ways you can get non-obvious references to collection types. If you just
wanted to support 1.23+ you could use `charList.getValue(i)`, but that's
not supported in 1.22.