### PR TITLE
Issue #693: Use github pages as an alternative to readthedocs.

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,4 +1,4 @@
-name: CI
+name: docs-gh-pages
 
 # Only publish docs when master changes
 on:
@@ -11,6 +11,7 @@ env:
 
 jobs:
   docs:
+    if: github.repository == 'mhmerrill/arkouda'
     runs-on: ubuntu-latest
     container:
       image: chapel/chapel:1.23.0

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,30 @@
+name: CI
+
+# Only publish docs when master changes
+on:
+  push:
+    branches:
+      - master
+
+env:
+  ARKOUDA_QUICK_COMPILE: true
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    container:
+      image: chapel/chapel:1.23.0
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: |
+        apt-get update && apt-get install -y python3-pip rsync
+        python3 -m pip install -e .[dev]
+    - name: Arkouda make doc
+      run: |
+        make doc
+    - name: publish-docs
+      uses: JamesIves/github-pages-deploy-action@4.1.0
+      with:
+        branch: gh-pages # This is the branch we'll deploy to
+        folder: docs # The folder we want to deploy, it becomes the root src of the branch

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 [Arkouda PDF Documentation](https://arkouda.readthedocs.io/_/downloads/en/latest/pdf/)
 
+[Arkouda docs at Github Pages](https://mhmerrill.github.io/arkouda)
+
 ## Nightly Arkouda Performance Charts
 [Arkouda nightly performance charts](https://chapel-lang.org/perf/arkouda/)
 


### PR DESCRIPTION
See Issue #693 

ReadTheDocs doesn't allow for custom docker containers when they pull your repo to build the docs, which means the `chpldoc` command isn't available.

An alternative is to use Github Pages to host the documentation.  This PR adds a new workflow to publish the documentation generated by the `make doc` target to a special branch in the repo named `gh-pages`.

Caveats:
- This workflow will only trigger on merges to master.  To see an example of what the gh-pages branch and documentation look like see:
    - https://github.com/glitch/arkouda/tree/gh-pages
    - https://glitch.github.io/arkouda/
- A corresponding configuration change in the Github repo settings is needed to activate/configure Github Pages

Configuration Steps

1. Click Settings and scroll to "GitHub Pages"
2. Under GitHub Pages / Source set the branch to `gh-pages` and set the folder to `/ (root)`

After the gh-pages.yml workflow runs the documentation should be available at mhmerrill.github.io/arkouda