### PR TITLE
added logic to handle situations where (1) the size of 1..n Categoric…

### DIFF
--- a/src/ConcatenateMsg.chpl
+++ b/src/ConcatenateMsg.chpl
@@ -118,14 +118,24 @@ module ConcatenateMsg
                   blocksizes[here.id] += dummyDomain.localSubdomain().size;
                   if objtype == "str" {
                     const e = toSymEntry(g, int);
-                    const firstSeg = e.a[e.aD.localSubdomain().low];
-                    var mybytes: int;
-                    if here.id == numLocales - 1 {
-                      mybytes = valSize - firstSeg;
-                    } else {
-                      mybytes = e.a[e.aD.localSubdomain().high + 1] - firstSeg;
+                    if here.id <= e.a.size -1 {
+                        const firstSeg = e.a[e.aD.localSubdomain().low];
+                        var mybytes: int;
+
+                        /*
+                         * Account for situations where the pdarray size is less than the
+                         * number of locales by first checking to see if the locale id equals
+                         * the length of the pdarray
+                         */
+                        if here.id == e.a.size - 1 || here.id == numLocales - 1 {
+                            mybytes = valSize - firstSeg;
+                        } else if here.id < e.a.size - 1 || here.id < numLocales -1 {
+                            mybytes = e.a[e.aD.localSubdomain().high + 1] - firstSeg;
+                        } else {
+                            cmLogger.error(getModuleName(),getRoutineName(),getLineNumber(),"GUARD CONDITION");
+                        }
+                        blockValSizes[here.id] += mybytes;
                     }
-                    blockValSizes[here.id] += mybytes;
                   }
                 }
               }
@@ -161,20 +171,31 @@ module ConcatenateMsg
                           // Number of strings on this locale for this input array
                           const mynsegs = thisSegs.aD.localSubdomain().size;
                           ref mysegs = thisSegs.a.localSlice[thisSegs.aD.localSubdomain()];
+
                           // Segments must be rebased to start from blockValStart,
                           // which is the current pointer to this locale's chunk of
                           // the values array
-                          esegs.a[{blockstarts[here.id]..#mynsegs}] = mysegs - mysegs[thisSegs.aD.localSubdomain().low] + blockValStarts[here.id];
-                          blockstarts[here.id] += mynsegs;
-                          const firstSeg = thisSegs.a[thisSegs.aD.localSubdomain().low];
-                          var mybytes: int;
-                          if here.id == numLocales - 1 {
-                            mybytes = thisVals.size - firstSeg;
-                          } else {
-                            mybytes = thisSegs.a[thisSegs.aD.localSubdomain().high + 1] - firstSeg;
+                          if here.id < thisSegs.size {
+                              esegs.a[{blockstarts[here.id]..#mynsegs}] = mysegs - mysegs[thisSegs.aD.localSubdomain().low] + blockValStarts[here.id];
+                              blockstarts[here.id] += mynsegs;
+                              const firstSeg = thisSegs.a[thisSegs.aD.localSubdomain().low];
+                              var mybytes: int;
+
+                              /*
+                               * Account for situations where the pdarray size is less than the
+                               * number of locales by first checking to see if the locale id equals
+                               * the length of the pdarray
+                               */
+                              if here.id == thisSegs.size - 1 || here.id == numLocales - 1 {
+                                 mybytes = thisVals.size - firstSeg;
+                              } else if here.id < thisSegs.size - 1 || here.id < numLocales -1  {
+                                  mybytes = thisSegs.a[thisSegs.aD.localSubdomain().high + 1] - firstSeg;
+                              } else {
+                                  cmLogger.error(getModuleName(),getRoutineName(),getLineNumber(),"GUARD CONDITION");
+                              }
+                              evals.a[{blockValStarts[here.id]..#mybytes}] = thisVals.a[firstSeg..#mybytes];
+                              blockValStarts[here.id] += mybytes;
                           }
-                          evals.a[{blockValStarts[here.id]..#mybytes}] = thisVals.a[firstSeg..#mybytes];
-                          blockValStarts[here.id] += mybytes;
                         }
                       }
                     } else {

--- a/tests/categorical_test.py
+++ b/tests/categorical_test.py
@@ -126,16 +126,6 @@ class CategoricalTest(ArkoudaTest):
         # that both permutation and segments are None
         self.assertFalse(resultCat.permutation)
         self.assertFalse(resultCat.segments)
-
-        resultCat = ak.concatenate([catOne,catOne])
-        self.assertEqual('category', resultCat.objtype)
-        self.assertIsInstance(resultCat, ak.Categorical)
-        self.assertEqual(100,resultCat.size)
-
-        # Since Categorical.concatenate uses Categorical.from_codes method, confirm
-        # that both permutation and segments are None
-        self.assertFalse(resultCat.permutation)
-        self.assertFalse(resultCat.segments)
         
         resultCat = ak.concatenate([catOne,catOne], ordered=False)
         self.assertEqual('category', resultCat.objtype)
@@ -146,3 +136,11 @@ class CategoricalTest(ArkoudaTest):
         # that both permutation and segments are None
         self.assertFalse(resultCat.permutation)
         self.assertFalse(resultCat.segments)
+        
+        catOne = self._getCategorical('string',11)
+        catTwo = self._getCategorical('string-two', 6)
+        
+        resultCat = catOne.concatenate([catTwo])
+        self.assertEqual('category', resultCat.objtype)
+        self.assertIsInstance(resultCat, ak.Categorical)
+        self.assertEqual(15,resultCat.size)


### PR DESCRIPTION
This PR addresses #710 as follows:

1. Fixes bug where 1..n Categorical objects have a segments pdarray with a length < numLocales
2. Fixes bug where the lengths of 1..n Categorical objects have segments arrays with differing lengths 
3. Added unit tests for items (1) and (2) 