### PR TITLE
Convert unordredCopy to aggregation in findSegmentsMsg

### DIFF
--- a/src/FindSegmentsMsg.chpl
+++ b/src/FindSegmentsMsg.chpl
@@ -195,10 +195,8 @@ module FindSegmentsMsg
          Segment boundaries are in terms of permuted arrays, so invert the permutation to get 
          back to the original index
          */
-        forall (s, i) in zip(sa, saD) {
-          // TODO convert to aggregation, which side is remote though?
-          use UnorderedCopy;
-          unorderedCopy(uka[i], pa[s]);
+        forall (s, u) in zip(sa, uka) with (var agg = newSrcAggregator(int)) {
+          agg.copy(u, pa[s]);
         }
 
         // Return entry names of segments and unique key indices


### PR DESCRIPTION
`findSegmentsMsg` is the second half of `ak.GroupBy` and currently takes on the same order of time as the (co)argsort. The whole function could probably use a refactor, but one clear issue was a lingering `unorderedCopy` near the end, which this PR replaces with aggregation. This should hopefully benefit `GroupBy` on all platforms, but especially IB.