### PR TITLE
Adjust uses of functions in the Memory module for 1.24

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,6 @@ check-deps: $(CHECK_DEPS)
 CHPL_MINOR := $(shell $(CHPL) --version | sed -n "s/chpl version 1\.\([0-9]*\).*/\1/p")
 CHPL_VERSION_OK := $(shell test $(CHPL_MINOR) -ge 22 && echo yes)
 CHPL_VERSION_WARN := $(shell test $(CHPL_MINOR) -le 22 && echo yes)
-
 .PHONY: check-chpl
 check-chpl:
 ifneq ($(CHPL_VERSION_OK),yes)
@@ -187,7 +186,8 @@ ARKOUDA_MAIN_SOURCE := $(ARKOUDA_SOURCE_DIR)/$(ARKOUDA_MAIN_MODULE).chpl
 # The Memory module was moved to Memory.Diagnostics in 1.24. Due to how
 # resolution of use and import statements works, we have to conditionally
 # use one of two definitions of a wrapper module as a workaround.
-# Resolving Chapel issue #17438 would fix this.
+# Resolving Chapel issue #17438 or making 1.24 the minimum required version
+# would fix this.
 ifeq ($(shell expr $(CHPL_MINOR) \>= 24),1)
 	ARKOUDA_COMPAT_MODULES := -M $(ARKOUDA_SOURCE_DIR)/compat/ge-124
 else

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ check-deps: $(CHECK_DEPS)
 CHPL_MINOR := $(shell $(CHPL) --version | sed -n "s/chpl version 1\.\([0-9]*\).*/\1/p")
 CHPL_VERSION_OK := $(shell test $(CHPL_MINOR) -ge 22 && echo yes)
 CHPL_VERSION_WARN := $(shell test $(CHPL_MINOR) -le 22 && echo yes)
+
 .PHONY: check-chpl
 check-chpl:
 ifneq ($(CHPL_VERSION_OK),yes)
@@ -183,8 +184,18 @@ endif
 ARKOUDA_SOURCES = $(shell find $(ARKOUDA_SOURCE_DIR)/ -type f -name '*.chpl')
 ARKOUDA_MAIN_SOURCE := $(ARKOUDA_SOURCE_DIR)/$(ARKOUDA_MAIN_MODULE).chpl
 
+# The Memory module was moved to Memory.Diagnostics in 1.24. Due to how
+# resolution of use and import statements works, we have to conditionally
+# use one of two definitions of a wrapper module as a workaround.
+# Resolving Chapel issue #17438 would fix this.
+ifeq ($(shell expr $(CHPL_MINOR) \>= 24),1)
+	ARKOUDA_COMPAT_MODULES := -M $(ARKOUDA_SOURCE_DIR)/compat/ge-124
+else
+	ARKOUDA_COMPAT_MODULES := -M $(ARKOUDA_SOURCE_DIR)/compat/lt-124
+endif
+
 $(ARKOUDA_MAIN_MODULE): check-deps $(ARKOUDA_SOURCES) $(ARKOUDA_MAKEFILES)
-	$(CHPL) $(CHPL_DEBUG_FLAGS) $(PRINT_PASSES_FLAGS) $(CHPL_FLAGS_WITH_VERSION) $(ARKOUDA_MAIN_SOURCE) -o $@
+	$(CHPL) $(CHPL_DEBUG_FLAGS) $(PRINT_PASSES_FLAGS) $(CHPL_FLAGS_WITH_VERSION) $(ARKOUDA_MAIN_SOURCE) $(ARKOUDA_COMPAT_MODULES) -o $@
 
 CLEAN_TARGETS += arkouda-clean
 .PHONY: arkouda-clean

--- a/src/MsgProcessing.chpl
+++ b/src/MsgProcessing.chpl
@@ -9,7 +9,6 @@ module MsgProcessing
     use Errors;
     use Logging;
     use Message;
-    use Memory;
     
     use MultiTypeSymbolTable;
     use MultiTypeSymEntry;
