### PR TITLE
Seeded RNG

### DIFF
--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -465,7 +465,7 @@ def linspace(start : int, stop : int, length : int) -> pdarray:
     repMsg = generic_msg("linspace {} {} {}".format(startstr, stopstr, lenstr))
     return create_pdarray(repMsg)
 
-def randint(low : Union[int,float], high : Union[int,float], size : int, dtype=int64) -> pdarray:
+def randint(low : Union[int,float], high : Union[int,float], size : int, dtype=int64, seed : Union[None, int]=None) -> pdarray:
     """
     Generate a pdarray of randomized int, float, or bool values in a specified range.
 
@@ -526,12 +526,12 @@ def randint(low : Union[int,float], high : Union[int,float], size : int, dtype=i
     lowstr = NUMBER_FORMAT_STRINGS[dtype.name].format(low)
     highstr = NUMBER_FORMAT_STRINGS[dtype.name].format(high)
     sizestr = NUMBER_FORMAT_STRINGS['int64'].format(size)
-    repMsg = generic_msg("randint {} {} {} {}".\
-                         format(sizestr, dtype.name, lowstr, highstr))
+    repMsg = generic_msg("randint {} {} {} {} {}".\
+                         format(sizestr, dtype.name, lowstr, highstr, seed))
     return create_pdarray(repMsg)
 
 @typechecked
-def uniform(size : int, low : float=0.0, high : float=1.0) -> pdarray:
+def uniform(size : int, low : float=0.0, high : float=1.0, seed: Union[None, int]=None) -> pdarray:
     """
     Generate a pdarray with uniformly distributed random values 
     in a specified range.
@@ -563,11 +563,11 @@ def uniform(size : int, low : float=0.0, high : float=1.0) -> pdarray:
     >>> ak.uniform(3)
     array([0.92176432277231968, 0.083130710959903542, 0.68894208386667544])
     """
-    return randint(low=low, high=high, size=size, dtype='float64')
+    return randint(low=low, high=high, size=size, dtype='float64', seed=seed)
 
     
 @typechecked
-def standard_normal(size : int) -> pdarray:
+def standard_normal(size : int, seed : Union[None, int]=None) -> pdarray:
     """
     Draw real numbers from the standard normal distribution.
 
@@ -600,13 +600,13 @@ def standard_normal(size : int) -> pdarray:
     """
     if size < 0:
         raise ValueError("The size parameter must be > 0")
-    msg = "randomNormal {}".format(NUMBER_FORMAT_STRINGS['int64'].format(size))
+    msg = "randomNormal {} {}".format(NUMBER_FORMAT_STRINGS['int64'].format(size), seed)
     repMsg = generic_msg(msg)
     return create_pdarray(repMsg)
 
 @typechecked
 def random_strings_uniform(minlen : int, maxlen : int, size : int, 
-                           characters : str='uppercase') -> Strings:
+                           characters : str='uppercase', seed : Union[None, int]=None) -> Strings:
     """
     Generate random strings with lengths uniformly distributed between 
     minlen and maxlen, and with characters drawn from a specified set.
