### PR TITLE
Print out arkouda unit test times

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -91,6 +91,8 @@ jobs:
       run: |
         make check
     - name: Arkouda unit tests
+      env:
+        ARKOUDA_PYTEST_OPTIONS: "--durations=0 --durations-min=5.0"
       run: |
         make test-python
     - name: Arkouda benchmark --correctness-only
@@ -123,7 +125,7 @@ jobs:
       run: |
          ./benchmarks/run_benchmarks.py --correctness-only
 
-  unit_tests_linux:
+  chapel_unit_tests_linux:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -351,7 +351,7 @@ print-%:
 	@echo "$($*)"
 
 test-python: 
-	python3 -m pytest -c pytest.ini
+	python3 -m pytest $(ARKOUDA_PYTEST_OPTIONS) -c pytest.ini
 
 CLEAN_TARGETS += test-clean
 .PHONY: test-clean


### PR DESCRIPTION
Print out test duration for any tests that take longer than 5 seconds
for standard comm=none and comm=gasnet-smp arkouda unit test runs.

Motivated by #388. I've been doing this manually from time to time, but
seems like it could be valuable to have the history in the CI logs.