@@ -190,7 +189,7 @@ module MsgProcessing
         var (_) = payload.splitMsgToTuple(1); // split request into fields
         mpLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"cmd: %s".format(cmd));
         if (memTrack) {
-            return new MsgTuple((memoryUsed():uint * numLocales:uint):string, MsgType.NORMAL);
+            return new MsgTuple((getMemUsed():uint * numLocales:uint):string, MsgType.NORMAL);
         }
         else {
             return new MsgTuple(st.memUsed():string, MsgType.NORMAL);

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -130,28 +130,16 @@ module ServerConfig
     Get the physical memory available on this locale
     */ 
     proc getPhysicalMemHere() {
-        use Version;
-        if chplVersion >= createVersion(1, 24) {
-            use Memory.Diagnostics;
-            return here.physicalMemory();
-        } else {
-            use Memory;
-            return here.physicalMemory();
-        }
+        use MemDiagnostics;
+        return here.physicalMemory();
     }
 
     /*
     Get the memory used on this locale
     */
     proc getMemUsed() {
-        use Version;
-        if chplVersion >= createVersion(1, 24) {
-            use Memory.Diagnostics;
-            return memoryUsed();
-        } else {
-            use Memory;
-            return memoryUsed();
-        }
+        use MemDiagnostics;
+        return memoryUsed();
     }
 
     /*

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -1,8 +1,6 @@
 /* arkouda server config param and config const */
 module ServerConfig
 {
-    use Memory;
-
     use ZMQ only;
     use HDF5.C_HDF5 only H5get_libversion;
     use SymArrayDmap only makeDistDom;
@@ -104,7 +102,7 @@ module ServerConfig
         cfg.numLocales = numLocales;
         cfg.numPUs = here.numPUs();
         cfg.maxTaskPar = here.maxTaskPar;
-        cfg.physicalMemory = here.physicalMemory();
+        cfg.physicalMemory = getPhysicalMemHere();
         cfg.distributionType = (makeDistDom(10).type):string;
         cfg.authenticate = authenticate; 
 
@@ -114,7 +112,7 @@ module ServerConfig
                 cfg.LocaleConfigs[here.id].name = here.name;
                 cfg.LocaleConfigs[here.id].numPUs = here.numPUs();
                 cfg.LocaleConfigs[here.id].maxTaskPar = here.maxTaskPar;
-                cfg.LocaleConfigs[here.id].physicalMemory = here.physicalMemory();
+                cfg.LocaleConfigs[here.id].physicalMemory = getPhysicalMemHere();
             }
         }
         var res: string = try! "%jt".format(cfg);
@@ -129,11 +127,39 @@ module ServerConfig
     }
 
     /*
+    Get the physical memory available on this locale
+    */ 
+    proc getPhysicalMemHere() {
+        use Version;
+        if chplVersion >= createVersion(1, 24) {
+            use Memory.Diagnostics;
+            return here.physicalMemory();
+        } else {
+            use Memory;
+            return here.physicalMemory();
+        }
+    }
+
+    /*
+    Get the memory used on this locale
+    */
+    proc getMemUsed() {
+        use Version;
+        if chplVersion >= createVersion(1, 24) {
+            use Memory.Diagnostics;
+            return memoryUsed();
+        } else {
+            use Memory;
+            return memoryUsed();
+        }
+    }
+
+    /*
     Get the memory limit for this server run
     returns a percentage of the physical memory per locale
     */
     proc getMemLimit():uint {
-        return ((perLocaleMemLimit:real / 100.0) * here.physicalMemory()):uint; // checks on locale-0
+        return ((perLocaleMemLimit:real / 100.0) * getPhysicalMemHere()):uint; // checks on locale-0
     }
 
     var memHighWater:uint = 0;
