### PR TITLE
Improve the performance of truncating existing hdf5 files

### DIFF
--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -1635,25 +1635,20 @@ module GenSymIO {
               warnFlag = false;
           }
 
-          for loc in 0..#A.targetLocales().size {
-              /*
-               * When done with a coforall over locales, only locale 0's file gets created
-               * correctly, whereas hhe other locales' files have corrupted headers.
-               */
-              //filenames[loc] = try! "%s_LOCALE%s%s".format(prefix, loc:string, extension);
+          coforall loc in A.targetLocales() do on loc {
               var file_id: C_HDF5.hid_t;
 
               gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                                              "Creating or truncating file");
 
-              file_id = C_HDF5.H5Fcreate(filenames[loc].c_str(), C_HDF5.H5F_ACC_TRUNC,
+              file_id = C_HDF5.H5Fcreate(filenames[loc.id].localize().c_str(), C_HDF5.H5F_ACC_TRUNC,
                                                         C_HDF5.H5P_DEFAULT, C_HDF5.H5P_DEFAULT);
               
               prepareGroup(file_id, group);
 
               if file_id < 0 { // Negative file_id means error
                   throw getErrorWithContext(
-                                    msg="The file %s does not exist".format(filenames[loc]),
+                                    msg="The file %s does not exist".format(filenames[loc.id]),
                                     lineNumber=getLineNumber(), 
                                     routineName=getRoutineName(), 
                                     moduleName=getModuleName(), 
@@ -1736,23 +1731,18 @@ module GenSymIO {
               warnFlag = false;
           }
 
-          for loc in 0..#A.targetLocales().size {
-              /*
-               * When done with a coforall over locales, only locale 0's file gets created
-               * correctly, whereas hhe other locales' files have corrupted headers.
-               */
-              //filenames[loc] = try! "%s_LOCALE%s%s".format(prefix, loc:string, extension);
+          coforall loc in A.targetLocales() do on loc {
               var file_id: C_HDF5.hid_t;
 
               gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                                               "Creating or truncating file");
 
-              file_id = C_HDF5.H5Fcreate(filenames[loc].c_str(), C_HDF5.H5F_ACC_TRUNC,
+              file_id = C_HDF5.H5Fcreate(filenames[loc.id].localize().c_str(), C_HDF5.H5F_ACC_TRUNC,
                                                       C_HDF5.H5P_DEFAULT, C_HDF5.H5P_DEFAULT);
 
               if file_id < 0 { // Negative file_id means error
                   throw getErrorWithContext(
-                                     msg="The file %s does not exist".format(filenames[loc]),
+                                     msg="The file %s does not exist".format(filenames[loc.id]),
                                      lineNumber=getLineNumber(), 
                                      routineName=getRoutineName(), 
                                      moduleName=getModuleName(), 


### PR DESCRIPTION
Improve performance of truncating existing hdf5 files by parallelizing
file creation. This improves the performance of writing hdf5 files when
the files already exist.

I was seeing poor write performance for the standalone IO benchmarks
when run a second time. These tests don't remove the files after running
and it turned out that truncating existing files was performing poorly.
This parallelizes and distributes the file creation to improve
performance. It's not clear to me why file truncation in hdf5 is slow,
but I think we want to be parallel here anyways. It was made serial in
fb122a5 due to string corruption, but I believe this was just due to a
lack of localizing a chapel string before converting it to a c string.

16-node-cs-hdr before:

```
make test-bin/IOSpeedTest
./test-bin/IOSpeedTest -nl 16 --size=$((10**8))
read: 16.26 GiB/s (0.73s)

./test-bin/IOSpeedTest -nl 16 --size=$((10**8))
write: 3.57 GiB/s (3.34s)

rm file_LOCALE00*
./test-bin/IOSpeedTest -nl 16 --size=$((10**8))
write: 16.26 GiB/s (0.73s)
```

16-node-cs-hdr after:
```
make test-bin/IOSpeedTest
./test-bin/IOSpeedTest -nl 16 --size=$((10**8))
write: 16.22 GiB/s (0.74s)

./test-bin/IOSpeedTest -nl 16 --size=$((10**8))
write: 16.25 GiB/s (0.73s)
```

This won't impact the nightly benchmark since it deletes the file
between runs and I'm guessing this isn't a very common use case in
practice, but it seemed worth addressing regardless.

Related to #632