### PR TITLE
Issue #471 : Documenting env vars used in Makefile.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ arkouda_server
 arkouda_server_real
 arkouda_server_llvm
 arkouda_server_llvm_real
+.arkouda/
 *.log
 *_real
 #*#

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -1,0 +1,60 @@
+# Environment Variables
+There are a number of environment variables you can use (depending on role, i.e. user|developer)
+to configure your environment.  This document will highlight the various environment variables
+available in separate sections.
+
+## Running
+These env vars are used when running the `arkouda_server`.
+  - ARKOUDA_SERVER_CONNECTION_INFO : Set if you want the Arkouda server to write `server:port` info to file on startup
+  - To tune buffers used for message aggregation during sorting on non-crazy systems, you can set the following.  They are per
+  task aggregation buffers so there is no contention between competing tasks.
+    - ARKOUDA_SERVER_AGGREGATION_DST_BUFF_SIZE : Used for tuning buffers associated with communication aggregation
+    - ARKOUDA_SERVER_AGGREGATION_SRC_BUFF_SIZE : Used for tuning the buffers associated with communication aggregation
+    - ARKOUDA_SERVER_AGGREGATION_YIELD_FREQUENCY : Configure the frequency when Aggregators yield, default every 1024 messages.
+   
+
+## Compilation / Makefile
+These env vars can be used to configure your build of Arkouda when running `make`
+
+#### Chapel Compiler Flags
+  - CHPL_FLAGS : A number of flags will be added automatically to the `chpl` compiler in the Makefile, you can add your
+    own, additional ones here.
+    - `-smemTrack=true -lhdf5 -lhdf5_hl -lzmq`, will add `--fast` unless one of the following env vars are set.
+  - ARKOUDA_DEVELOPER : Setting this to 1 or true will add the `-O1` flag to CHPL_FLAGS.  NOTE: _mutually exclusive_ with
+    `ARKOUDA_QUICK_COMPILE`
+  - ARKOUDA_QUICK_COMPILE : Setting this to 1 or true will add the following flags.  NOTE: _mutually exclusive_ with
+    `ARKOUDA_DEVELOPER`
+    - `--no-checks --no-loop-invariant-code-motion --no-fast-followers --ccflags="-O0"`
+  - ARKOUDA_PRINT_PASSES_FILE : Setting this adds `--print-passes-file <file>` to the Chapel compiler flags and writes
+    the associated "pass timing" output to the specified file.  This is mainly used in the nightly testing infrastructure.
+  - CHPL_DEBUG_FLAGS : We add `--print-passes` automatically, but you can add additional flags here.
+
+#### Dependency Paths
+Most folks install anaconda and link to these libraries through Makefile.paths instructions.  If you have an alternative
+setup you can set them explicitly via:
+  - ARKOUDA_ZMQ_PATH : Path to ZMQ library
+  - ARKOUDA_HDF5_PATH : Path to HDF5 library
+  - ARKOUDA_SKIP_CHECK_DEPS : Setting this will skip the automated checks for dependencies (i.e. ZMQ, HDF5). This is
+    useful for developers doing repeated Arkouda builds since they should have already verified the deps have been set up.
+
+## Testing
+Also see the python tests [README](tests/README.md) for more information on Python based unit & functional testing.
+  - VERBOSE : Setting this to `1` will add the `--print-passes` Chapel compiler flag when running _Chapel_-based unit tests.
+  - ARKOUDA_VERBOSE : Client env to set verbosity
+  - ARKOUDA_SERVER_HOST : Client env var of the Arkouda Server hostname
+  - ARKOUDA_SERVER_PORT : Client env var of the Arkouda Server port
+  - ARKOUDA_CLIENT_TIMEOUT : Client env var to control the client timeout for unit testing.
+  - ARKOUDA_FULL_STACK_TEST : Client testing option
+  - TEST_DATA_URL : Client testing variable for ReadAllTest/read_all_tests.py
+  - ARKOUDA_NUMLOCALES : Client unit testing option to set the number of Chpl server locales for unit tests
+  - ARKOUDA_SERVER_CONNECTION_INFO : Client env var to specify where the `ak-server-info` file is found
+  - ARKOUDA_HOME : This is used by `make check` tests to specify the location of Arkouda's server executable and
+                   util/test module.  **_WARNING_**: The env var is subject to future change since it is mainly an
+                   internal use variable.
+
+## Python Client
+  - ARKOUDA_CLIENT_DIRECTORY : Sets the parent directory of where the client will look for `.arkouda/tokens.txt`
+  - ARKOUDA_TUNNEL_SERVER : Env var to control ssh tunnel server url
+  - ARKOUDA_KEY_FILE : Client env var for keyfile when using ssh tunnel
+  - ARKOUDA_PASSWORD : Client env var for password when using ssh tunnel
+  - ARKOUDA_LOG_LEVEL : Client env var to control client side Logging Level

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ This yielded a >20TB dataframe in Arkouda.
    - [Connecting to Arkouda](#run-ak-connect)
 6. [Logging](#log-ak)
 7. [Type Checking in Arkouda](#typecheck-ak)
-8. [Contributing](#contrib-ak)
+8. [Environment Variables](#env-vars-ak)
+9. [Contributing](#contrib-ak)
 
 
 <a id="prereq-main"></a>
@@ -514,6 +515,10 @@ type checking require type hints. Consequently, to opt-out of type checking, sim
 
 </details>
 
+<a id="env-vars-ak"></a>
+## Environment Variables <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
+The various Arkouda aspects (compilation, run-time, client, tests, etc.) can be configured using a number of environment
+variables (env vars).  See the [ENVIRONMENT](ENVIRONMENT.md) documentation for more details.
 
 <a id="contrib-ak"></a>
 ## Contributing to Arkouda <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>

--- a/arkouda/security.py
+++ b/arkouda/security.py
@@ -58,14 +58,15 @@ def get_arkouda_client_directory() -> Path:
     Returns
     -------
     Path
-        Path corresponding to the .arkouda directory path
+        Path corresponding to the user's .arkouda directory path
 
     Notes
     -----
     The default implementation is to place the .arkouda 
     directory in the current user's home directory. The
-    default can be overridden by seting the ARKOUDA_HOME
-    environment variable.
+    default can be overridden by setting the ARKOUDA_CLIENT_DIRECTORY
+    environment variable.  It is important this is not the same location
+    as the server's token directory as the file format is different.
     """
     arkouda_parent_dir = os.getenv('ARKOUDA_CLIENT_DIRECTORY')
     if not arkouda_parent_dir:
@@ -90,7 +91,7 @@ def get_username() -> str:
     
     Notes
     -----
-    The curreently supported operating systems are Windows, Linux, 
+    The currently supported operating systems are Windows, Linux,
     and MacOS AKA Darwin
     """
     try:


### PR DESCRIPTION
Issue #471 
This PR does not contain any code changes, only documentation.  It adds documentation for environment variables in the various aspects of:

- compilation (makefile)
- tests
- run-time (arkouda_server)
- client (python)

It does **_not_** include documentation for the various `const` and `param` items in the chpl-based arkouda server side code.  (There are quite a bit of those and I'm not sure it's within the scope of this ticket).  Also, there are a number of variable like items in the Makefile but they did not appear to be user facing/configurable (i.e. things like ARKOUDA_PROJECT_DIR, ARKOUDA_SOURCE_DIR, etc.)