### PR TITLE
Run the IO benchmark as part of regular benchmarking

### DIFF
--- a/benchmarks/IO.py
+++ b/benchmarks/IO.py
@@ -33,12 +33,12 @@ def time_ak_write_read(N_per_locale, trials, dtype, path, seed):
     avgwrite = sum(writetimes) / trials
     avgread = sum(readtimes) / trials
 
-    print("Write times: min = {:.4f} sec, max = {:.4f} sec, avg = {:.4f} sec".format(min(writetimes), max(writetimes), avgwrite))
-    print("Read times : min = {:.4f} sec, max = {:.4f} sec, avg = {:.4f} sec".format(min(readtimes), max(readtimes), avgread))
+    print("write Average time = {:.4f} sec".format(avgwrite))
+    print("read Average time = {:.4f} sec".format(avgread))
 
     nb = a.size * a.itemsize
-    print("Write rates: min = {:.4f} GiB/sec, max = {:.4f} GiB/sec, avg = {:.4f} GiB/sec".format(nb/2**30/max(writetimes), nb/2**30/min(writetimes), nb/2**30/avgwrite))
-    print("Read rates : min = {:.4f} GiB/sec, max = {:.4f} GiB/sec, avg = {:.4f} GiB/sec".format(nb/2**30/max(readtimes), nb/2**30/min(readtimes), nb/2**30/avgread))
+    print("write Average rate = {:.2f} GiB/sec".format(nb/2**30/avgwrite))
+    print("read Average rate = {:.2f} GiB/sec".format(nb/2**30/avgread))
 
 def check_correctness(dtype, path, seed):
     N = 10**4
@@ -58,7 +58,7 @@ def create_parser():
     parser.add_argument('hostname', help='Hostname of arkouda server')
     parser.add_argument('port', type=int, help='Port of arkouda server')
     parser.add_argument('-n', '--size', type=int, default=10**8, help='Problem size: length of array to write/read')
-    parser.add_argument('-t', '--trials', type=int, default=3, help='Number of times to run the benchmark')
+    parser.add_argument('-t', '--trials', type=int, default=1, help='Number of times to run the benchmark')
     parser.add_argument('-d', '--dtype', default='int64', help='Dtype of array ({})'.format(', '.join(TYPES)))
     parser.add_argument('-p', '--path', default=os.getcwd()+'ak-io-test', help='Target path for measuring read/write rates')
     parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')

--- a/benchmarks/graph_infra/IO.perfkeys
+++ b/benchmarks/graph_infra/IO.perfkeys
@@ -1,0 +1,4 @@
+write Average time =
+write Average rate =
+read Average time =
+read Average rate =

--- a/benchmarks/graph_infra/arkouda.graph
+++ b/benchmarks/graph_infra/arkouda.graph
@@ -47,9 +47,15 @@ graphtitle: Set Operations Performance
 ylabel: Performance (GiB/s)
 
 perfkeys: zeros Average rate =, ones Average rate =, randint Average rate =
-graphkeys: zeros GiB/s, ones GiB/s, randint GiB/s
+graphkeys: Zeros GiB/s, Ones GiB/s, Randint GiB/s
 files: array_create.dat, array_create.dat, array_create.dat
 graphtitle: Array Creation Performance
