### PR TITLE
Avoid converting GenSymEntry's to strings

### DIFF
--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -24,14 +24,17 @@ module AryUtil
       :arg name: name of the array
       :arg A: array to be printed
     */
-    proc printAry(name:string, A) {
+    proc formatAry(A):string throws {
         if A.size <= printThresh {
-            try! auLogger.info(getModuleName(),getRoutineName(),getLineNumber(),
-                                         "name: %t A: %t".format(name,A));
+            return "%t".format(A);
         } else {
-            try! writeln(name,[i in A.domain.low..A.domain.low+2] A[i],
-                      " ... ", [i in A.domain.high-2..A.domain.high] A[i]);       
+            return "%t ... %t".format(A[A.domain.low..A.domain.low+2],
+                                      A[A.domain.high-2..A.domain.high]);
         }
+    }
+
+    proc printAry(name:string, A) {
+        try! writeln(name, formatAry(A));
     }
     
     /* 1.18 version print out localSubdomains 

--- a/src/ConcatenateMsg.chpl
+++ b/src/ConcatenateMsg.chpl
@@ -115,7 +115,7 @@ module ConcatenateMsg
                 }
                 var repMsg = "created " + st.attrib(segName) + "+created " + st.attrib(valName);
                 cmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                  "created concatenated pdarray %t".format(st.lookup(valName)));
+                                  "created concatenated pdarray %s".format(valName));
                 return repMsg;
             }
             when "pdarray" {
@@ -140,7 +140,7 @@ module ConcatenateMsg
                             start += o.size;
                         }
                         cmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                         "created concatenated pdarray: %t".format(st.lookup(rname)));
+                                         "created concatenated pdarray: %s".format(rname));
                     }
                     when DType.Float64 {
                         // create array to copy into
@@ -159,7 +159,7 @@ module ConcatenateMsg
                             start += o.size;
                         }
                         cmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                         "created concatenated pdarray: %t".format(st.lookup(rname)));
+                                         "created concatenated pdarray: %s".format(rname));
                     }
                     when DType.Bool {
                         // create array to copy into
@@ -178,7 +178,7 @@ module ConcatenateMsg
                             start += o.size;
                         }
                         cmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                           "created concatenated pdarray: %t".format(st.lookup(rname)));
+                                           "created concatenated pdarray: %s".format(rname));
                     }
                     otherwise {
                         var errorMsg = notImplementedError("concatenate",dtype);

--- a/src/ConcatenateMsg.chpl
+++ b/src/ConcatenateMsg.chpl
@@ -115,7 +115,7 @@ module ConcatenateMsg
                 }
                 var repMsg = "created " + st.attrib(segName) + "+created " + st.attrib(valName);
                 cmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                  "created concatenated pdarray %s".format(valName));
+                                  "created concatenated pdarray %s".format(st.attrib(valName)));
                 return repMsg;
             }
             when "pdarray" {
@@ -140,7 +140,7 @@ module ConcatenateMsg
                             start += o.size;
                         }
                         cmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                         "created concatenated pdarray: %s".format(rname));
+                                         "created concatenated pdarray: %s".format(st.attrib(rname)));
                     }
                     when DType.Float64 {
                         // create array to copy into
@@ -159,7 +159,7 @@ module ConcatenateMsg
                             start += o.size;
                         }
                         cmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                         "created concatenated pdarray: %s".format(rname));
+                                         "created concatenated pdarray: %s".format(st.attrib(rname)));
                     }
                     when DType.Bool {
                         // create array to copy into
@@ -178,7 +178,7 @@ module ConcatenateMsg
                             start += o.size;
                         }
                         cmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                           "created concatenated pdarray: %s".format(rname));
+                                           "created concatenated pdarray: %s".format(st.attrib(rname)));
                     }
                     otherwise {
                         var errorMsg = notImplementedError("concatenate",dtype);

--- a/src/EfuncMsg.chpl
+++ b/src/EfuncMsg.chpl
@@ -49,7 +49,7 @@ module EfuncMsg
         var gEnt: borrowed GenSymEntry = st.lookup(name);
         
         eLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                           "cmd: %s efunc: %s pdarray: %t".format(cmd,efunc,gEnt));
+                           "cmd: %s efunc: %s pdarray: %s".format(cmd,efunc,name));
        
         select (gEnt.dtype) {
             when (DType.Int64) {

--- a/src/EfuncMsg.chpl
+++ b/src/EfuncMsg.chpl
@@ -49,7 +49,7 @@ module EfuncMsg
         var gEnt: borrowed GenSymEntry = st.lookup(name);
         
         eLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                           "cmd: %s efunc: %s pdarray: %s".format(cmd,efunc,name));
+                           "cmd: %s efunc: %s pdarray: %s".format(cmd,efunc,st.attrib(name)));
        
         select (gEnt.dtype) {
             when (DType.Int64) {

--- a/src/In1dMsg.chpl
+++ b/src/In1dMsg.chpl
@@ -59,8 +59,8 @@ module In1dMsg
         var gAr2: borrowed GenSymEntry = st.lookup(sname);
         
         iLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                        "cmd: %s pdarray1: %t pdarray2: %t invert: %t new pdarray name: %t".format(
-                                   cmd,gAr1,gAr2,invert,rname));
+                        "cmd: %s pdarray1: %s pdarray2: %s invert: %t new pdarray name: %t".format(
+                                   cmd,st.attrib(name),st.attrib(sname),invert,rname));
 
         select (gAr1.dtype, gAr2.dtype) {
             when (DType.Int64, DType.Int64) {

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -88,7 +88,7 @@ module IndexingMsg
         
         imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
             "cmd: %s pdarray to slice: %s start: %i stop: %i stride: %i slice: %t new name: %s".format(
-                       cmd, name, start, stop, stride, slice, rname));
+                       cmd, st.attrib(name), start, stop, stride, slice, rname));
 
         proc sliceHelper(type t) throws {
             var e = toSymEntry(gEnt,t);
@@ -318,7 +318,7 @@ module IndexingMsg
         var gIV: borrowed GenSymEntry = st.lookup(iname);
         
         imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                              "cmd: %s gX: %s gIV: %s value: %s".format(cmd,name,iname,value));
+                              "cmd: %s gX: %s gIV: %s value: %s".format(cmd,st.attrib(name),st.attrib(iname),value));
 
         // scatter indexing by integer index vector
         proc ivInt64Helper(type Xtype, type dtype): string throws {

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -87,8 +87,8 @@ module IndexingMsg
         var gEnt: borrowed GenSymEntry = st.lookup(name);
         
         imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-            "cmd: %s pdarray to slice: %t start: %i stop: %i stride: %i slice: %t new name: %s".format(
-                       cmd, gEnt, start, stop, stride, slice, rname));
+            "cmd: %s pdarray to slice: %s start: %i stop: %i stride: %i slice: %t new name: %s".format(
+                       cmd, name, start, stop, stride, slice, rname));
 
         proc sliceHelper(type t) throws {
             var e = toSymEntry(gEnt,t);
@@ -318,7 +318,7 @@ module IndexingMsg
         var gIV: borrowed GenSymEntry = st.lookup(iname);
         
         imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                              "cmd: %s gX: %t gIV: %t value: %s".format(cmd,gX,gIV,value));
+                              "cmd: %s gX: %s gIV: %s value: %s".format(cmd,name,iname,value));
 
         // scatter indexing by integer index vector
         proc ivInt64Helper(type Xtype, type dtype): string throws {

--- a/src/MsgProcessing.chpl
+++ b/src/MsgProcessing.chpl
@@ -76,7 +76,7 @@ module MsgProcessing
         st.addEntry(rname, size, dtype);
         // if verbose print result
         mpLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
-                                    "created the pdarray %t".format(st.lookup(rname)));
+                                    "created the pdarray %s".format(rname));
                                     
         // response message                                    
         return try! "created " + st.attrib(rname);
@@ -342,7 +342,7 @@ module MsgProcessing
         var gEnt: borrowed GenSymEntry = st.lookup(name);
 
         mpLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                      "cmd: %s value: %s in pdarray %t".format(cmd,name,gEnt));
+                                      "cmd: %s value: %s in pdarray %s".format(cmd,name,name));
 
         select (gEnt.dtype, dtype) {
             when (DType.Int64, DType.Int64) {

--- a/src/MsgProcessing.chpl
+++ b/src/MsgProcessing.chpl
@@ -76,7 +76,7 @@ module MsgProcessing
         st.addEntry(rname, size, dtype);
         // if verbose print result
         mpLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
-                                    "created the pdarray %s".format(rname));
+                                    "created the pdarray %s".format(st.attrib(rname)));
                                     
         // response message                                    
         return try! "created " + st.attrib(rname);
@@ -342,7 +342,7 @@ module MsgProcessing
         var gEnt: borrowed GenSymEntry = st.lookup(name);
 
         mpLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                      "cmd: %s value: %s in pdarray %s".format(cmd,name,name));
+                                      "cmd: %s value: %s in pdarray %s".format(cmd,name,st.attrib(name)));
 
         select (gEnt.dtype, dtype) {
             when (DType.Int64, DType.Int64) {

--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -50,10 +50,6 @@ module MultiTypeSymEntry
         inline proc toSymEntry(type etype) {
             return try! this :borrowed SymEntry(etype);
         }
-
-        override proc writeThis(f) throws {
-          halt("GenSymEntry cannot be stringified");
-        }
     }
 
     /* Symbol table entry
@@ -115,7 +111,24 @@ module MultiTypeSymEntry
         }
         
         override proc writeThis(f) throws {
-          halt("SymEntry cannot be stringified");
+          use Reflection;
+          proc writeField(f, param i) throws {
+            if !isArray(getField(this, i)) {
+              f <~> getFieldName(this.type, i) <~> " = " <~> getField(this, i):string;
+            } else {
+              f <~> getFieldName(this.type, i) <~> " = " <~> formatAry(getField(this, i));
+            }
+          }
+
+          super.writeThis(f);
+          f <~> " {";
+          param nFields = numFields(this.type);
+          for param i in 0..nFields-2 {
+            writeField(f, i);
+            f <~> ", ";
+          }
+          writeField(f, nFields-1);
+          f <~> "}";
         }
     }
 

--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -50,6 +50,10 @@ module MultiTypeSymEntry
         inline proc toSymEntry(type etype) {
             return try! this :borrowed SymEntry(etype);
         }
+
+        override proc writeThis(f) throws {
+          halt("GenSymEntry cannot be stringified");
+        }
     }
 
     /* Symbol table entry
@@ -110,6 +114,9 @@ module MultiTypeSymEntry
             if v {writeln("deinit SymEntry");try! stdout.flush();}
         }
         
+        override proc writeThis(f) throws {
+          halt("SymEntry cannot be stringified");
+        }
     }
 
 }

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -1355,7 +1355,7 @@ module OperatorMsg
         var right: borrowed GenSymEntry = st.lookup(bname);
 
         omLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                    "cmd: %s op: %s left pdarray: %s right pdarray: %s".format(cmd,op,aname,bname));
+                    "cmd: %s op: %s left pdarray: %s right pdarray: %s".format(cmd,op,st.attrib(aname),st.attrib(bname)));
 
         select (left.dtype, right.dtype) {
             when (DType.Int64, DType.Int64) {

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -1355,7 +1355,7 @@ module OperatorMsg
         var right: borrowed GenSymEntry = st.lookup(bname);
 
         omLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                    "cmd: %s op: %s left pdarray: %t right pdarray: %t".format(cmd,op,left,right));   
+                    "cmd: %s op: %s left pdarray: %s right pdarray: %s".format(cmd,op,aname,bname));
 
         select (left.dtype, right.dtype) {
             when (DType.Int64, DType.Int64) {

--- a/test/akpow.good
+++ b/test/akpow.good
@@ -1,3 +1,3 @@
 Unit Test for akpow
-      id_2 = {dtype = Int64, itemsize = 8, size = 5, ndim = 1, shape = (5), aD = {0..4}, a = -2 -2 -2 -2 -2}
-      id_1 = {dtype = Int64, itemsize = 8, size = 5, ndim = 1, shape = (5), aD = {0..4}, a = 2 2 2 2 2}
+      id_2 = {dtype = Int64, itemsize = 8, size = 5, ndim = 1, shape = (5)} {etype = int(64), aD = {0..4}, a = -2 -2 -2 -2 -2}
+      id_1 = {dtype = Int64, itemsize = 8, size = 5, ndim = 1, shape = (5)} {etype = int(64), aD = {0..4}, a = 2 2 2 2 2}


### PR DESCRIPTION
There were some places that were converting a `GenSymEntry` into a
string. This resulted in converting the array contained in the
symbol entry into a string, which will be be very slow.

Change to using the symbol entry's attributes, which just includes
some useful metadata, but not the array itself.

This also adjusts `GenSymEntry.writeThis` to only write a portion of
large arrays instead of the whole thing. That way if they are
accidentally printed in the future there won't be such a large
performance hit.

Resolves #614