### PR TITLE
Issue #693 : Adds fixes and patches to get Chapel based Arkouda server docs to build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ ARKOUDA_PROJECT_DIR := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 
 PROJECT_NAME := arkouda
 ARKOUDA_SOURCE_DIR := $(ARKOUDA_PROJECT_DIR)/src
+ARKOUDA_LOCAL_SOURCE_DIR := src
 ARKOUDA_MAIN_MODULE := arkouda_server
 ARKOUDA_MAKEFILES := Makefile Makefile.paths
 
@@ -267,7 +268,7 @@ doc-server: ${DOC_DIR} $(DOC_SERVER_OUTPUT_DIR)/index.html
 $(DOC_SERVER_OUTPUT_DIR)/index.html: $(ARKOUDA_SOURCES) $(ARKOUDA_MAKEFILES) | $(DOC_SERVER_OUTPUT_DIR)
 	@echo "Building documentation for: Server"
 	@# Build the documentation to the Chapel output directory
-	$(CHPLDOC) $(CHPLDOC_FLAGS) $(ARKOUDA_MAIN_SOURCE) -o $(DOC_SERVER_OUTPUT_DIR)
+	$(CHPLDOC) $(CHPLDOC_FLAGS) $(ARKOUDA_LOCAL_SOURCE_DIR)/$(ARKOUDA_MAIN_MODULE).chpl -o $(DOC_SERVER_OUTPUT_DIR)
 	@# Create the .nojekyll file needed for github pages in the  Chapel output directory
 	touch $(DOC_SERVER_OUTPUT_DIR)/.nojekyll
 	@echo "Completed building documentation for: Server"

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ This yielded a >20TB dataframe in Arkouda.
  * requires typeguard for runtime type checking
  * requires pandas for testing and conversion utils
  * requires pytest, pytest-env, and h5py to execute the Python test harness
- * requires sphinx, sphinx-argparse, and sphinx-autoapi to generate docs
+ * requires sphinx, sphinx-argparse, sphinx-autoapi, sphinx-rtd-theme, sphinxcontrib-chapeldomain to generate docs
 
 <a id="prereq-mac"></a>
 ### MacOS Environment <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>

