### PR TITLE
Lower the problem size for groupby_test

### DIFF
--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -4,8 +4,8 @@ from context import arkouda as ak
 from arkouda.dtypes import float64, int64
 from base_test import ArkoudaTest
 
-SIZE = 10000
-GROUPS = 64
+SIZE = 100
+GROUPS = 8
 verbose = True
 
 def groupby_to_arrays(df : pd.DataFrame, kname, vname, op, levels):


### PR DESCRIPTION
groupby_test was taking ~12.5 minutes in gasnet CI testing. Lower the
problem size so it finishes in ~2.5 minutes.

Suggested by @reuster986 in #388