### PR TITLE
Fix connect() call in client_test.py

### DIFF
--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -36,7 +36,7 @@ class ClientTest(ArkoudaTest):
         ak.disconnect()
         self.assertFalse(ak.client.connected)
         ak.disconnect()
-        ak.connect()
+        ak.connect(server=ArkoudaTest.server, port=ArkoudaTest.port)
         
     def test_client_get_config(self):
         '''
@@ -107,4 +107,4 @@ class ClientTest(ArkoudaTest):
         ak.client.set_defaults()
         self.assertEqual(100, ak.client.pdarrayIterThresh)
         self.assertEqual(1073741824, ak.client.maxTransferBytes)
-        self.assertFalse(ak.client.verbose)        
+        self.assertFalse(ak.client.verbose)


### PR DESCRIPTION
`test_disconnect_on_disconnected_client()` was doing a plain `connect()`, which
tries to connect to localhost instead of the server/port the testing systems
knows. This was causing hangs in our nightly distributed testing.