### PR TITLE
Add module compat flags to makefile targets that build chapel tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -353,10 +353,7 @@ $(TEST_BINARY_DIR):
 
 .PHONY: $(TEST_TARGETS) # Force tests to always rebuild.
 $(TEST_TARGETS): $(TEST_BINARY_DIR)/$(TEST_BINARY_SIGIL)%: $(TEST_SOURCE_DIR)/%.chpl | $(TEST_BINARY_DIR)
-	$(CHPL) $(TEST_CHPL_FLAGS) -M $(ARKOUDA_SOURCE_DIR) $< -o $@
-
-test/%: test/%.chpl
-	$(CHPL) $@.chpl $(TEST_CHPL_FLAGS) -M $(ARKOUDA_SOURCE_DIR)
+	$(CHPL) $(TEST_CHPL_FLAGS) -M $(ARKOUDA_SOURCE_DIR) $(ARKOUDA_COMPAT_MODULES) $< -o $@
 
 print-%:
 	@echo "$($*)"


### PR DESCRIPTION
Follow on to #713, we need to add the compatibility modules when
compiling standalone chapel tests using `make test-bin` or 
`make test-chapel`

While here, remove an unneeded `test` target. I added that in 3d0739e,
but I didn't realize that it duplicated `test-bin` functionality.