### PR TITLE
Make fill* random routines stable with varying numLocales

### DIFF
--- a/src/RandArray.chpl
+++ b/src/RandArray.chpl
@@ -20,71 +20,49 @@ module RandArray {
   } 
 
   proc fillInt(a:[] ?t, const aMin, const aMax, const seedStr:string="None") throws where isIntType(t) {
-    coforall loc in Locales {
-      on loc {
-        ref myA = a.localSlice[a.localSubdomain()];
-        if (seedStr.toLower() == "none") {
-          fillRandom(myA);
-        } else {
-          var seed = (seedStr:int) + here.id;
-          fillRandom(myA, seed);
-        }
-        [ai in myA] if (ai < 0) { ai = -ai; }
-        if (aMax > aMin) {
-          const modulus = aMax - aMin;
-          [x in myA] x = ((x % modulus) + aMin):t;
-          //myA = (myA % modulus) + aMin:t;
-        }
+      if (seedStr.toLower() == "none") {
+        fillRandom(a);
+      } else {
+        var seed = (seedStr:int) + here.id;
+        fillRandom(a, seed);
       }
-    }
+      [ai in a] if (ai < 0) { ai = -ai; }
+      if (aMax > aMin) {
+        const modulus = aMax - aMin;
+        [x in a] x = ((x % modulus) + aMin):t;
+      }
   }
 
   proc fillUInt(a:[] ?t, const aMin, const aMax, const seedStr:string="None") throws where isUintType(t) {
-    coforall loc in Locales {
-      on loc {
-        ref myA = a.localSlice[a.localSubdomain()];
-        if (seedStr.toLower() == "none") {
-          fillRandom(myA);
-        } else {
-          var seed = (seedStr:int) + here.id;
-          fillRandom(myA, seed);
-        }
-        if (aMax > aMin) {
-          const modulus = aMax - aMin;
-          [x in myA] x = ((x % modulus) + aMin):t;
-          //myA = (myA % modulus) + aMin:t;
-        }
+      if (seedStr.toLower() == "none") {
+        fillRandom(a);
+      } else {
+        var seed = (seedStr:int) + here.id;
+        fillRandom(a, seed);
       }
-    }
+      if (aMax > aMin) {
+        const modulus = aMax - aMin;
+        [x in a] x = ((x % modulus) + aMin):t;
+      }
   }
 
   proc fillReal(a:[] real, const aMin:numeric=0.0, const aMax:numeric=1.0, const seedStr:string="None") throws {
-    coforall loc in Locales {
-      on loc {
-        ref myA = a.localSlice[a.localSubdomain()];
-        if (seedStr.toLower() == "none") {
-          fillRandom(myA);
-        } else {
-          var seed = (seedStr:int) + here.id;
-          fillRandom(myA, seed);
-        }
-        const scale = aMax - aMin;
-        myA = scale*myA + aMin;
-      }
+    if (seedStr.toLower() == "none") {
+      fillRandom(a);
+    } else {
+      var seed = (seedStr:int) + here.id;
+      fillRandom(a, seed);
     }
+    const scale = aMax - aMin;
+    a = scale*a + aMin;
   }
 
   proc fillBool(a:[] bool, const seedStr:string="None") throws {
-    coforall loc in Locales {
-      on loc {
-        ref myA = a.localSlice[a.localSubdomain()];
-        if (seedStr.toLower() == "none") {
-          fillRandom(myA);
-        } else {
-          var seed = (seedStr:int) + here.id;
-          fillRandom(myA, seed);
-        }
-      }
+    if (seedStr.toLower() == "none") {
+      fillRandom(a);
+    } else {
+      var seed = (seedStr:int) + here.id;
+      fillRandom(a, seed);
     }
   }
 

--- a/tests/pdarray_creation_test.py
+++ b/tests/pdarray_creation_test.py
@@ -327,12 +327,12 @@ class PdarrayCreationTest(ArkoudaTest):
         pda = ak.random_strings_uniform(minlen=1, maxlen=5, seed=1, size=10)
  
         self.assertTrue((ak.array(['TVKJ', 'EWAB', 'CO', 'HFMD', 'U', 'MMGT', 
-                        'N', 'WOQN', 'HZ', 'VSX']) == pda).any())
+                        'N', 'WOQN', 'HZ', 'VSX']) == pda).all())
         
         pda = ak.random_strings_uniform(minlen=1, maxlen=5, seed=1, size=10,
                                         characters='printable')
         self.assertTrue((ak.array(['+5"f', '-P]3', '4k', '~HFF', 'F', '`,IE', 
-                        'Y', 'jkBa', '9(', '5oZ']) == pda).any())
+                        'Y', 'jkBa', '9(', '5oZ']) == pda).all())
 
     def test_random_strings_lognormal(self):
         pda = ak.random_strings_lognormal(2, 0.25, 100, characters='printable')


### PR DESCRIPTION
Previously `fillInt`, `fillUint`, `fillReal`, and `fillBool` would do a
coforall across the locales and use `fillRandom` on the  local array
with a seed that was based on `here.id`. Basing the seed on the locale
ID made the results unstable as the number of locales varies.

Instead of doing that, just use `fillRandom` on the distributed array.
This routine does similar operations under the covers on distributed
arrays as the manual coforall+local-fill, but we take care to make sure
the results are stable no matter how many locales are used.

This fixes the instability in `test_random_strings_uniform_with_seed()`
as the number of locales changes. I checked that test for 1-32 locales.

Resolves https://github.com/mhmerrill/arkouda/issues/617

Co-developed with @mppf (our RNG expert)