### PR TITLE
Closes #665 : Updates GroupBy example documentation.

### DIFF
--- a/pydoc/usage/groupby.rst
+++ b/pydoc/usage/groupby.rst
@@ -10,7 +10,9 @@ For example, imagine a dataset with two columns, ``userID`` and ``dayOfWeek``. T
 
 .. code-block:: python
 
-   byDayOfWeek = ak.GroupBy(dayOfWeek)
+   # Note: The GroupBy arg should be the values of the dayOfWeek column
+   #       and must be an Arkouda compatible data structure i.e. `pdarray`
+   byDayOfWeek = ak.GroupBy(data['dayOfWeek'])
    day, numIDs = byDayOfWeek.aggregate(userID, 'nunique')
 
 


### PR DESCRIPTION
Updating Documentation for GroupBy example.  I also added a small note since I didn't want people thinking they could pass the contents of a pandas dataframe column or a list straight out of a python dictionary etc.