### PR TITLE
Issue #693: Use github pages as an alternative to readthedocs.

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,33 @@
+name: docs-gh-pages
+
+# Only publish docs when master changes
+on:
+  push:
+    branches:
+      - master
+
+env:
+  ARKOUDA_QUICK_COMPILE: true
+
+jobs:
+  docs:
+    if: github.repository == 'mhmerrill/arkouda'
+    runs-on: ubuntu-latest
+    container:
+      image: chapel/chapel:1.23.0
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: |
+        apt-get update && apt-get install -y python3-pip rsync
+        python3 -m pip install -e .[dev]
+    - name: Arkouda make doc
+      run: |
+        make doc
+    - name: publish-docs
+      uses: JamesIves/github-pages-deploy-action@4.1.0
+      with:
+        repository-name: Bears-R-Us/arkouda-docs # The repository we'll deploy to
+        branch: gh-pages # This is the branch we'll deploy to
+        folder: docs # The local folder we want to deploy, it becomes the root src of the branch
+        token: ${{ secrets.ARKOUDA_DOCS_TOKEN }} # You must have a personal access token and repo secret created.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 [Arkouda PDF Documentation](https://arkouda.readthedocs.io/_/downloads/en/latest/pdf/)
 
+[Arkouda docs at Github Pages](https://bears-r-us.github.io/arkouda-docs/)
+
 ## Nightly Arkouda Performance Charts
 [Arkouda nightly performance charts](https://chapel-lang.org/perf/arkouda/)
 


### PR DESCRIPTION
This adds a separate workflow which will publish to an alternate repo.
It will only trigger when run on the main/configured arkouda repo.
You must have the appropriate remote repo write permissions along with
a personal access token and repo secret configured for authentication.

What we're going to do:
-----------------------
Set up a Github "Personal Access Token" and set it as a "Secret" for our Repository.  We are going to use this token/secret to perform Github actions on our behalf.  Who really needs this?  Folks who have Bears-R-Us Organization & Repo write-access to the `arkouda-docs` repository.  This will allow merged pull-requests and pushes on mhmerrill/arkouda : master branch to automatically update the auto-generated documentation over in Bear-R-Us:arkouda-docs repo (gh-pages branch).

Why a Personal Access Token?
----------------------------
We could also generate an SSH key-pair and share it with everybody but it requires a lot more configuration in the Github action workflow.  Also if anybody exposes the shared key it affects the group, whereas you can manage your personal access token yourself and access an be maintained purely within the Bears-R-Us repoository "Access" section.

What happens if I don't have a token?
-------------------------------------
The `publish-docs` workflow target will fail if you merge a PR or make a direct push to the master branch of Arkouda.  Someone with the proper access and configured token will need to re-run that workflow to have the docs generated & published.

How to:
-------
Create a personal access token outlined here: https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token
Grant your token "workflow" access which will enable the minimum set of access controls necessary.

**COPY THE VALUE OF THIS TOKEN** into a temporary text file or something because it disappears forever when you navigate away from the page.

Navigate to your Arkouda repo.
Select the "Settings" tab (right-most tab)
Select "Secrets" from the left hand menu (towards the bottom)
Click the "New Repository Secret" button at the top right.

Name the secret: "ARKOUDA_DOCS_TOKEN"
and copy your personal access token string into the Value section.
Click the "Add secret" button

You should now see the ARKOUDA_DOCS_TOKEN saved as a Repository secret.
This makes it available to your Github actions.  You can delete/revoke the Secret and/or token at any time.