### PR TITLE
Issue mhmerrill#734: Create Registration List Function

### DIFF
--- a/arkouda/client.py
+++ b/arkouda/client.py
@@ -8,7 +8,7 @@ from arkouda.logger import getArkoudaLogger
 from arkouda.message import RequestMessage, MessageFormat, ReplyMessage, \
      MessageType
 
-__all__ = ["AllSymbols", "connect", "disconnect", "shutdown", "get_config", 
+__all__ = ["AllSymbols", "RegisteredSymbols", "connect", "disconnect", "shutdown", "get_config",
            "get_mem_used", "__version__", "ruok"]
 
 # Try to read the version from the file located at ../VERSION
@@ -40,6 +40,7 @@ pdarrayIterThresh  = pdarrayIterThreshDefVal
 maxTransferBytesDefVal = 2**30
 maxTransferBytes = maxTransferBytesDefVal
 AllSymbols = "__AllSymbols__"
+RegisteredSymbols = "__RegisteredSymbols__"
 
 logger = getArkoudaLogger(name='Arkouda Client') 
 clientLogger = getArkoudaLogger(name='Arkouda User Logger', logFormat='%(message)s')   

--- a/src/MultiTypeSymbolTable.chpl
+++ b/src/MultiTypeSymbolTable.chpl
@@ -310,8 +310,9 @@ module MultiTypeSymbolTable
         /*
         Returns verbose attributes of the sym entry at the given string, if the string maps to an entry.
         Pass __AllSymbols__ to process all sym entries in the sym table.
+        Pass __RegisteredSymbols__ to process all registered sym entries.
 
-        Returns: name, dtype, size, ndim, shape, and item size
+        Returns: name, dtype, size, ndim, shape, item size, and registration status
 
         :arg name: name of entry to be processed
         :type name: string
@@ -321,35 +322,26 @@ module MultiTypeSymbolTable
         proc info(name:string): string throws {
             var s: string;
             if tab.size == 0 {
-                s = "the symbol table is empty";
+                s = "__EMPTY_SYMBOLTABLE__";
             }
             else if name == "__AllSymbols__" {
                 for n in tab {
-                    s += "name:%t dtype:%t size:%t ndim:%t shape:%t itemsize:%t registered:%t\n".format(n, 
-                              dtype2str(tab.getBorrowed(n).dtype), tab.getBorrowed(n).size, 
-                              tab.getBorrowed(n).ndim, tab.getBorrowed(n).shape, 
-                              tab.getBorrowed(n).itemsize, registry.contains(n));
+                    s += formatEntry(n, tab.getBorrowed(n));
                 }
             } 
             else if name == "__RegisteredSymbols__" {
                 if registry.size == 0 {
-                    s = "the registry is empty";
+                    s = "__EMPTY_REGISTRY__";
                 }
                 else {
                     for n in registry {
-                        s += "name:%t dtype:%t size:%t ndim:%t shape:%t itemsize:%t registered:%t\n".format(n, 
-                                  dtype2str(tab.getBorrowed(n).dtype), tab.getBorrowed(n).size, 
-                                  tab.getBorrowed(n).ndim, tab.getBorrowed(n).shape, 
-                                  tab.getBorrowed(n).itemsize, registry.contains(n));
+                        s += formatEntry(n, tab.getBorrowed(n));
                     }
                 }
             }
             else {
                 if (tab.contains(name)) {
-                    s = "name:%t dtype:%t size:%t ndim:%t shape:%t itemsize:%t registered:%t\n".format(name, 
-                              dtype2str(tab.getBorrowed(name).dtype), tab.getBorrowed(name).size, 
-                              tab.getBorrowed(name).ndim, tab.getBorrowed(name).shape, 
-                              tab.getBorrowed(name).itemsize, registry.contains(name));
+                    s += formatEntry(name, tab.getBorrowed(name));
                 }
                 else {
                     throw getErrorWithContext(
@@ -361,6 +353,22 @@ module MultiTypeSymbolTable
                 }
             }
             return s;
+        }
+
+        /*
+        Returns formatted string for info call. 
+
+        :arg name: name of entry to be formatted
+        :type name: string
+
+        :arg entry: Generic Sym Entry to be formatted (tab.getBorrowed(name))
+        :type entry: GenSymEntry
+
+        :returns: formatted string
+        */
+        proc formatEntry(name:string, item:borrowed GenSymEntry): string throws {
+            return "name:%t dtype:%t size:%t ndim:%t shape:%t itemsize:%t registered:%t\n".format(name, 
+                              dtype2str(item.dtype), item.size, item.ndim, item.shape, item.itemsize, registry.contains(name));
         }
 
         /*

--- a/src/MultiTypeSymbolTable.chpl
+++ b/src/MultiTypeSymbolTable.chpl
@@ -320,19 +320,36 @@ module MultiTypeSymbolTable
         */
         proc info(name:string): string throws {
             var s: string;
-            if name == "__AllSymbols__" {
+            if tab.size == 0 {
+                s = "the symbol table is empty";
+            }
+            else if name == "__AllSymbols__" {
                 for n in tab {
-                    s += "name:%t dtype:%t size:%t ndim:%t shape:%t itemsize:%t\n".format(n, 
+                    s += "name:%t dtype:%t size:%t ndim:%t shape:%t itemsize:%t registered:%t\n".format(n, 
                               dtype2str(tab.getBorrowed(n).dtype), tab.getBorrowed(n).size, 
                               tab.getBorrowed(n).ndim, tab.getBorrowed(n).shape, 
-                              tab.getBorrowed(n).itemsize);
+                              tab.getBorrowed(n).itemsize, registry.contains(n));
                 }
-            } else {
+            } 
+            else if name == "__RegisteredSymbols__" {
+                if registry.size == 0 {
+                    s = "the registry is empty";
+                }
+                else {
+                    for n in registry {
+                        s += "name:%t dtype:%t size:%t ndim:%t shape:%t itemsize:%t registered:%t\n".format(n, 
+                                  dtype2str(tab.getBorrowed(n).dtype), tab.getBorrowed(n).size, 
+                                  tab.getBorrowed(n).ndim, tab.getBorrowed(n).shape, 
+                                  tab.getBorrowed(n).itemsize, registry.contains(n));
+                    }
+                }
+            }
+            else {
                 if (tab.contains(name)) {
-                    s = "name:%t dtype:%t size:%t ndim:%t shape:%t itemsize:%t\n".format(name, 
+                    s = "name:%t dtype:%t size:%t ndim:%t shape:%t itemsize:%t registered:%t\n".format(name, 
                               dtype2str(tab.getBorrowed(name).dtype), tab.getBorrowed(name).size, 
                               tab.getBorrowed(name).ndim, tab.getBorrowed(name).shape, 
-                              tab.getBorrowed(name).itemsize);
+                              tab.getBorrowed(name).itemsize, registry.contains(name));
                 }
                 else {
                     throw getErrorWithContext(

--- a/tests/registration_test.py
+++ b/tests/registration_test.py
@@ -130,8 +130,8 @@ class RegistrationTest(ArkoudaTest):
         '''
         Tests the following:
 
-        1. info() with an empty symbol table returns 'the symbol table is empty' regardless of arguments
-        2. info(ak.RegisteredSymbols) when no objects are registered returns 'the registry is empty'
+        1. info() with an empty symbol table returns '__EMPTY_SYMBOLTABLE__' regardless of arguments
+        2. info(ak.RegisteredSymbols) when no objects are registered returns '__EMPTY_REGISTRY__'
         3. The registered field is set to false for objects that have not been registered
         4. The registered field is set to true for objects that have been registered
         5. info(ak.AllSymbols) contains both registered and non-registered objects
@@ -140,16 +140,16 @@ class RegistrationTest(ArkoudaTest):
         # Cleanup symbol table from previous tests
         cleanup()
 
-        self.assertEqual(ak.info(ak.AllSymbols), 'the symbol table is empty',
+        self.assertEqual(ak.info(ak.AllSymbols), '__EMPTY_SYMBOLTABLE__',
                          msg='info(AllSymbols) empty symbol table message failed')
-        self.assertEqual(ak.info(ak.RegisteredSymbols), 'the symbol table is empty',
+        self.assertEqual(ak.info(ak.RegisteredSymbols), '__EMPTY_SYMBOLTABLE__',
                          msg='info(RegisteredSymbols) empty symbol table message failed')
 
         my_array = ak.ones(10, dtype=ak.int64)
         self.assertTrue('registered:false' in ak.info(ak.AllSymbols).split(),
                         msg='info(AllSymbols) should contain non-registered objects')
 
-        self.assertEqual(ak.info(ak.RegisteredSymbols), 'the registry is empty',
+        self.assertEqual(ak.info(ak.RegisteredSymbols), '__EMPTY_REGISTRY__',
                          msg='info(RegisteredSymbols) empty registry message failed')
 
         # After register(), the registered field should be set to true for all info calls
@@ -169,27 +169,28 @@ class RegistrationTest(ArkoudaTest):
                         msg='info(AllSymbols) and info(RegisteredSymbols) should have same num of objects after clear()')
 
         # After unregister(), the registered field should be set to false for AllSymbol and object name info calls
-        # RegisteredSymbols info calls should return 'the registry is empty'
+        # RegisteredSymbols info calls should return '__EMPTY_REGISTRY__'
         my_array.unregister()
         self.assertTrue('registered:false' in ak.info("keep_me").split(),
                         msg='info(keep_me) registered field should be false after unregister()')
         self.assertTrue('registered:false' in ak.info(ak.AllSymbols).split(),
                         msg='info(AllSymbols) should contain unregistered objects')
-        self.assertEqual(ak.info(ak.RegisteredSymbols), 'the registry is empty',
+        self.assertEqual(ak.info(ak.RegisteredSymbols), '__EMPTY_REGISTRY__',
                          msg='info(RegisteredSymbols) empty registry message failed after unregister()')
 
-        # After clear(), every info call should return 'the symbol table is empty'
+        # After clear(), every info call should return '__EMPTY_SYMBOLTABLE__'
         ak.clear()
-        self.assertEqual(ak.info("keep_me"), 'the symbol table is empty',
+        self.assertEqual(ak.info("keep_me"), '__EMPTY_SYMBOLTABLE__',
                          msg='info(keep_me) empty symbol message failed')
-        self.assertEqual(ak.info(ak.AllSymbols), 'the symbol table is empty',
+        self.assertEqual(ak.info(ak.AllSymbols), '__EMPTY_SYMBOLTABLE__',
                          msg='info(AllSymbols) empty symbol table message failed')
-        self.assertEqual(ak.info(ak.RegisteredSymbols), 'the symbol table is empty',
+        self.assertEqual(ak.info(ak.RegisteredSymbols), '__EMPTY_SYMBOLTABLE__',
                          msg='info(RegisteredSymbols) empty symbol table message failed')
 
 def cleanup():
     ak.clear()
-    for registered_object in ak.info(ak.AllSymbols).split('\n')[:-1]:
-        name = registered_object.split()[0].split(':')[1].replace('"', '')
-        ak.unregister_pdarray(name)
-    ak.clear()
+    if ak.info(ak.AllSymbols) != '__EMPTY_SYMBOLTABLE__':
+        for registered_object in filter(None, ak.info(ak.AllSymbols).split('\n')):
+            name = registered_object.split()[0].split(':')[1].replace('"', '')
+            ak.unregister_pdarray(name)
+        ak.clear()


### PR DESCRIPTION
This pull request (Issue #734) adds functionality to list all objects in the registry

- Adds `registered` field to the output of `ak.info()`
- Adds special `__RegisteredSymbols__` symbol which prints all registered objects when passed to `ak.info`  (`ak.info(ak.RegisteredSymbols)`).  This behaves similarly to the `__AllSymbols__` symbol
- Adds checks to return a message when info is called with an empty symbol table or `RegisteredSymbols` is used with an empty registry
- Updates `registration_test.py` to test new info() functionality

Change in behavior:  A `registered` field has been added to `ak.info()` . This may effect any logic which relies on the number or order of fields returned by `ak.info()`