### PR TITLE
Flatten feature

### DIFF
--- a/arkouda/dtypes.py
+++ b/arkouda/dtypes.py
@@ -1,4 +1,4 @@
-from typing import cast, Tuple
+from typing import cast, Tuple, Union
 import numpy as np # type: ignore
 from typeguard import typechecked
 import builtins
@@ -27,8 +27,7 @@ str = np.dtype(np.str)
 DTypes = frozenset(["bool", "int64", "float64", "uint8", "str"])
 DTypeObjects = frozenset([bool, int64, float64, uint8, str])
 
-@typechecked
-def _as_dtype(dt : np.dtype) -> np.dtype:
+def _as_dtype(dt) -> np.dtype:
     if not isinstance(dt, np.dtype):
         return np.dtype(dt)
     return dt

--- a/arkouda/dtypes.py
+++ b/arkouda/dtypes.py
@@ -1,4 +1,4 @@
-from typing import cast, Tuple, Union
+from typing import cast, Tuple
 import numpy as np # type: ignore
 from typeguard import typechecked
 import builtins

--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -15,7 +15,7 @@ __all__ = ["cast", "abs", "log", "exp", "cumsum", "cumprod", "sin", "cos",
            "where", "histogram", "value_counts"]    
 
 @typechecked
-def cast(pda : Union[pdarray, Strings], dt) -> Union[pdarray, Strings]:
+def cast(pda : Union[pdarray, Strings], dt: Union[np.dtype,str]) -> Union[pdarray, Strings]:
     """
     Cast an array to another dtype.
 

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -196,10 +196,6 @@ def concatenate(arrays : Sequence[Union[pdarray,Strings,'Categorical']], #type: 
         Raised if 1..n array elements are dtypes for which
         concatenate has not been implemented.
 
-    Notes
-    -----
-    ak.concatenate is not supported for bool or float64 pdarrays
-
     Examples
     --------
     >>> ak.concatenate([ak.array([1, 2, 3]), ak.array([4, 5, 6])])

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -412,7 +412,7 @@ class Strings:
                                                        self.objtype,
                                                        return_segments,
                                                        json.dumps([delimiter]))
-        repMsg = generic_msg(msg)
+        repMsg = cast(str, generic_msg(msg))
         if return_segments:
             arrays = repMsg.split('+', maxsplit=2)
             return Strings(arrays[0], arrays[1]), create_pdarray(arrays[2])

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -375,6 +375,51 @@ class Strings:
                                                         json.dumps([substr]))
         return create_pdarray(generic_msg(msg))
 
+    def flatten(self, delimiter : str, return_segments : bool=False) -> Union[Strings,Tuple]:
+        """Unpack delimiter-joined substrings into a flat array.
+
+        Parameters
+        ----------
+        delimeter : str
+            Characters used to split strings into substrings
+        return_segments : bool
+            If True, also return mapping of original strings to first substring
+            in return array.
+
+        Returns
+        -------
+        Strings
+            Flattened substrings with delimiters removed
+        pdarray, int64 (optional)
+            For each original string, the index of first corresponding substring
+            in the return array
+
+        See Also
+        --------
+        peel, rpeel
+
+        Examples
+        --------
+        >>> orig = ak.array(['one|two', 'three|four|five', 'six'])
+        >>> orig.flatten('|')
+        array(['one', 'two', 'three', 'four', 'five', 'six'])
+        >>> flat, map = orig.flatten('|', return_segments=True)
+        >>> map
+        array([0, 2, 5])
+        """
+        msg = "segmentedFlatten {}+{} {} {} {}".format(self.offsets.name,
+                                                       self.bytes.name,
+                                                       self.objtype,
+                                                       return_segments,
+                                                       json.dumps([delimiter]))
+        repMsg = generic_msg(msg)
+        if return_segments:
+            arrays = repMsg.split('+', maxsplit=2)
+            return Strings(arrays[0], arrays[1]), create_pdarray(arrays[2])
+        else:
+            arrays = repMsg.split('+', maxsplit=1)
+            return Strings(arrays[0], arrays[1])
+    
     @typechecked
     def peel(self, delimiter : str, times : int=1, includeDelimiter : bool=False, 
              keepPartial : bool=False, fromRight : bool=False) -> Tuple:

--- a/pydoc/usage/creation.rst
+++ b/pydoc/usage/creation.rst
@@ -28,7 +28,11 @@ Random
 
 .. autofunction:: arkouda.randint
 
+.. _concatenate-label:
+                  
 Concatenation
 =============
+
+Performance note: in multi-locale settings, the default (ordered) mode of ``concatenate`` is very communication-intensive because the distribution of the original and resulting arrays are unrelated and most data must be moved non-locally. If the application does not require the concatenated array to be ordered (e.g. if the result is simply going to be sorted anyway), then using the keyword ``ordered=False`` will greatly speed up concatenation by minimizing non-local data movement.
 
 .. autofunction:: arkouda.concatenate

--- a/pydoc/usage/pdarray.rst
+++ b/pydoc/usage/pdarray.rst
@@ -37,6 +37,8 @@ Iteration
 
 While it is possible to iterate directly over a ``pdarray`` with ``for x in array``, this is not recommended because it triggers a transfer of all array data from the arkouda server to the Python client as a ``numpy.ndarray``. This transfer will raise an error if it exceeds the byte limit defined in ``arkouda.maxTransferBytes``. There is almost always a more array-oriented way to express an iterator-based computation; see the coming sections for details.
 
+.. _cast-label:
+
 Type Casting
 ============
 

--- a/pydoc/usage/strings.rst
+++ b/pydoc/usage/strings.rst
@@ -31,7 +31,14 @@ Arkouda ``Strings`` objects support the following operations:
 * :ref:`setops-label`, e.g. ``unique`` and ``in1d``
 * :ref:`sorting-label`, via ``argsort`` and ``coargsort``
 * :ref:`groupby-label`, both alone and in conjunction with numeric arrays
-* Substring search
+* :ref:`cast-label` to and from numeric arrays
+* :ref:`concatenate-label` with other ``Strings``
+
+String-Specific Methods
+=======================
+
+Substring search
+----------------
   
   .. automethod:: arkouda.Strings.contains
                     
@@ -39,7 +46,8 @@ Arkouda ``Strings`` objects support the following operations:
                     
   .. automethod:: arkouda.Strings.endswith
 
-* Splitting and joining
+Splitting and joining
+---------------------
 
   .. automethod:: arkouda.Strings.peel
                   
@@ -48,4 +56,11 @@ Arkouda ``Strings`` objects support the following operations:
   .. automethod:: arkouda.Strings.stick
 
   .. automethod:: arkouda.Strings.lstick
+
+Flattening
+----------
+
+Given an array of strings where each string encodes a variable-length sequence delimited by a common substring, flattening offers a method for unpacking the sequences into a flat array of individual elements. A mapping between original strings and new array elements can be preserved, if desired. This method can be used in pipe
+  
+  .. automethod:: arkouda.Strings.flatten
 

--- a/src/Flatten.chpl
+++ b/src/Flatten.chpl
@@ -1,0 +1,114 @@
+module Flatten {
+  use SegmentedArray;
+  use Errors;
+  use SymArrayDmap;
+  use CommAggregation;
+  use Reflection;
+  
+  proc SegString.flatten(delim: string, returnSegs: bool) throws {
+    if delim.numBytes == 0 {
+      throw new owned ErrorWithContext("Cannot flatten with empty delimiter",
+                                       getLineNumber(),
+                                       getRoutineName(),
+                                       getModuleName(),
+                                       "ValueError");
+    }
+    if this.size == 0 {
+      return (this.offsets.a, this.values.a, this.offsets.a);
+    }
+    // delimHits is true immediately following instances of delim, i.e.
+    // at the starts of newly created segments
+    var delimHits: [this.values.aD] bool;
+    const hitD = this.values.aD.interior(this.values.size - delim.numBytes);
+    delimHits[hitD] = this.findSubstringInBytes(delim)[hitD.translate(-delim.numBytes)];
+    // Hits could be overlapping, if delim is palindromic and > 1 byte
+    // Convert to greedy, erasing overlapping hits
+    for i in 1..(delim.numBytes-1) {
+      delimHits[hitD] &= !delimHits[hitD.translate(-i)];
+    }
+    // Allocate values. Each delim will be replaced by a null byte
+    const nHits = + reduce delimHits;
+    const valSize = this.values.size - (nHits * (delim.numBytes - 1));
+    const valDom = makeDistDom(valSize);
+    var val: [valDom] uint(8);
+    // Allocate offsets. Each instance of delim creates an additional segment.
+    const offDom = makeDistDom(this.offsets.size + nHits);
+    var off: [offDom] int;
+    // Need to merge original offsets with new offsets from delims
+    // offTruth is true at start of every segment (new or old)
+    var offTruth: [this.values.aD] bool = delimHits;
+    forall o in this.offsets.a with (var agg = newDstAggregator(bool)) {
+      agg.copy(offTruth[o], true);
+    }
+    // Running segment number
+    var scanOff = (+ scan offTruth) - offTruth;
+    // Copy over the offsets; later we will shrink them if delim is > 1 byte
+    forall (i, o, t) in zip(this.values.aD, scanOff, offTruth) with (var agg = newDstAggregator(int)) {
+      if t {
+        agg.copy(off[o], i);
+      }
+    }
+    // If user requests mapping of original strings to new ones,
+    // Then we need to build segments based on how many delims were
+    // present in each string, plus the original string boundaries.
+    // Fortunately, scanOff already has this information.
+    const segD = if returnSegs then this.offsets.aD else makeDistDom(0);
+    var seg: [segD] int;
+    if returnSegs {
+      forall (s, o) in zip(seg, this.offsets.a) with (var agg = newSrcAggregator(int)) {
+        agg.copy(s, scanOff[o]);
+      }
+    }
+    // Now copy the values
+    if delim.numBytes == 1 {
+      // Can simply overwrite delim with null byte
+      val = this.values.a;
+      forall (vi, t) in zip(delimHits.domain, delimHits) {
+        if t {
+          // Previous index is where delim occurred
+          val[vi-1] = 0:uint(8);
+        }
+      }
+    } else {
+      // Need to do a gather, much like this.this([] int) but with modified offsets
+      // Strategy: generate a dest-local array of indices to gather from src, so
+      // we can use srcAggregator to copy remote values to local dest.
+
+      // Form the index array by initializing as a derivative and then integrating.
+      // Within a substring, values are consecutive, so derivative is one.
+      // Initialize all derivatives to one, then overwrite substring boundaries.
+      var srcIdx: [valDom] int = 1;
+      // For substring boundaries, derivative = 
+      //     if (previous string terminated by delim) then delim.numBytes else 1;
+      var followsDelim: [offDom] bool;
+      forall (d, o) in zip(followsDelim, off) with (var agg = newSrcAggregator(bool)) {
+        agg.copy(d, delimHits[o]);
+      }
+      const boundaryDeriv = (followsDelim:int * (delim.numBytes - 1)) + 1;
+      // Next step requires offsets to be translated to new domain, i.e. with
+      // delims removed.
+      // Number of delims preceding current string
+      const delimsBefore = + scan followsDelim;
+      // Each delim gets replaced by null byte (length 1)
+      off -= delimsBefore * (delim.numBytes - 1);
+      // Use dest offsets to overwrite the derivative at the substring boundaries
+      forall (o, d) in zip(off, boundaryDeriv) with (var agg = newDstAggregator(int)) {
+        agg.copy(srcIdx[o], d);
+      }
+      // Force first derivative to match start of src domain
+      srcIdx[valDom.low] = this.values.aD.low;
+      // Perform integration to compute gather indices
+      srcIdx = (+ scan srcIdx);
+      // Now we have dest-local copy of src indices, so gather with a src aggregator
+      ref va = this.values.a;
+      forall (v, si) in zip(val, srcIdx) with (var agg = newSrcAggregator(uint(8))) {
+        agg.copy(v, va[si]);
+      }
+      // Finally, fill in null terminators
+      forall o in off[offDom.interior(off.size-1)] with (var agg = newDstAggregator(uint(8))) {
+        agg.copy(val[o-1], 0:uint(8));
+      }
+    }
+    return (off, val, seg);
+  }
+}

--- a/src/FlattenMsg.chpl
+++ b/src/FlattenMsg.chpl
@@ -1,0 +1,42 @@
+module FlattenMsg {
+  use MultiTypeSymbolTable;
+  use MultiTypeSymEntry;
+  use Errors;
+  use Reflection;
+  use Flatten;
+  use ServerConfig;
+  use SegmentedArray;
+  use GenSymIO;
+
+  proc segFlattenMsg(cmd: string, payload: bytes, st: borrowed SymTab) throws {
+    var (name, objtype, returnSegsStr, delimJson) = payload.decode().splitMsgToTuple(4);
+    const returnSegs: bool = returnSegsStr.toLower() == "true";
+    const arr = jsonToPdArray(delimJson, 1);
+    const delim: string = arr[arr.domain.low];
+    var repMsg: string;
+    select objtype {
+      when "str" {
+        const rSegName = st.nextName();
+        const rValName = st.nextName();
+        const optName: string = if returnSegs then st.nextName() else "";
+        var (segName, valName) = name.splitMsgToTuple('+', 2);
+        const strings = new owned SegString(segName, valName, st);
+        var (off, val, segs) = strings.flatten(delim, returnSegs);
+        st.addEntry(rSegName, new shared SymEntry(off));
+        st.addEntry(rValName, new shared SymEntry(val));
+        repMsg = "created %s+created %s".format(st.attrib(rSegName), st.attrib(rValName));
+        if returnSegs {
+          st.addEntry(optName, new shared SymEntry(segs));
+          repMsg += "+created %s".format(st.attrib(optName));
+        }
+      } otherwise {
+        throw new owned ErrorWithContext("Not implemented for objtype %s".format(objtype),
+                                         getLineNumber(),
+                                         getRoutineName(),
+                                         getModuleName(),
+                                         "TypeError");
+      }
+    }
+    return repMsg;
+  }
+}

--- a/src/MsgProcessing.chpl
+++ b/src/MsgProcessing.chpl
@@ -35,6 +35,7 @@ module MsgProcessing
     public use KExtremeMsg;
     public use CastMsg;
     public use BroadcastMsg;
+    public use FlattenMsg;
     
     const mpLogger = new Logger();
     

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -437,7 +437,7 @@ module SegmentedArray {
     proc findSubstringInBytes(const substr: string) {
       // Find the start position of every occurence of substr in the flat bytes array
       // Start by making a right-truncated subdomain representing all valid starting positions for substr of given length
-      var D: subdomain(values.aD) = values.aD[values.aD.low..#(values.size - substr.numBytes)];
+      var D: subdomain(values.aD) = values.aD[values.aD.low..#(values.size - substr.numBytes + 1)];
       // Every start position is valid until proven otherwise
       var truth: [D] bool = true;
       // Shift the flat values one byte at a time and check against corresponding byte of substr

--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -243,6 +243,7 @@ proc main() {
                 when "segmentedBinopvs"  {repMsg = segBinopvsMsg(cmd, payload, st);}
                 when "segmentedGroup"    {repMsg = segGroupMsg(cmd, payload, st);}
                 when "segmentedIn1d"     {repMsg = segIn1dMsg(cmd, payload, st);}
+                when "segmentedFlatten"  {repMsg = segFlattenMsg(cmd, payload, st);}
                 when "lshdf"             {repMsg = lshdfMsg(cmd, payload, st);}
                 when "readhdf"           {repMsg = readhdfMsg(cmd, payload, st);}
                 when "readAllHdf"        {repMsg = readAllHdfMsg(cmd, payload, st);}

--- a/tests/string_test.py
+++ b/tests/string_test.py
@@ -419,3 +419,15 @@ class StringTest(ArkoudaTest):
         print(str(strings))
         self.assertEqual("['string 0', 'string 1', 'string 2', ... , 'string 98', 'string 99', 'string 100']",
                          str(strings))
+
+    def test_flatten(self):
+        orig = ak.array(['one|two', 'three|four|five', 'six'])
+        flat, mapping = orig.flatten('|', return_segments=True)
+        ans = ak.array(['one', 'two', 'three', 'four', 'five', 'six'])
+        ans2 = ak.array([0, 2, 5])
+        self.assertTrue((flat == ans).all())
+        self.assertTrue((mapping == ans2).all())
+        thirds = [ak.cast(ak.arange(i, 99, 3), 'str') for i in range(3)]
+        thickrange = thirds[0].stick(thirds[1], delimiter=', ').stick(thirds[2], delimiter=', ')
+        flatrange = thickrange.flatten(', ')
+        self.assertTrue((ak.cast(flatrange, 'int64') == ak.arange(99)).all())


### PR DESCRIPTION
This PR is in answer to a request from a couple of our users, who wanted the ability to regularize some semi-structured string data in arkouda. The `Strings.flatten(delimiter)` method treats each string in the array as a variable-length, delimited list of values and unpacks it into a flat array, with one value per element. 

In addition to the code itself, this PR adds a unit test and documentation for `flatten` and updates the docs for some related functions that have changed.