### PR TITLE
Skip long string partitioning in string argsort

### DIFF
--- a/test/StringArgsortSpeedTest.chpl
+++ b/test/StringArgsortSpeedTest.chpl
@@ -2,7 +2,7 @@ use TestBase;
 
 config const size = 10**4;
 config const minLen = 1;
-config const maxLen = 8;
+config const maxLen = 16;
 
 proc main() {
   var st = new owned SymTab();


### PR DESCRIPTION
String argsort first partitions long strings and sorts them separately.
The core string radix sort then has an iteration for every digit of the
longest short string, so the idea is that if you just have a few long
strings you sort them separately and you can minimize the total number
of iterations in the core radix sort. This is still a good idea, but the
current implementation has pretty high overhead, especially for single
node, so skip it by default. Note that prior to optimizing the core
radix sort in #671 the separate sorting was still a win for performance,
but after that the core radix sort is much faster and we'll have to do
more tuning for the separate long string sorting.

I expect to revisit this in the future since the idea is still good, but
I think we need to improve the heuristics for what to consider a long
string and look at optimizing the sort that's used for long strings.

This improves single node str-argsort. There's no difference for the
multi-locale str-argsort since it happened to set up the pivot such that
everything was considered short anyways. Here's some chapcs comm=none
results before and after this change:

```
make test-bin/StringArgsortSpeedTest
```

| size  | before    | after      |
| ----- | --------: | ---------: |
| 10**6 | 0.6 MB/s  |  81.0 MB/s |
| 10**8 | timed out | 128.9 MB/s |

Resolves #680