@@ -147,7 +173,7 @@ module ServerConfig
         // to use memoryUsed() procedure from Chapel's Memory module
         if (memTrack) {
             // this is a per locale total
-            var total = memoryUsed() + (additionalAmount:uint / numLocales:uint);
+            var total = getMemUsed() + (additionalAmount:uint / numLocales:uint);
             if (trace) {
                 if (total > memHighWater) {
                     memHighWater = total;

--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -42,7 +42,7 @@ proc main() {
         var version = "arkouda server version = %s".format(arkoudaVersion);
         var directory = "initialized the .arkouda directory %s".format(arkDirectory);
         var memLimit =  "getMemLimit() %i".format(getMemLimit());
-        var memUsed = "bytes of memoryUsed() = %i".format(memoryUsed());
+        var memUsed = "bytes of memoryUsed() = %i".format(getMemUsed());
         var serverMessage: string;
         var serverToken: string;
     
@@ -73,7 +73,7 @@ proc main() {
         asLogger.info(getModuleName(), getRoutineName(), getLineNumber(), 
                                                "getMemLimit() %i".format(getMemLimit()));
         asLogger.info(getModuleName(), getRoutineName(), getLineNumber(), 
-                                               "bytes of memoryUsed() = %i".format(memoryUsed()));
+                                               "bytes of memoryUsed() = %i".format(getMemUsed()));
     }
 
     var st = new owned SymTab();
@@ -385,7 +385,7 @@ proc main() {
             }
             if (trace && memTrack) {
                 asLogger.info(getModuleName(),getRoutineName(),getLineNumber(),
-                    "bytes of memory used after command %t".format(memoryUsed():uint * numLocales:uint));
+                    "bytes of memory used after command %t".format(getMemUsed():uint * numLocales:uint));
             }
         } catch (e: ErrorWithMsg) {
             // Generate a ReplyMsg of type ERROR and serialize to a JSON-formatted string

--- a/src/compat/ge-124/MemDiagnostics.chpl
+++ b/src/compat/ge-124/MemDiagnostics.chpl
@@ -1,0 +1,4 @@
+module MemDiagnostics {
+  public use Memory.Diagnostics;
+}
+

--- a/src/compat/ge-124/MemDiagnostics.chpl
+++ b/src/compat/ge-124/MemDiagnostics.chpl
@@ -1,3 +1,4 @@
+// Wrapper for the Memory.Diagnostics standard module in versions >= 1.24
 module MemDiagnostics {
   public use Memory.Diagnostics;
 }

--- a/src/compat/lt-124/MemDiagnostics.chpl
+++ b/src/compat/lt-124/MemDiagnostics.chpl
@@ -1,3 +1,4 @@
+// Wrapper for the Memory standard module in versions < 1.24
 module MemDiagnostics {
   public use Memory;
 }

--- a/src/compat/lt-124/MemDiagnostics.chpl
+++ b/src/compat/lt-124/MemDiagnostics.chpl
@@ -1,0 +1,4 @@
+module MemDiagnostics {
+  public use Memory;
+}
+

--- a/test/COMPOPTS
+++ b/test/COMPOPTS
@@ -13,6 +13,9 @@ TEST_FLAGS=$(cd $ARKOUDA_HOME && make print-TEST_CHPL_FLAGS)
 # -M dir
 SRC_DIR=$(cd $ARKOUDA_HOME && make print-ARKOUDA_SOURCE_DIR)
 
+# Compat modules due to movement of Memory -> Memory.Diagnostics in 1.24
+COMPAT_MODULES=$(cd $ARKOUDA_HOME && make print-ARKOUDA_COMPAT_MODULES)
+
 # Location of the configuration file, so we always include it and disable extra
 # debugging that might make noise in the tests
 CONFIG_FILE="${SRC_DIR}/ServerConfig.chpl"
@@ -20,4 +23,4 @@ CONFIG_OPTS="${CONFIG_FILE} -sv=false -strace=false"
 
 TEST_OPTS="-sprintTimes=false -sprintDiags=false -sprintDiagsSum=false"
 
-echo "${TEST_FLAGS} -M ${SRC_DIR} ${CONFIG_OPTS} ${TEST_OPTS}"
+echo "${TEST_FLAGS} -M ${SRC_DIR} ${COMPAT_MODULES} ${CONFIG_OPTS} ${TEST_OPTS}"

--- a/test/UnitTestSort.chpl
+++ b/test/UnitTestSort.chpl
@@ -181,21 +181,8 @@ prototype module UnitTestSort
               perfValRange = uint(16);
   config const perfMemFraction = 50;
 
-  // Get physical memory on this locale
-  proc getPhysicalMemHere() {
-    use Version;
-    if chplVersion >= createVersion(1, 24) {
-      use Memory.Diagnostics;
-      return here.physicalMemory(unit=MemUnits.Bytes);
-    } else {
-      use Memory;
-      return here.physicalMemory(unit=MemUnits.Bytes);
-    }
-  }
-
   proc testPerformance() {
     param elemSize = numBytes(perfElemType);
-    const totMem = here.physicalMemory(unit = MemUnits.Bytes);
     const totMem = getPhysicalMemHere();
     const fraction = totMem / elemSize / perfMemFraction * numLocales;
     const nElems = if numElems > 0 then numElems else fraction;

--- a/test/UnitTestSort.chpl
+++ b/test/UnitTestSort.chpl
@@ -3,7 +3,6 @@ prototype module UnitTestSort
 
   use TestBase;
 
-  use Memory;
   use Random;
 
   use RadixSortLSD;
@@ -182,9 +181,22 @@ prototype module UnitTestSort
               perfValRange = uint(16);
   config const perfMemFraction = 50;
 
+  // Get physical memory on this locale
+  proc getPhysicalMemHere() {
+    use Version;
+    if chplVersion >= createVersion(1, 24) {
+      use Memory.Diagnostics;
+      return here.physicalMemory(unit=MemUnits.Bytes);
+    } else {
+      use Memory;
+      return here.physicalMemory(unit=MemUnits.Bytes);
+    }
+  }
+
   proc testPerformance() {
     param elemSize = numBytes(perfElemType);
     const totMem = here.physicalMemory(unit = MemUnits.Bytes);
+    const totMem = getPhysicalMemHere();
     const fraction = totMem / elemSize / perfMemFraction * numLocales;
     const nElems = if numElems > 0 then numElems else fraction;
 


### PR DESCRIPTION
The contents of the `Memory` module were deprecated in 1.24, and
copies were made in a submodule called `Memory.Diagnostics`.

Add some wrapper functions for `locale.physicalMemory()` and
`memoryUsed()` to the `ServerConfig` module. Due to how import and
use statements are currently resolved, these wrappers use a
compatibility module with contents that differ depending on whether
Chapel's version is < or >= 1.24.

Adjust the Makefile to include the correct version of the module
`MemDiagnostics` based on the Chapel minor version. Do the same
for the `COMPOPTS` in `$ARKOUDA_HOME/test`.

To remove the compatibility module, Arkouda's minimum required
version should be bumped to 1.24 -or- the Chapel issue at
https://github.com/chapel-lang/chapel/issues/17438 should be
resolved.

TESTING:

- [x] Passed all tests using `make test` on 1.24
- [x] Compiled server on 1.23

Unfortunately I'm having trouble getting `start_test` to work on a
1.23 release, but I'm hoping that the CI checks are proof enough
that things seem to be working for 1.23.