### PR TITLE
Issue #729: In-line modification for registration

### DIFF
--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -96,6 +96,7 @@ class Strings:
             raise ValueError(e)   
 
         self.dtype = npstr
+        self.name:Union[str, None] = None
         self.logger = getArkoudaLogger(name=__class__.__name__) # type: ignore
 
     def __iter__(self):
@@ -827,13 +828,11 @@ class Strings:
         self.bytes.save(prefix_path=prefix_path, 
                                     dataset='{}/values'.format(dataset), mode=mode)
 
-    @classmethod
-    def register_helper(cls, offsets, bytes):
-        return cls(offsets, bytes)
-
     def register(self, user_defined_name : str) -> Strings:
-        return self.register_helper(self.offsets.register(user_defined_name+'_offsets'),
-                               self.bytes.register(user_defined_name+'_bytes'))
+        self.offsets.register(user_defined_name+'_offsets')
+        self.bytes.register(user_defined_name+'_bytes')
+        self.name = user_defined_name
+        return self
 
     def unregister(self) -> None:
         self.offsets.unregister()

--- a/src/MultiTypeSymbolTable.chpl
+++ b/src/MultiTypeSymbolTable.chpl
@@ -62,10 +62,15 @@ module MultiTypeSymbolTable
                                      "Registering symbol: %s ".format(userDefinedName));            
             }
             
+            // RE: Issue#729 we no longer support multiple name registration of the same object
+            if (registry.contains(name)) {
+                registry -= name;
+            }
+
             registry += userDefinedName; // add user defined name to registry
 
             // point at same shared table entry
-            tab.addOrSet(userDefinedName, tab.getValue(name));
+            tab.addOrSet(userDefinedName, tab.getAndRemove(name));
         }
 
         proc unregName(name: string) throws {

--- a/src/RegistrationMsg.chpl
+++ b/src/RegistrationMsg.chpl
@@ -45,7 +45,7 @@ module RegistrationMsg
         st.regName(name, userDefinedName);
         
         // response message
-        repMsg = "created %s".format(st.attrib(userDefinedName));
+        repMsg = "success";
         regLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
         return new MsgTuple(repMsg, MsgType.NORMAL);
     }

--- a/tests/string_test.py
+++ b/tests/string_test.py
@@ -472,3 +472,36 @@ class StringTest(ArkoudaTest):
         thickrange = thirds[0].stick(thirds[1], delimiter=', ').stick(thirds[2], delimiter=', ')
         flatrange = thickrange.flatten(', ')
         self.assertTrue((ak.cast(flatrange, 'int64') == ak.arange(99)).all())
+
+    def test_string_registration(self):
+        # Initial registration should set name
+        keep = ak.random_strings_uniform(1, 10, UNIQUE, characters='printable')
+        keep.register("keep_me")
+        self.assertTrue(keep.name is "keep_me")
+        self.assertTrue(keep.offsets.name == "keep_me_offsets")
+        self.assertTrue(keep.bytes.name == "keep_me_bytes")
+
+        # Register a second time to confirm name change
+        keep.register("kept")
+        self.assertTrue(keep.name is "kept")
+        self.assertTrue(keep.offsets.name == "kept_offsets")
+        self.assertTrue(keep.bytes.name == "kept_bytes")
+
+        # Add an item to discard
+        discard = ak.random_strings_uniform(1, 10, UNIQUE, characters='printable')
+
+        ak.clear()
+        self.assertTrue(keep.name == "kept")
+        self.assertTrue(keep.offsets.name == "kept_offsets")
+        self.assertTrue(keep.bytes.name == "kept_bytes")
+
+        with self.assertRaises(RuntimeError, msg="discard was not registered and should be discarded"):
+            str(discard)
+
+        # Unregister, should remain usable until we clear
+        keep.unregister()
+        str(keep) # Should not cause error
+        self.assertTrue(keep.offsets.name == "kept_offsets", msg="name should remain intact even after unregister")
+        ak.clear()
+        with self.assertRaises(RuntimeError, msg="keep was unregistered and should be cleared"):
+            str(keep) # should cause RuntimeError


### PR DESCRIPTION
This PR (Issue #729) changes arkouda-python object registration to an in-place modification for

- `pdarray`
- `Strings`

It includes server-side changes to the Registration message as well as the actions applied to the SymbolTable.
It includes client-side changes to the register methods.

**Change in behavior**: register is now an in-place operation versus returning a new python object.
**Change in API**: The static method `register_pdarray` has been removed since you can no longer pass it a simple string.  `register(user_defined_name)` are the instance methods which must be used for registration of an object.