@@ -639,17 +639,19 @@ def random_strings_uniform(minlen : int, maxlen : int, size : int,
     if minlen < 0 or maxlen < minlen or size < 0:
         raise ValueError(("Incompatible arguments: minlen < 0, maxlen < minlen, " +
                           "or size < 0"))
-    msg = "randomStrings {} {} {} {} {}".\
-                            format(NUMBER_FORMAT_STRINGS['int64'].format(size),
-                            "uniform", characters,
-                            NUMBER_FORMAT_STRINGS['int64'].format(minlen),
-                            NUMBER_FORMAT_STRINGS['int64'].format(maxlen))
+    msg = "randomStrings {} {} {} {} {} {}".\
+          format(NUMBER_FORMAT_STRINGS['int64'].format(size),
+                 "uniform", characters,
+                 NUMBER_FORMAT_STRINGS['int64'].format(minlen),
+                 NUMBER_FORMAT_STRINGS['int64'].format(maxlen),
+                 seed)
     repMsg = generic_msg(msg)
     return Strings(*(repMsg.split('+')))
 
 @typechecked
-def random_strings_lognormal(logmean : Union[float, int], logstd : float, 
-                             size : int, characters : str='uppercase') -> Strings:
+def random_strings_lognormal(logmean : Union[float, int], logstd : Union[float, int], 
+                             size : int, characters : str='uppercase',
+                             seed : Union[None, int]=None) -> Strings:
     """
     Generate random strings with log-normally distributed lengths and 
     with characters drawn from a specified set.
@@ -689,15 +691,13 @@ def random_strings_lognormal(logmean : Union[float, int], logstd : float,
     have an average length of :math:`exp(\mu + 0.5*\sigma^2)`, a minimum length of 
     zero, and a heavy tail towards longer strings.
     """
-    # needed because per https://www.python.org/dev/peps/pep-0484/#id27 any int is a float
-    if not isinstance(logstd, float):
-        raise TypeError('type of argument "logstd" must be a float; got int instead')
     if logstd <= 0 or size < 0:
         raise ValueError("Incompatible arguments: logstd <= 0 or size < 0")
-    msg = "randomStrings {} {} {} {} {}".\
-                             format(NUMBER_FORMAT_STRINGS['int64'].format(size),
-                             "lognormal", characters,
-                             NUMBER_FORMAT_STRINGS['float64'].format(logmean),
-                             NUMBER_FORMAT_STRINGS['float64'].format(logstd))
+    msg = "randomStrings {} {} {} {} {} {}".\
+          format(NUMBER_FORMAT_STRINGS['int64'].format(size),
+                 "lognormal", characters,
+                 NUMBER_FORMAT_STRINGS['float64'].format(logmean),
+                 NUMBER_FORMAT_STRINGS['float64'].format(logstd),
+                 seed)
     repMsg = generic_msg(msg)
     return Strings(*(repMsg.split('+')))

--- a/src/RandArray.chpl
+++ b/src/RandArray.chpl
@@ -8,11 +8,16 @@ module RandArray {
   use Map;
   use SipHash;
 
-  proc fillInt(a:[] ?t, const aMin, const aMax) where isIntType(t) {
+  proc fillInt(a:[] ?t, const aMin, const aMax, const seedStr:string="None") throws where isIntType(t) {
     coforall loc in Locales {
       on loc {
         ref myA = a.localSlice[a.localSubdomain()];
-        fillRandom(myA);
+        if (seedStr.toLower() == "none") {
+          fillRandom(myA);
+        } else {
+          var seed = (seedStr:int) + here.id;
+          fillRandom(myA, seed);
+        }
         [ai in myA] if (ai < 0) { ai = -ai; }
         if (aMax > aMin) {
           const modulus = aMax - aMin;
@@ -23,11 +28,16 @@ module RandArray {
     }
   }
 
-  proc fillUInt(a:[] ?t, const aMin, const aMax) where isUintType(t) {
+  proc fillUInt(a:[] ?t, const aMin, const aMax, const seedStr:string="None") throws where isUintType(t) {
     coforall loc in Locales {
       on loc {
         ref myA = a.localSlice[a.localSubdomain()];
-        fillRandom(myA);
+        if (seedStr.toLower() == "none") {
+          fillRandom(myA);
+        } else {
+          var seed = (seedStr:int) + here.id;
+          fillRandom(myA, seed);
+        }
         if (aMax > aMin) {
           const modulus = aMax - aMin;
           [x in myA] x = ((x % modulus) + aMin):t;
@@ -37,31 +47,47 @@ module RandArray {
     }
   }
 
-  proc fillReal(a:[] real, const aMin:numeric=0.0, const aMax:numeric=1.0) {
+  proc fillReal(a:[] real, const aMin:numeric=0.0, const aMax:numeric=1.0, const seedStr:string="None") throws {
     coforall loc in Locales {
       on loc {
         ref myA = a.localSlice[a.localSubdomain()];
-        fillRandom(myA);
+        if (seedStr.toLower() == "none") {
+          fillRandom(myA);
+        } else {
+          var seed = (seedStr:int) + here.id;
+          fillRandom(myA, seed);
+        }
         const scale = aMax - aMin;
         myA = scale*myA + aMin;
       }
     }
   }
 
-  proc fillBool(a:[] bool) {
+  proc fillBool(a:[] bool, const seedStr:string="None") throws {
     coforall loc in Locales {
       on loc {
         ref myA = a.localSlice[a.localSubdomain()];
-        fillRandom(myA);
+        if (seedStr.toLower() == "none") {
+          fillRandom(myA);
+        } else {
+          var seed = (seedStr:int) + here.id;
+          fillRandom(myA, seed);
+        }
       }
     }
   }
 
-  proc fillNormal(a:[?D] real) {
+  proc fillNormal(a:[?D] real, const seedStr:string="None") throws {
     var u1:[D] real;
     var u2:[D] real;
-    fillRandom(u1);
-    fillRandom(u2);
+    if (seedStr.toLower() == "none") {
+      fillRandom(u1);
+      fillRandom(u2);
+    } else {
+      var seed = (seedStr:int);
+      fillRandom(u1, seed);
+      fillRandom(u2, seed+1);
+    }
     a = sqrt(-2*log(u1))*cos(2*pi*u2);
   }
 
@@ -105,8 +131,11 @@ module RandArray {
   charBounds[charSet.Printable] = (32, 127);
   charBounds[charSet.Binary] = (0, 0);
 
-  proc newRandStringsUniformLength(const n: int, const minLen: int, 
-                           const maxLen: int, characters:charSet = charSet.Uppercase) throws {
+  proc newRandStringsUniformLength(const n: int,
+                                   const minLen: int, 
+                                   const maxLen: int,
+                                   characters:charSet = charSet.Uppercase,
+                                   const seedStr:string="None") throws {
     if (n < 0) || (minLen < 0) || (maxLen < minLen) {  
         writeln(generateErrorContext(
                  msg="Incompatible arguments: n and minLen must be > 0 and maxLen < minLen", 
@@ -117,19 +146,22 @@ module RandArray {
         throw new owned ArgumentError();                     
     }
     var lengths = makeDistArray(n, int);
-    fillInt(lengths, minLen+1, maxLen+1);
+    fillInt(lengths, minLen+1, maxLen+1, seedStr=seedStr);
     const nBytes = + reduce lengths;
     var segs = (+ scan lengths) - lengths;
     var vals = makeDistArray(nBytes, uint(8));
     var (lb, ub) = charBounds[characters];
-    fillUInt(vals, lb, ub);
+    fillUInt(vals, lb, ub, seedStr=seedStr);
     // Strings are null-terminated
     [(s, l) in zip(segs, lengths)] vals[s+l-1] = 0:uint(8);
     return (segs, vals);
   }
 
-  proc newRandStringsLogNormalLength(const n: int, const logMean: numeric, 
-                       const logStd: numeric, characters:charSet = charSet.Uppercase) throws {
+  proc newRandStringsLogNormalLength(const n: int,
+                                     const logMean: numeric, 
+                                     const logStd: numeric,
+                                     characters:charSet = charSet.Uppercase,
+                                     const seedStr:string="None") throws {
     if (n < 0) || (logStd <= 0) {
         writeln(generateErrorContext(
                      msg="Incompatible arguments: n must be > 0 and logStd <= 0", 
@@ -140,14 +172,14 @@ module RandArray {
         throw new owned ArgumentError();
     }
     var ltemp = makeDistArray(n, real);
-    fillNormal(ltemp);
+    fillNormal(ltemp, seedStr=seedStr);
     ltemp = exp(logMean + logStd*ltemp);
     var lengths:[ltemp.domain] int = [l in ltemp] ceil(l):int;
     const nBytes = + reduce lengths;
     var segs = (+ scan lengths) - lengths;
     var vals = makeDistArray(nBytes, uint(8));
     var (lb, ub) = charBounds[characters];
-    fillUInt(vals, lb, ub);
+    fillUInt(vals, lb, ub, seedStr=seedStr);
     // Strings are null-terminated
     [(s, l) in zip(segs, lengths)] vals[s+l-1] = 0:uint(8);
     return (segs, vals);

--- a/src/RandMsg.chpl
+++ b/src/RandMsg.chpl
@@ -22,7 +22,7 @@ module RandMsg
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
         // split request into fields
-        var (lenStr,dtypeStr,aMinStr,aMaxStr) = payload.decode().splitMsgToTuple(4);
+        var (lenStr,dtypeStr,aMinStr,aMaxStr,seed) = payload.decode().splitMsgToTuple(5);
         var len = lenStr:int;
         var dtype = str2dtype(dtypeStr);
 
@@ -42,7 +42,7 @@ module RandMsg
                 if v {writeln("alloc time = ",Time.getCurrentTime() - t1,"sec"); try! stdout.flush();}
                 
                 t1 = Time.getCurrentTime();
-                fillInt(e.a, aMin, aMax);
+                fillInt(e.a, aMin, aMax, seed);
                 if v {writeln("compute time = ",Time.getCurrentTime() - t1,"sec"); try! stdout.flush();}
             }
             when (DType.UInt8) {
@@ -54,7 +54,7 @@ module RandMsg
                 if v {writeln("alloc time = ",Time.getCurrentTime() - t1,"sec"); try! stdout.flush();}
                 
                 t1 = Time.getCurrentTime();
-                fillUInt(e.a, aMin, aMax);
+                fillUInt(e.a, aMin, aMax, seed);
                 if v {writeln("compute time = ",Time.getCurrentTime() - t1,"sec"); try! stdout.flush();}
             }
             when (DType.Float64) {
@@ -66,7 +66,7 @@ module RandMsg
                 if v {writeln("alloc time = ",Time.getCurrentTime() - t1,"sec"); try! stdout.flush();}
                 
                 t1 = Time.getCurrentTime();
-                fillReal(e.a, aMin, aMax);
+                fillReal(e.a, aMin, aMax, seed);
                 if v {writeln("compute time = ",Time.getCurrentTime() - t1,"sec"); try! stdout.flush();}
             }
             when (DType.Bool) {
@@ -76,7 +76,7 @@ module RandMsg
                 if v {writeln("alloc time = ",Time.getCurrentTime() - t1,"sec"); try! stdout.flush();}
                 
                 t1 = Time.getCurrentTime();
-                fillBool(e.a);
+                fillBool(e.a, seed);
                 if v {writeln("compute time = ",Time.getCurrentTime() - t1,"sec"); try! stdout.flush();}
             }            
             otherwise {
@@ -96,13 +96,13 @@ module RandMsg
 
     proc randomNormalMsg(cmd: string, payload: bytes, st: borrowed SymTab): string throws {
       var pn = Reflection.getRoutineName();
-      var (lenStr) = payload.decode().splitMsgToTuple(1);
+      var (lenStr, seed) = payload.decode().splitMsgToTuple(2);
       var len = lenStr:int;
       // Result + 2 scratch arrays
       overMemLimit(3*8*len);
       var rname = st.nextName();
       var entry = new shared SymEntry(len, real);
-      fillNormal(entry.a);
+      fillNormal(entry.a, seed);
       st.addEntry(rname, entry);
       return "created " + st.attrib(rname);
     }

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -14,8 +14,8 @@ module SegmentedMsg {
 
   proc randomStringsMsg(cmd: string, payload: bytes, st: borrowed SymTab): string throws {
       var pn = Reflection.getRoutineName();
-      var (lenStr, dist, charsetStr, arg1str, arg2str)
-          = payload.decode().splitMsgToTuple(5);
+      var (lenStr, dist, charsetStr, arg1str, arg2str, seedStr)
+          = payload.decode().splitMsgToTuple(6);
       var len = lenStr: int;
       var charset = str2CharSet(charsetStr);
       var segName = st.nextName();
@@ -27,7 +27,7 @@ module SegmentedMsg {
               var maxLen = arg2str:int;
               // Lengths + 2*segs + 2*vals (copied to SymTab)
               overMemLimit(8*len + 16*len + (maxLen + minLen)*len);
-              var (segs, vals) = newRandStringsUniformLength(len, minLen, maxLen, charset);
+              var (segs, vals) = newRandStringsUniformLength(len, minLen, maxLen, charset, seedStr);
               var segEntry = new shared SymEntry(segs);
               var valEntry = new shared SymEntry(vals);
               st.addEntry(segName, segEntry);
@@ -39,7 +39,7 @@ module SegmentedMsg {
               var logStd = arg2str:real;
               // Lengths + 2*segs + 2*vals (copied to SymTab)
               overMemLimit(8*len + 16*len + exp(logMean + (logStd**2)/2):int*len);
-              var (segs, vals) = newRandStringsLogNormalLength(len, logMean, logStd, charset);
+              var (segs, vals) = newRandStringsLogNormalLength(len, logMean, logStd, charset, seedStr);
               var segEntry = new shared SymEntry(segs);
               var valEntry = new shared SymEntry(vals);
               st.addEntry(segName, segEntry);

--- a/test/TestBase.chpl
+++ b/test/TestBase.chpl
@@ -117,7 +117,7 @@ proc writeSegString(msg: string, ss: SegString) {
 
 proc nameForRandintMsg(len: int, dtype:DType, aMin: int, aMax: int, st: borrowed SymTab) {
   use RandMsg;
-  const payloadStr = try! "%i %s %i %i".format(len, dtype2str(dtype), aMin, aMax);
+  const payloadStr = try! "%i %s %i %i None".format(len, dtype2str(dtype), aMin, aMax);
   const payload = try! payloadStr.encode();
   writeReq(payloadStr);
   const repMsg = randintMsg(cmd='randint', payload=payload, st);

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -7,7 +7,33 @@ Encapsulates unit tests for the numeric module with the exception
 of the where method, which is in the where_test module
 """
 class NumericTest(ArkoudaTest):
-    
+
+    def testSeededRNG(self):
+        N = 100
+        seed = 8675309
+        numericdtypes = [ak.int64, ak.float64, ak.bool]
+        for dt in numericdtypes:
+            # Make sure unseeded runs differ
+            a = ak.randint(0, 2**32, N, dtype=dt)
+            b = ak.randint(0, 2**32, N, dtype=dt)
+            self.assertFalse((a == b).all())
+            # Make sure seeded results are same
+            a = ak.randint(0, 2**32, N, dtype=dt, seed=seed)
+            b = ak.randint(0, 2**32, N, dtype=dt, seed=seed)
+            self.assertTrue((a == b).all())
+        # Uniform
+        self.assertFalse((ak.uniform(N) == ak.uniform(N)).all())
+        self.assertTrue((ak.uniform(N, seed=seed) == ak.uniform(N, seed=seed)).all())
+        # Standard Normal
+        self.assertFalse((ak.standard_normal(N) == ak.standard_normal(N)).all())
+        self.assertTrue((ak.standard_normal(N, seed=seed) == ak.standard_normal(N, seed=seed)).all())
+        # Strings (uniformly distributed length)
+        self.assertFalse((ak.random_strings_uniform(1, 10, N) == ak.random_strings_uniform(1, 10, N)).all())
+        self.assertTrue((ak.random_strings_uniform(1, 10, N, seed=seed) == ak.random_strings_uniform(1, 10, N, seed=seed)).all())
+        # Strings (log-normally distributed length)
+        self.assertFalse((ak.random_strings_lognormal(2, 1, N) == ak.random_strings_lognormal(2, 1, N)).all())
+        self.assertTrue((ak.random_strings_lognormal(2, 1, N, seed=seed) == ak.random_strings_lognormal(2, 1, N, seed=seed)).all())
+            
     def testCast(self):
         N = 100
         arrays = {ak.int64: ak.randint(-(2**48), 2**48, N),

--- a/tests/pdarray_creation.py
+++ b/tests/pdarray_creation.py
@@ -280,12 +280,7 @@ class PdarrayCreationTest(ArkoudaTest):
             ak.random_strings_lognormal('2', 0.25, 100)          
         self.assertEqual('type of argument "logmean" must be one of (float, int); got str instead', 
                          cm.exception.args[0])   
-        
-        with self.assertRaises(TypeError) as cm:          
-            ak.random_strings_lognormal(2, 25, 100)          
-        self.assertEqual('type of argument "logstd" must be a float; got int instead', 
-                         cm.exception.args[0])     
-        
+                
         with self.assertRaises(TypeError) as cm:          
             ak.random_strings_lognormal(2, 0.25, '100')          
         self.assertEqual('type of argument "size" must be int; got str instead', 


### PR DESCRIPTION
This PR supports seeded random data generation and adds tests for same. Addresses #576 

Another minor change is that it allows the `logstd` argument of `ak.random_strings_lognormal` to be `int` as well as `float`.