### PR TITLE
Add a couple of use statements to maintain access to string secondary methods

### DIFF
--- a/src/CastMsg.chpl
+++ b/src/CastMsg.chpl
@@ -9,6 +9,7 @@ module CastMsg {
   use CommAggregation;
 
   proc castMsg(cmd: string, payload: bytes, st: borrowed SymTab): string throws {
+    use ServerConfig; // for string.splitMsgToTuple
     param pn = Reflection.getRoutineName();
     var (name, objtype, targetDtype, opt) = payload.decode().splitMsgToTuple(4);
     select objtype {

--- a/src/Errors.chpl
+++ b/src/Errors.chpl
@@ -1,6 +1,7 @@
 module Errors {
 
     use SysError;
+    private use IO; // for string.format
 
     /*
      * Generates an error message that provides a fuller context to the error


### PR DESCRIPTION
With the change on Chapel's master to return to respecting the privacy and limitations
of use and import statements, these modules started encountering errors when
trying to access string.format (defined in IO) and string.splitMsgToTuple
(defined in ServerConfig).  For the former, add a use of IO to the main body
of the module as it is used in multiple functions.  For the latter, add a use
within the body of castMsg, as it is the only function in the module that uses
the method.

This allowed `make` to run to completion locally

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>