### PR TITLE
Fix compilation error with Chapel git

### DIFF
--- a/src/BroadcastMsg.chpl
+++ b/src/BroadcastMsg.chpl
@@ -4,6 +4,7 @@ module BroadcastMsg {
   use Errors;
   use Reflection;
   use Broadcast;
+  use ServerConfig;
   
   /* 
    * Broadcast a value per segment of a segmented array to the


### PR DESCRIPTION
Bring in `ServerConfig` to make `splitMsgToTuple` available in
`BroadcastMsg`. In 1.23 this was brought in through some lax visibility
rules on methods, but those have been tightened up on the dev branch.