### PR TITLE
Accept variable precision in HDF5 dtypes for read

### DIFF
--- a/arkouda/pdarrayIO.py
+++ b/arkouda/pdarrayIO.py
@@ -27,7 +27,8 @@ def ls_hdf(filename : str) -> str:
     return generic_msg("lshdf {}".format(json.dumps([filename])))
 
 @typechecked
-def read_hdf(dsetName : str, filenames : Union[str,List[str]]) \
+def read_hdf(dsetName : str, filenames : Union[str,List[str]],
+             strictTypes: bool=True) \
           -> Union[pdarray, Strings]:
     """
     Read a single dataset from multiple HDF5 files into an Arkouda
@@ -75,10 +76,12 @@ def read_hdf(dsetName : str, filenames : Union[str,List[str]]) \
     #     return Strings(*rep_msg.split('+'))
     # else:
     #     return create_pdarray(rep_msg)
-    return read_all(filenames, datasets=dsetName)
+    return read_all(filenames, datasets=dsetName, strictTypes=strictTypes)
 
-def read_all(filenames : Union[str,List[str]], datasets : 
-             Optional[Union[str,List[str]]]=None, iterative : bool=False) \
+def read_all(filenames : Union[str,List[str]],
+             datasets : Optional[Union[str,List[str]]]=None,
+             iterative : bool=False,
+             strictTypes: bool=True) \
              -> Union[pdarray, Strings, Mapping[str,Union[pdarray,Strings]]]:
     """
     Read datasets from HDF5 files.
@@ -136,10 +139,10 @@ def read_all(filenames : Union[str,List[str]], datasets :
         if len(nonexistent) > 0:
             raise ValueError("Dataset(s) not found: {}".format(nonexistent))
     if iterative == True: # iterative calls to server readhdf
-        return {dset:read_hdf(dset, filenames) for dset in datasets}
+        return {dset:read_hdf(dset, filenames, strictTypes=strictTypes) for dset in datasets}
     else:  # single call to server readAllHdf
-        rep_msg = generic_msg("readAllHdf {:n} {:n} {} | {}".\
-                format(len(datasets), len(filenames), json.dumps(datasets), 
+        rep_msg = generic_msg("readAllHdf {} {:n} {:n} {} | {}".\
+                format(strictTypes, len(datasets), len(filenames), json.dumps(datasets), 
                        json.dumps(filenames)))
         if ',' in rep_msg:
             rep_msgs = rep_msg.split(' , ')

--- a/arkouda/pdarrayIO.py
+++ b/arkouda/pdarrayIO.py
@@ -40,7 +40,13 @@ def read_hdf(dsetName : str, filenames : Union[str,List[str]],
         The name of the dataset (must be the same across all files)
     filenames : list or str
         Either a list of filenames or shell expression
-
+    strictTypes: bool
+        If True (default), require all dtypes in all files to have the
+        same precision and sign. If False, allow dtypes of different
+        precision and sign across different files. For example, if one 
+        file contains a uint32 dataset and another contains an int64
+        dataset, the contents of both will be read into an int64 pdarray.
+        
     Returns
     -------
     Union[pdarray,Strings] 
@@ -92,8 +98,15 @@ def read_all(filenames : Union[str,List[str]],
         Either a list of filenames or shell expression
     datasets : list or str or None
         (List of) name(s) of dataset(s) to read (default: all available)
-    iterative : boolean
+    iterative : bool
         Iterative (True) or Single (False) function call(s) to server
+    strictTypes: bool
+        If True (default), require all dtypes of a given dataset to have the
+        same precision and sign. If False, allow dtypes of different
+        precision and sign across different files. For example, if one 
+        file contains a uint32 dataset and another contains an int64
+        dataset with the same name, the contents of both will be read 
+        into an int64 pdarray.
 
     Returns
     -------


### PR DESCRIPTION
Data is always messy, and we have datasets spread across multiple files where, for example, the dtype is `uint32` in half the files and `uint64` in the other half. Currently, attempting to `ak.read_all()` these files raises an error because of inconsistent dtypes. This PR introduces the optional `strictTypes` keyword arg for `ak.read_hdf` and `ak.read_all`. The default (`strictTypes=True`) preserves current behavior, but the user can set `strictTypes=False` and arkouda will read the dataset as long as all the types can be cast losslessly to an arkouda dtype (e.g. `int64`). There will still be an error if the dtypes are of different kinds, e.g. `int` and `float` are still incompatible.