--- a/chapel-patches/README.md
+++ b/chapel-patches/README.md
@@ -1,0 +1,21 @@
+# Chapel Patches
+
+From time to time we may need to apply a patch to chapel.  This outlines the
+patches, corresponding chapel version, and the reason it is needed along with any
+instructions to apply it.
+
+### chpldoc.693.patch
+This patch is required for Chapel version 1.23.0 and corresponds to Arkouda
+Github issue #693.  It syncs the version of Sphinx etc. needed to get the chpldoc
+make target to compile correctly.  To apply (perfom commands in your CHPL_HOME:
+```bash
+# In the root of your chapel source code run
+git apply --stat ${AK_HOME}/chapel-patches/chpldoc.693.patch  # To show what will be changed
+git apply --check ${AK_HOME}/chapel-patches/chpldoc.693.patch  # To check
+git apply ${AK_HOME}/chapel-patches/chpldoc.693.patch  # To apply patch and modify files
+make chpldoc  # Previously that target should have failed, after the patch it should work correctly
+
+# Note, if you haven't installed python packages sphinx-rtd-theme and sphinxcontrib-chapeldomain you should do that now
+pip install sphinx-rtd-theme
+pip install sphinxcontrib-chapeldomain
+```

--- a/chapel-patches/chpldoc.693.patch
+++ b/chapel-patches/chpldoc.693.patch
@@ -1,0 +1,58 @@
+From 04dcc9f6145e64c632babddbdcd1b6694ae9dbd1 Mon Sep 17 00:00:00 2001
+From: glitch <glitch@users.noreply.github.com>
+Date: Sat, 6 Mar 2021 06:59:55 -0500
+Subject: [PATCH] GH-693 : Chapel patch for version 1.23.0 to get `chpldoc`
+ target to build. The required changes update and sync the versions of sphinx
+ etc.
+
+---
+ third-party/chpl-venv/chpldoc-requirements.txt                | 4 ++--
+ .../chpl-venv/sphinxcontrib-chapeldomain/requirements.txt     | 4 ++--
+ third-party/chpl-venv/sphinxcontrib-chapeldomain/setup.py     | 2 +-
+ 3 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/third-party/chpl-venv/chpldoc-requirements.txt b/third-party/chpl-venv/chpldoc-requirements.txt
+index e73a957863..892d930190 100644
+--- a/third-party/chpl-venv/chpldoc-requirements.txt
++++ b/third-party/chpl-venv/chpldoc-requirements.txt
+@@ -2,12 +2,12 @@
+ Jinja2==2.10.1
+ MarkupSafe==1.1.1
+ Pygments==2.4.2
+-Sphinx==1.8.5
++Sphinx==3.2.1
+ # Sphinx==2.0.1 # requires python 3
+ # Sphinx==2.1.2 # requires python 3
+ # Sphinx==2.2.0 # requires python 3
+ docutils==0.15.2
+ argparse==1.4.0
+-sphinx-rtd-theme==0.4.3
++sphinx-rtd-theme==0.5.0
+ ./sphinxcontrib-chapeldomain
+ babel==2.7.0
+diff --git a/third-party/chpl-venv/sphinxcontrib-chapeldomain/requirements.txt b/third-party/chpl-venv/sphinxcontrib-chapeldomain/requirements.txt
+index 47d36821ed..e01b0f77a4 100644
+--- a/third-party/chpl-venv/sphinxcontrib-chapeldomain/requirements.txt
++++ b/third-party/chpl-venv/sphinxcontrib-chapeldomain/requirements.txt
+@@ -1,3 +1,3 @@
+-docutils<=0.14
++docutils==0.15.2
+ six
+-Sphinx==1.8.5
++Sphinx==3.2.1
+diff --git a/third-party/chpl-venv/sphinxcontrib-chapeldomain/setup.py b/third-party/chpl-venv/sphinxcontrib-chapeldomain/setup.py
+index 78efb511a1..97eea973a0 100644
+--- a/third-party/chpl-venv/sphinxcontrib-chapeldomain/setup.py
++++ b/third-party/chpl-venv/sphinxcontrib-chapeldomain/setup.py
+@@ -44,7 +44,7 @@ setup(
+     install_requires=[
+         'docutils',
+         'six',
+-        'Sphinx>=1.6.0,<1.6.999',
++        'Sphinx>=3.2.1',
+     ],
+     namespace_packages=['sphinxcontrib']
+ )
+-- 
+2.25.1
+

--- a/pydoc/requirements.txt
+++ b/pydoc/requirements.txt
@@ -1,6 +1,8 @@
 Sphinx
 sphinx-argparse
 sphinx-autoapi
+sphinxcontrib-chapeldomain
+sphinx-rtd-theme
 h5py
 pandas
 pexpect

--- a/pydoc/server/index.rst
+++ b/pydoc/server/index.rst
@@ -1,2 +1,3 @@
 Chapel API Reference	
 ====================
+This is just a placeholder!  It should get removed as part of the build process.

--- a/setup.py
+++ b/setup.py
@@ -147,8 +147,8 @@ setup(
     # projects.
     extras_require={  # Optional
         'dev': ['h5py','pexpect', 'pytest', 
-                'pytest-env','Sphinx', 'sphinx-argparse', 
-                'sphinx-autoapi', 'mypy', "sphinxcontrib-chapeldomain", "sphinx-rtd-theme"],
+                'pytest-env','Sphinx>=3.5.1', 'sphinx-argparse>=0.2.5',
+                'sphinx-autoapi>=1.6.0', 'mypy', "sphinxcontrib-chapeldomain>=0.0.19", "sphinx-rtd-theme>=0.5.1"],
     },
     # replace orginal install command with version that also builds
     # chapel and the arkouda server.

--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,7 @@ setup(
     extras_require={  # Optional
         'dev': ['h5py','pexpect', 'pytest', 
                 'pytest-env','Sphinx', 'sphinx-argparse', 
-                'sphinx-autoapi', 'mypy'],
+                'sphinx-autoapi', 'mypy', "sphinxcontrib-chapeldomain", "sphinx-rtd-theme"],
     },
     # replace orginal install command with version that also builds
     # chapel and the arkouda server.


### PR DESCRIPTION
Adds fixes and patches to get Chapel based Arkouda server docs to build.
 - Adds patch for Chapel source 1.23.0 to get chpldoc command to build with README instructions.
 - Adds and updates sphinx related requirements.

I looked at different methods to get this working and I believe this was the simplest, most straight forward approach.  The Chapel team has fixed the issue upstream so the patches are an interim solution until Arkouda moves to a new Chapel version (not yet released).

The README.md under chapel-patches outlines the basic instructions, but to summarize:
  - Apply the patch to Chapel source code via git. (Note: Chapel source can be from an exploded tarball, it doesn't need to be checked out from github or anything, git is just being used at the tool to apply a patch in this case)
  - In Chapel source root, `make  chpldoc`
  - Install two additional python packages via pip: sphinx-rtd-theme and sphinxcontrib-chapeldomain
  - In Arkouda root, `make doc`