### PR TITLE
Remove some old compatibility shims

### DIFF
--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -561,7 +561,7 @@ module ArgSortMsg
 
           var ivname = st.nextName();
           var merged = makeDistArray(size, numDigits*uint(bitsPerDigit));
-          var curDigit = RSLSD_tupleLow + numDigits - totalDigits;
+          var curDigit = numDigits - totalDigits;
           for (name, nBits, neg) in zip(names, bitWidths, negs) {
               var g: borrowed GenSymEntry = st.lookup(name);
               proc mergeArray(type t) {

--- a/src/CommAggregation.chpl
+++ b/src/CommAggregation.chpl
@@ -126,7 +126,7 @@ module CommAggregation {
       unorderedCopyTaskFence();
     }
     inline proc copy(ref dst: elemType, const in srcVal: elemType) {
-      unorderedCopyWrapper(dst, srcVal);
+      unorderedCopy(dst, srcVal);
     }
   }
 
@@ -246,7 +246,7 @@ module CommAggregation {
     }
     inline proc copy(ref dst: elemType, const ref src: elemType) {
       assert(dst.locale.id == here.id);
-      unorderedCopyWrapper(dst, src);
+      unorderedCopy(dst, src);
     }
   }
 
@@ -343,23 +343,6 @@ module CommAggregation {
   //
   // Helper routines
   //
-
-  // Unordered copy wrapper that also supports tuples. In 1.20 this will call
-  // unorderedCopy for each tuple element, but in 1.21 it is a single call.
-  private inline proc unorderedCopyWrapper(ref dst, const ref src): void {
-    use Reflection;
-    // Always resolves in 1.21, only resolves for numeric/bool types in 1.20
-    if canResolve("unorderedCopy", dst, src) {
-      unorderedCopy(dst, src);
-    } else if isTuple(dst) && isTuple(src) {
-      for param i in 1..dst.size {
-        unorderedCopyWrapper(dst(i), src(i));
-      }
-    } else {
-      compilerWarning("Missing optimized unorderedCopy for " + dst.type:string);
-      dst = src;
-    }
-  }
 
   private proc getEnvInt(name: string, default: int): int {
     extern proc getenv(name : c_string) : c_string;

--- a/src/RadixSortLSD.chpl
+++ b/src/RadixSortLSD.chpl
@@ -13,9 +13,6 @@ module RadixSortLSD
     private param numBuckets = 1 << bitsPerDigit; // these need to be const for comms/performance reasons
     private param maskDigit = numBuckets-1; // these need to be const for comms/performance reasons
 
-    // Hack to determine tuple lower bound across 1.20-1.22
-    const RSLSD_tupleLow = [1..1].domain.low;
-
     use BlockDist;
     use BitOps;
     use AryUtil;
@@ -67,7 +64,7 @@ module RadixSortLSD
     inline proc getBitWidth(a: [?aD] ?t): (int, bool)
         where isHomogeneousTuple(t) && t == t.size*uint(bitsPerDigit) {
       for digit in 0..t.size-1 {
-        const m = max reduce [ai in a] ai[RSLSD_tupleLow+digit];
+        const m = max reduce [ai in a] ai(digit);
         if m > 0 then return ((t.size-digit) * bitsPerDigit, false);
       }
       return (t.size * bitsPerDigit, false);
@@ -115,7 +112,7 @@ module RadixSortLSD
 
     inline proc getDigit(key: _tuple, rshift: int, last: bool, negs: bool): int
         where isHomogeneousTuple(key) && key.type == key.size*uint(bitsPerDigit) {
-      const keyHigh = key.size - (1-RSLSD_tupleLow);
+      const keyHigh = key.size - 1;
       return key[keyHigh - rshift/bitsPerDigit]:int;
     }
 


### PR DESCRIPTION
Arkouda requires Chapel 1.22 or newer nowadays, so remove some
compatibility shims for older versions of Chapel.

Remove `unorderedCopyWrapper`, which was a compatibility shim to have
code work with 1.20 and 1.21.

Remove some tuple indexing tricks that were only needed when supporting
1.21 and 1.22 concurrently. This reverts 88d1f44.