### PR TITLE
Skip run_benchmarks --gen-graphs for gasnet CI testing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -103,8 +103,10 @@ jobs:
         make test-python
     - name: Arkouda benchmark --correctness-only
       run: |
-         ./benchmarks/run_benchmarks.py --correctness-only
-         ./benchmarks/run_benchmarks.py --size=100 --gen-graphs
+        ./benchmarks/run_benchmarks.py --correctness-only
+        if [ "${{matrix.image}}" != "chapel-gasnet-smp" ]; then
+          ./benchmarks/run_benchmarks.py --size=100 --gen-graphs
+        fi
 
   arkouda_tests_mac:
     runs-on: macos-latest


### PR DESCRIPTION
b9acd92 updated CI testing to do `./run_benchmarks --gen-graphs` in
order to make sure graph generation works. This is still valuable, but
it's pretty slow under gasnet testing so only run it in the comm=none
config.

This brings arkouda_tests_linux from ~40 minutes down to ~35 minutes

Part of https://github.com/mhmerrill/arkouda/issues/388