### PR TITLE
Correct Strings.__init__ typing

### DIFF
--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -194,7 +194,7 @@ def array(a : Union[pdarray,np.ndarray, Iterable]) -> Union[pdarray, Strings]:
             for i, b in enumerate(s):
                 values[o+i] = b
         # Recurse to create pdarrays for offsets and values, then return Strings object
-        return Strings(array(offsets), array(values))
+        return Strings(cast(array(offsets),pdarray), cast(array(values),pdarray))
     # If not strings, then check that dtype is supported in arkouda
     if a.dtype.name not in DTypes:
         raise RuntimeError("Unhandled dtype {}".format(a.dtype))

--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -194,7 +194,7 @@ def array(a : Union[pdarray,np.ndarray, Iterable]) -> Union[pdarray, Strings]:
             for i, b in enumerate(s):
                 values[o+i] = b
         # Recurse to create pdarrays for offsets and values, then return Strings object
-        return Strings(cast(array(offsets),pdarray), cast(array(values),pdarray))
+        return Strings(cast(pdarray, array(offsets)), cast(pdarray, array(values)))
     # If not strings, then check that dtype is supported in arkouda
     if a.dtype.name not in DTypes:
         raise RuntimeError("Unhandled dtype {}".format(a.dtype))

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -47,8 +47,8 @@ class Strings:
     BinOps = frozenset(["==", "!="])
     objtype = "str"
 
-    def __init__(self, offset_attrib : Union[pdarray,np.ndarray], 
-                 bytes_attrib : Union[pdarray,np.ndarray]) -> None:
+    def __init__(self, offset_attrib : Union[pdarray,str], 
+                 bytes_attrib : Union[pdarray,str]) -> None:
         """
         Initializes the Strings instance by setting all instance
         attributes, some of which are derived from the array parameters.

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -55,9 +55,9 @@ class Strings:
         
         Parameters
         ----------
-        offset_attrib : Union[pdarray, np.ndarray,array]
+        offset_attrib : Union[pdarray, str]
             the array containing the offsets 
-        bytes_attrib : Union[pdarray, np.ndarray,array]
+        bytes_attrib : Union[pdarray, str]
             the array containing the string values    
             
         Returns
@@ -67,8 +67,8 @@ class Strings:
         Raises
         ------
         RuntimeError
-            Raised if there's an error converting a Numpy array or standard
-            Python array to either the offset_attrib or bytes_attrib   
+            Raised if there's an error converting a server-returned str-descriptor
+            or pdarray to either the offset_attrib or bytes_attrib   
         ValueError
             Raised if there's an error in generating instance attributes 
             from either the offset_attrib or bytes_attrib parameter 


### PR DESCRIPTION
correct the typing of the `Strings.__init__` to accept `pdarray` and `str` types instead of `np.ndarray`