### PR TITLE
Optimize string argsort

### DIFF
--- a/src/SegStringSort.chpl
+++ b/src/SegStringSort.chpl
@@ -8,9 +8,10 @@ module SegStringSort {
   use PrivateDist;
   use Reflection;
   use Logging;
+  use ServerConfig;
 
-  private config const SSS_v = true;
-  private const v = SSS_v;
+  private config const SSS_v = false;
+  private const vv = SSS_v;
   private config const SSS_numTasks = here.maxTaskPar;
   private const numTasks = SSS_numTasks;
   private config const SSS_MINBYTES = 8;
@@ -38,14 +39,14 @@ module SegStringSort {
     const lengths = ss.getLengths();
     ssLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                        "Found lengths in %t seconds".format(getCurrentTime() - t));
-    if v { t = getCurrentTime(); }
+    t = getCurrentTime();
     // Compute length survival function and choose a pivot length
     const (pivot, nShort) = getPivot(lengths);
     ssLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                        "Computed pivot in %t seconds".format(getCurrentTime() - t)); 
     ssLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                        "Pivot = %t, nShort = %t".format(pivot, nShort)); 
-    if v {t = getCurrentTime(); }
+    t = getCurrentTime();
     const longStart = ss.offsets.aD.low + nShort;
     const isLong = (lengths >= pivot);
     var locs = [i in ss.offsets.aD] i;
@@ -71,14 +72,14 @@ module SegStringSort {
 
       ssLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                            "Gathered long strings in %t seconds".format(getCurrentTime() - tl));
-      if v { tl = getCurrentTime(); }
+      tl = getCurrentTime();
       // Sort the strings, but bring the inds along for the ride
       const myComparator = new StringIntComparator();
       sort(stringsWithInds, comparator=myComparator);
 
       ssLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                              "Sorted long strings in %t seconds".format(getCurrentTime() - tl));
-      if v { tl = getCurrentTime(); }
+      tl = getCurrentTime();
 
       forall (h, s) in zip(highDom, stringsWithInds.domain) with (var agg = newDstAggregator(int)) {
         const (_,val) = stringsWithInds[s];
@@ -87,7 +88,7 @@ module SegStringSort {
       ssLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                               "Permuted long inds in %t seconds".format(getCurrentTime() - tl));
     }
-    if v { t = getCurrentTime(); }
+    t = getCurrentTime();
     const ranks = radixSortLSD_raw(ss.offsets.a, lengths, ss.values.a, gatherInds, pivot);
     ssLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                           "Sorted ranks in %t seconds".format(getCurrentTime() - t));

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -706,7 +706,7 @@ module SegmentedArray {
       return (&& reduce (ediff() >= 0));
     }
 
-    proc argsort(checkSorted:bool=true): [offsets.aD] int throws {
+    proc argsort(checkSorted:bool=false): [offsets.aD] int throws {
       const ref D = offsets.aD;
       const ref va = values.a;
       if checkSorted && isSorted() {

--- a/test/StringArgsortSpeedTest.chpl
+++ b/test/StringArgsortSpeedTest.chpl
@@ -1,0 +1,20 @@
+use TestBase;
+
+config const size = 10**4;
+config const minLen = 1;
+config const maxLen = 8;
+
+proc main() {
+  var st = new owned SymTab();
+  var (segs, vals) = newRandStringsUniformLength(size*numLocales, minLen, maxLen);
+  var strings = new owned SegString(segs, vals, st);
+
+  var d: Diags;
+  d.start();
+  strings.argsort();
+  d.stop(printTime=false);
+
+  const MB = byteToMB(vals.size);
+  if printTimes then
+    writef("Sorted %i strings (%.1dr MB) in %.2dr seconds (%.2dr MB/s)\n", size*numLocales, MB, d.elapsed(), MB/d.elapsed());
+}


### PR DESCRIPTION
Skip checking if strings are already sorted and use more aggregation to
optimize string argsort

`SegString.isSorted()` involves a lot of fine-grained remote array
accesses, which doesn't perform well. Skip that check since it's faster
to just sort directly. We can probably optimize this check later, but
for now it was easier to just skip it.

Use aggregation to gather values in string sorting. Elements from the
`values` array can be remote, so using aggregation avoids lots of
fine-grained remote accesses. To do that replace `unorderedCopy` for the
first `copyDigit` with assignment for local operations and aggregation
for the potentially remote `values`. Increase aggregation usage for the
second `copyDigit` by aggregating the remote `values` as well. Note that
this requires calculating and storing the bucket position prior to
gathering the new values/digits.

Perf results for str-argsort on 16-node-xc and 16-node-cs-hdr. First 3
use the current default problem size (10**6), but with this we can start
running larger problem sizes as shown in the last 2 rows:

| config            | 16-node-xc   | 16-node-cs-hdr |
| ----------------- | ------------ | -------------- |
| master            | 0.0086 GiB/s | 0.0027 GiB/s   |
| no checkSorted    | 0.0414 GiB/s | 0.0035 GiB/s   |
| copyDigit agg     | 0.1137 GiB/s | 0.0118 GiB/s   |
| --size=$((10**8)) | 0.8214 GiB/s | 0.7413 GiB/s   |
| --size=$((2**29)) | 0.8543 GiB/s | 1.6285 GiB/s   |

Part of https://github.com/mhmerrill/arkouda/issues/659