### PR TITLE
ak.from_series support for object dtype to enable generation of Strings

### DIFF
--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -81,16 +81,27 @@ def from_series(series : pd.Series,
     data type is either inferred from the the Series or is set via the dtype parameter. 
     
     Series of datetime or timedelta are converted to Arkouda arrays of dtype int64 (nanoseconds)
+    
+    A Pandas Series containing strings has a dtype of object. Arkouda assumes the Series
+    contains strings and sets the dtype to str
     """ 
     if not dtype:   
         dt = series.dtype.name
     else:
         dt = str(dtype)
     try:
+        '''
+        If the Series has a object dtype, set dtype to string to comply with method
+        signature that does not require a dtype; this is required because Pandas can infer
+        non-str dtypes from the input np or Python array.
+        '''
+        if dt == 'object':
+            dt = 'string'
+
         n_array = series.to_numpy(dtype=SeriesDTypes[dt])
     except KeyError:
         raise ValueError(('dtype {} is unsupported. Supported dtypes are bool, ' +
-                          'float64, int64, string, datetime64[ns], and timedelta64[ns]').format(dt))
+                      'float64, int64, string, datetime64[ns], and timedelta64[ns]').format(dt))
     return array(n_array)
 
 def array(a : Union[pdarray,np.ndarray, Iterable]) -> Union[pdarray, Strings]:

--- a/tests/pdarray_creation_test.py
+++ b/tests/pdarray_creation_test.py
@@ -493,6 +493,11 @@ class PdarrayCreationTest(ArkoudaTest):
         
         self.assertIsInstance(objects, ak.Strings)
         self.assertEqual(np.str, objects.dtype)
+        
+        objects = ak.from_series(pd.Series(['a', 'b', 'c', 'd', 'e']))
+        
+        self.assertIsInstance(objects, ak.Strings)
+        self.assertEqual(np.str, objects.dtype)       
 
         p_array = ak.from_series(pd.Series(np.random.randint(0,10,10)))
 
@@ -553,8 +558,8 @@ class PdarrayCreationTest(ArkoudaTest):
             ak.from_series(pd.Series(np.random.randint(0,10,10), dtype=np.int8))      
         self.assertEqual(('dtype int8 is unsupported. Supported dtypes are bool, ' +
                           'float64, int64, string, datetime64[ns], and timedelta64[ns]'), 
-                         cm.exception.args[0])            
-            
+                         cm.exception.args[0])
+        
     def test_fill(self):
         ones = ak.ones(100)
 


### PR DESCRIPTION
This PR fixes inconsistency in the ak.from_series method signature. Specifically, the method signature does not require a dtype, deferring to the Pandas Series type inference; this type inference does not work for Pandas Series containing strings, for which the dtype is object.

This PR adds logic to check for dtype of object and sets the dtype to str for the numpy conversion. Also added corresponding unit test and pydoc comments.