### PR TITLE
Speed up gasnet arkouda tests by only using 1 thread per locale

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,7 +74,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image: [chapel, chapel-gasnet-smp]
+        include:
+          - image: chapel
+            threads: 2
+          - image: chapel-gasnet-smp
+            threads: 1
+    env:
+      CHPL_RT_NUM_THREADS_PER_LOCALE: ${{matrix.threads}}
     container:
       image: chapel/${{matrix.image}}:1.23.0
     steps:


### PR DESCRIPTION
Gasnet CI testing runs oversubscribed so 2 locales are running on 1
node, which creates contention. The gasnet-smp docker image we use
sets `CHPL_RT_OVERSUBSCRIBED=yes`, but there's still competition. To
limit interference just use 1 thread per locale for multi-locale
testing.  Reducing interference speeds things up, and also has the side
effect of reducing the amount of setup time sorting (which depends on
numCores*numThreads) and that further speeds things up.

This brings arkouda_tests_linux from ~80 minutes down to ~40 minutes

Part of https://github.com/mhmerrill/arkouda/issues/388