### PR TITLE
Fix connect() call in registration_test.py

### DIFF
--- a/tests/registration_test.py
+++ b/tests/registration_test.py
@@ -64,7 +64,7 @@ class RegistrationTest(ArkoudaTest):
                                       aar_array.to_ndarray()).all())
         
         ak.disconnect()
-        ak.connect()
+        ak.connect(server=ArkoudaTest.server, port=ArkoudaTest.port)
         aar_array = ak.attach_pdarray('test_int64_a')
         
         self.assertEqual(ar_array.name, aar_array.name)


### PR DESCRIPTION
`test_attach()` was doing a plain `connect()`, which tries to connect to
localhost instead of the server/port the testing systems knows. This
would cause hang in our nightly distributed testing.

Similar to https://github.com/mhmerrill/arkouda/pull/613