+ylabel: Performance (GiB/s)
+
+perfkeys: write Average rate =, read Average rate =
+graphkeys: Write GiB/s, Read GiB/s
+files: IO.dat, IO.dat
+graphtitle: IO Performance
 ylabel: Performance (GiB/s)
 
 perfkeys: Average rate =

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -20,7 +20,7 @@ from util import *
 logging.basicConfig(level=logging.INFO)
 
 BENCHMARKS = ['stream', 'argsort', 'coargsort', 'groupby', 'gather', 'scatter', 'reduce',
-              'scan', 'noop', 'setops', 'array_create']
+              'scan', 'noop', 'setops', 'array_create', 'IO']
 
 def get_chpl_util_dir():
     """ Get the Chapel directory that contains graph generation utilities. """

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -1410,7 +1410,7 @@ module GenSymIO {
     /*
      * Writes the float, int, or bool pdarray out to hdf5
      */
-    private proc write1DDistArray(filename: string, mode: int, dsetName: string, A, 
+    proc write1DDistArray(filename: string, mode: int, dsetName: string, A,
                                                                 array_type: DType) throws {
         /* Output is 1 file per locale named <filename>_<loc>, and a dataset
         named <dsetName> is created in each one. If mode==1 (append) and the

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -520,7 +520,7 @@ module GenSymIO {
                 return try! "Error: unknown cause";
             }
 
-            gsLogger.error(getModuleName(),getRoutineName(),getLineNumber(),
+            gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                            "Got subdomains and total length for dataset %s".format(dsetName));
 
             select (isSegArray, dataclass) {

--- a/test/COMPOPTS
+++ b/test/COMPOPTS
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+if [[ -n $CHPL_HOME ]]; then
+  export PATH="$PATH:$CHPL_HOME/bin/$CHPL_HOST_BIN_SUBDIR"
+fi
+
 PARENT_DIR=$(dirname $(cd $(dirname $0) ; pwd))
 ARKOUDA_HOME=${ARKOUDA_HOME:-$PARENT_DIR}
 

--- a/test/IOSpeedTest.chpl
+++ b/test/IOSpeedTest.chpl
@@ -1,0 +1,26 @@
+use TestBase;
+use GenSymIO;
+
+config const size = 10**4;
+
+proc main() {
+  var D = makeDistDom(size*numLocales);
+  var A, B: [D] int;
+  A = D;
+  const GiB = (8*D.size):real / (2**30):real;
+
+  var d: Diags;
+
+  d.start();
+  write1DDistArray("file", TRUNCATE, "dst", A, DType.Bool);
+  d.stop(printTime=false);
+  if printTimes then writeln("write: %.2dr GiB/s (%.2drs)".format(GiB/d.elapsed(), d.elapsed()));
+
+  var filenames = generateFilenames("file", "", B);
+  var (subdoms, _)  = get_subdoms(filenames, "dst");
+  d.start();
+  read_files_into_distributed_array(B, subdoms, filenames, "dst");
+  d.stop(printTime=false);
+  if printTimes then writeln("read: %.2dr GiB/s (%.2drs)".format(GiB/d.elapsed(), d.elapsed()));
+  forall (a, b) in zip (A, B) do assert(a == b);
+}

--- a/test/IOSpeedTestMsg.chpl
+++ b/test/IOSpeedTestMsg.chpl
@@ -1,0 +1,35 @@
+use TestBase;
+use GenSymIO;
+
+config const size = 10**4;
+config const write = true;
+config const read = true;
+
+proc main() {
+  var st = new owned SymTab();
+  var A = st.addEntry("A", size*numLocales, int);
+  A.a = A.aD;
+  const GiB = (8*A.aD.size):real / (2**30):real;
+
+  var d: Diags;
+
+  if write {
+    d.start();
+    var cmd = "tohdf";
+    var payload = "A array 0 [\"file\"] int64";
+    tohdfMsg(cmd, payload.encode(), st);
+    d.stop(printTime=false);
+    if printTimes then writeln("write: %.2dr GiB/s (%.2drs)".format(GiB/d.elapsed(), d.elapsed()));
+  }
+
+  if read {
+    d.start();
+    var cmd = "readAllHdf";
+    var payload = "True 1 1 [\"array\"] | [\"file_LOCALE*\"]";
+    var repMsg = readAllHdfMsg(cmd, payload.encode(), st);
+    var B = toSymEntry(st.lookup(parseName(repMsg)), int);
+    d.stop(printTime=false);
+    if printTimes then writeln("read: %.2dr GiB/s (%.2drs)".format(GiB/d.elapsed(), d.elapsed()));
+    forall (a, b) in zip (A.a, B.a) do assert(a == b);
+  }
+}


### PR DESCRIPTION
Add the new IO benchmark to the benchmarks suite and run it as part of
regular/nightly testing.

Also add some standalone IO speed tests.  One that calls
`write1DDistArray()`/`read_files_into_distributed_array()` directly, and
another that calls the msg wrappers `tohdfMsg()`/`readAllHdfMsg()`.
These are being used to investigate #632 and seem like they could be
useful in the longer term.