### PR TITLE
Re-enable logging of command message from client to server

### DIFF
--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -173,6 +173,19 @@ proc main() {
                 authenticateUser(token);
             }
 
+            if (logging) {
+              try {
+                if (cmd != "array") {
+                  writeln(">>> %s %s".format(cmd, payload.decode(decodePolicy.replace)));
+                } else {
+                  writeln(">>> %s [binary data]".format(cmd));
+                }
+                stdout.flush();
+              } catch {
+                // No action on error
+              }
+            }
+
             // If cmd is shutdown, don't bother generating a repMsg
             if cmd == "shutdown" {
                 shutdown();


### PR DESCRIPTION
Some months ago, `arkouda_server.chpl` stopped logging command strings with args (the lines starting with `>>> `). However, the command args are very useful for analysis of the logs, so this PR adds them back in.