### PR TITLE
Increase the aggregation buffer sizes for non-ugni configurations

### DIFF
--- a/src/CommAggregation.chpl
+++ b/src/CommAggregation.chpl
@@ -5,9 +5,10 @@ module CommAggregation {
   use CommPrimitives;
 
   // TODO should tune these values at startup
+  param defaultBuffSize = if CHPL_COMM == "ugni" then 4096 else 8096;
   private config const yieldFrequency = getEnvInt("ARKOUDA_SERVER_AGGREGATION_YIELD_FREQUENCY", 1024);
-  private config const dstBuffSize = getEnvInt("ARKOUDA_SERVER_AGGREGATION_DST_BUFF_SIZE", 4096);
-  private config const srcBuffSize = getEnvInt("ARKOUDA_SERVER_AGGREGATION_SRC_BUFF_SIZE", 4096);
+  private config const dstBuffSize = getEnvInt("ARKOUDA_SERVER_AGGREGATION_DST_BUFF_SIZE", defaultBuffSize);
+  private config const srcBuffSize = getEnvInt("ARKOUDA_SERVER_AGGREGATION_SRC_BUFF_SIZE", defaultBuffSize);
 
 
   /* Creates a new destination aggregator (dst/lhs will be remote). */


### PR DESCRIPTION
Increase the aggregation buffer sizes from 4K to 8K for non-ugni
configurations. This is motivated by improving perforrmace on InfiniBand
systems, but the larger buffer sizes also benefit Ethernet networks as
well. Note that longer term we want to auto-tune these buffer sizes, but
for now this is a better default. On ugni increasing the size does not
change performance much so I didn't want to increase the memory overhead
for no benefit.

Here are some results for the nightly 16-node-cs-hdr configuration using
the default problem size:

| benchmark | before       | after        |
| --------: | -----------: | -----------: |
| gather    |  83.47 GiB/s | 108.17 GiB/s |
| scatter   | 106.99 GiB/s | 128.14 GiB/s |
| argsort   |   8.65 GiB/s |  10.08 GiB/s |

And some scaling results using 8 GiB / node:

![ak-gather-perf-lg](https://user-images.githubusercontent.com/1588337/113608070-0b6ce700-9618-11eb-9785-a3071990bdd8.png)
![ak-scatter-perf-lg](https://user-images.githubusercontent.com/1588337/113608076-0dcf4100-9618-11eb-8484-2a06f1f949cc.png)
![ak-argsort-perf-lg](https://user-images.githubusercontent.com/1588337/113608084-0f990480-9618-11eb-8a05-ac819befb23b.png)
