### PR TITLE
Optimize int64 prod reduce

### DIFF
--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -63,13 +63,8 @@ module ReductionMsg
                         return try! "int64 %i".format(val);
                     }
                     when "prod" {
-                      ref ea = e.a;
-                      // If any element is zero, skip the computation and return 0.0
-                      var val: real = 0.0;
-                      if (&& reduce (ea != 0)) {
                         // Cast to real to avoid int64 overflow
-                        val = * reduce ea:real;
-                      }
+                        var val = * reduce e.a:real;
                         // Return value is always float64 for prod
                         return try! "float64 %.17r".format(val);
                     }


### PR DESCRIPTION
Skip a second reduction that would first check for 0's in prod reduce.
This was originally added in f596b73, though we don't remember the exact
intent of it. The 0 check may have been an optimization to avoid the
prod reduce, but the 0 check takes about the same time as the full prod
reduce, which result in 2x the running time when there are no 0's, so
just remove the 0 check.

Note that because numpy is serial and arkouda is parallel, they can
produce different results for prod reductions because the order of
operations is different. An array filled with 0-10000 will reduce to 0
for numpy because it's always `0 * A[i]`, but can be `0` or `nan` in
arkouda. It'll be 0 if arkouda is running serially, but will be `nan`
when parallel because one task will get 0, and another will overflow and
get `inf` and `0 * inf` is nan. Note that numpy will also get nan when
the order of operations is changed like if the array in above is
reversed. e.g.

```python
A = np.arange(0, 10000, 1) * 1.0
B = np.arange(9999, -1, -1) * 1.0

print((np.prod(A), np.prod(B)))                     # (0.0, nan)
print((ak.prod(ak.array(A)), ak.prod(ak.array(B)))) # ({0.0,nan}, nan)
```

So while the answers can technically differ it's just an order of
operations difference, and I think this behavior better matches numpy.

Resolves #620