### PR TITLE
Issue #714: Fixes error with out-of-order string concat & format.

### DIFF
--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -37,7 +37,7 @@ proc initArkoudaDirectory() {
 
 proc main() {
 
-    proc printServerSpashMessage() throws {
+    proc printServerSplashMessage() throws {
         var arkDirectory = initArkoudaDirectory();
         var version = "arkouda server version = %s".format(arkoudaVersion);
         var directory = "initialized the .arkouda directory %s".format(arkDirectory);
@@ -48,8 +48,9 @@ proc main() {
     
         if authenticate {
             serverToken = getArkoudaToken('%s%s%s'.format(arkDirectory, pathSep, 'tokens.txt'));
-            serverMessage = ">>>>>>>>>>>>>>> server listening on tcp://%s:%t?token=%s " +
-                        "<<<<<<<<<<<<<<<".format(serverHostname, ServerPort, serverToken);
+            serverMessage = ">>>>>>>>>>>>>>> " +
+                            "server listening on tcp://%s:%t?token=%s ".format(serverHostname, ServerPort, serverToken) +
+                            "<<<<<<<<<<<<<<<";
         } else {
             serverMessage = ">>>>>>>>>>>>>>> server listening on tcp://%s:%t <<<<<<<<<<<<<<<".format(
                                         serverHostname, ServerPort);
@@ -88,8 +89,9 @@ proc main() {
     // configure token authentication and server startup message accordingly
     if authenticate {
         serverToken = getArkoudaToken('%s%s%s'.format(arkDirectory, pathSep, 'tokens.txt'));
-        serverMessage = ">>>>>>>>>>>>>>> server listening on tcp://%s:%t?token=%s " +
-                        "<<<<<<<<<<<<<<<".format(serverHostname, ServerPort, serverToken);
+        serverMessage = ">>>>>>>>>>>>>>> " +
+                        "server listening on tcp://%s:%t?token=%s ".format(serverHostname, ServerPort, serverToken) +
+                        "<<<<<<<<<<<<<<<";
     } else {
         serverMessage = ">>>>>>>>>>>>>>> server listening on tcp://%s:%t <<<<<<<<<<<<<<<".format(
                                         serverHostname, ServerPort);


### PR DESCRIPTION
This fixes Issue #714  where launching arkouda_server with the --authenticate flag was throwing an error due to an order of operations issue with concatenate and format.

Alternatively this can be solved via Issue #715 (with [PR#716](https://github.com/mhmerrill/arkouda/pull/716)

Why no test?
-------------------
In starting an integration/unit test for this over in python it became apparent that we don't include the token information in the server info file that gets written out (there isn't really a way to get it over to the client other than screen scraping).  Since I didn't have access to the token in the test, I couldn't shut the server down.  Rather than try and solve that here, I'm going to address it in a separate ticket because it's a bit of a bigger change than this simple bugfix.