### PR TITLE
Disable mac CI testing again

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -106,31 +106,6 @@ jobs:
          ./benchmarks/run_benchmarks.py --correctness-only
          ./benchmarks/run_benchmarks.py --size=100 --gen-graphs
 
-  arkouda_tests_mac:
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: |
-        brew install hdf5 zeromq
-        # brew install chapel@1.23.0 (except that isn't actually supported, so use sha with 1.23.0)
-        CHAPEL_FORMULA=$(mktemp -d)/chapel.rb
-        curl -fsSL https://raw.githubusercontent.com/Homebrew/homebrew-core/8a5d08fe5b/Formula/chapel.rb -o $CHAPEL_FORMULA
-        brew install $CHAPEL_FORMULA
-    - name: Build/Install Arkouda
-      run: |
-        make
-        python3 -m pip install -e .[dev]
-    - name: Arkouda make check
-      run: |
-        make check
-    - name: Arkouda unit tests
-      run: |
-        make test-python
-    - name: Arkouda benchmark --correctness-only
-      run: |
-         ./benchmarks/run_benchmarks.py --correctness-only
-
   chapel_unit_tests_linux:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
It's been pretty flaky recently with infrastructure issues outside our
control. Most issues seem to be networking issues with being unable to
brew install or curl but there have been other variants.

We have gone back and forth with disabling/re-enabling in the past in
#241, #300, and #415 due to similar issue. Given the current instability
just disable it again.