### PR TITLE
Resolve a SipHash regression from 605

### DIFF
--- a/src/SipHash.chpl
+++ b/src/SipHash.chpl
@@ -10,6 +10,8 @@ module SipHash {
   param cROUNDS = 2;
   param dROUNDS = 4;
 
+  private config param DEBUG = false;
+
   const defaultSipHashKey: [0..#16] uint(8) = for i in 0..#16 do i: uint(8);
 
   const shLogger = new Logger();
@@ -151,15 +153,17 @@ module SipHash {
     }
 
     inline proc TRACE() {
-        try! {
-          shLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                               "%i v0 %016xu".format(D.size, v0));
-          shLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                               "%i v1 %016xu".format(D.size, v1));
-          shLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                               "%i v2 %016xu".format(D.size, v2));
-          shLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                               "%i v3 %016xu".format(D.size, v3));
+        if DEBUG {
+            try! {
+              shLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                                   "%i v0 %016xu".format(D.size, v0));
+              shLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                                   "%i v1 %016xu".format(D.size, v1));
+              shLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                                   "%i v2 %016xu".format(D.size, v2));
+              shLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                                   "%i v3 %016xu".format(D.size, v3));
+            }
         }
     }
 


### PR DESCRIPTION
In #605 a param flag around the `TRACE` function was removed, which led to a
severe performance degradation for SipHash. What was previously a no-op,
became a `logger.debug()` call. And even though that logger.debug() call was
itself a no-op, there was still a lot of string creation and concatenation at
the call site. Add the param flag back to resolve the regression.

Performance on the nightly chapcs machine with comm=none:

Before:

```
make test-bin/SipHashSpeedTest
./test-bin/SipHashSpeedTest --NINPUTS=100_000
> Hashed 100000 blocks (6.0 MB) in 63.91 seconds (0.09 MB/s)
```

Now:

```
make test-bin/SipHashSpeedTest
./test-bin/SipHashSpeedTest --NINPUTS=100_000
> Hashed 100000 blocks (6.0 MB) in 0.00 seconds (17391.30 MB/s)
./test-bin/SipHashSpeedTest --NINPUTS=100_000_000
> Hashed 100000000 blocks (6152.0 MB) in 0.31 seconds (20112.27 MB/s)
```

Resolves #636