### PR TITLE
Issue #729: Registering two objects with the same name will now result in an error

### DIFF
--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -953,6 +953,9 @@ class pdarray:
         """
         Register this pdarray with a user defined name in the arkouda server
         so it can be attached to later using pdarray.attach()
+        This is an in-place operation, registering a pdarray more than once will
+        update the name in the registry and remove the previously registered name.
+        A name can only be registered to one pdarray at a time.
         
         Parameters
         ----------
@@ -963,7 +966,8 @@ class pdarray:
         -------
         pdarray
             The same pdarray which is now registered with the arkouda server and has an updated name.
-            This is an in-place modification, the original is returned to support a fluid programming style
+            This is an in-place modification, the original is returned to support a fluid programming style.
+            Please note you cannot register two different pdarrays with the same name.
         
         Raises
         ------
@@ -972,6 +976,8 @@ class pdarray:
             user_defined_name is not a str
         RegistrationError
             If the server was unable to register the pdarray with the user_defined_name
+            If the user is attempting to register more than one pdarray with the same name, the former should be
+            unregistered first to free up the registration name.
         
         See also
         --------

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -16,7 +16,7 @@ import builtins
 __all__ = ["pdarray", "info", "clear", "any", "all", "is_sorted", "sum", "prod", 
            "min", "max", "argmin", "argmax", "mean", "var", "std", "mink", 
            "maxk", "argmink", "argmaxk", "attach_pdarray",
-           "unregister_pdarray"]
+           "unregister_pdarray", "RegistrationError"]
 
 logger = getArkoudaLogger(name='pdarrayclass')    
 
@@ -949,7 +949,6 @@ class pdarray:
         return cast(str, generic_msg(cmd="tohdf", args="{} {} {} {} {}".\
                            format(self.name, dataset, m, json_array, self.dtype)))
 
-
     def register(self, user_defined_name : str) -> pdarray:
         """
         Register this pdarray with a user defined name in the arkouda server
@@ -995,11 +994,13 @@ class pdarray:
         if not isinstance(user_defined_name, str):
             raise TypeError(f"user_defined_name must be of type str, was {type(user_defined_name)}")
 
-        rep_msg = generic_msg(cmd="register", args=f"{self.name} {user_defined_name}")
-        if isinstance(rep_msg, bytes):
-            rep_msg = str(rep_msg, "UTF-8")
-
-        if rep_msg != "success":
+        try:
+            rep_msg = generic_msg(cmd="register", args=f"{self.name} {user_defined_name}")
+            if isinstance(rep_msg, bytes):
+                rep_msg = str(rep_msg, "UTF-8")
+            if rep_msg != "success":
+                raise RegistrationError
+        except (RuntimeError, RegistrationError):  # Registering two objects with the same name is not allowed
             raise RegistrationError(f"Server was unable to register {user_defined_name}")
 
         self.name = user_defined_name

--- a/src/MultiTypeSymbolTable.chpl
+++ b/src/MultiTypeSymbolTable.chpl
@@ -53,18 +53,16 @@ module MultiTypeSymbolTable
                                    errorClass="UnknownSymbolError");
             }
 
-            // check to see if userDefinedName is defined
+            // check to see if userDefinedName is already defined, with in-place modification, this will be an error
             if (registry.contains(userDefinedName)) {
                 mtLogger.error(getModuleName(),getRoutineName(),getLineNumber(),
                                      "regName: requested symbol `%s` is already in use".format(userDefinedName));
-                // We should return an error here
                 throw getErrorWithContext(
                                     msg=incompatibleArgumentsError("regName", name),
                                     lineNumber=getLineNumber(),
                                     routineName=getRoutineName(),
                                     moduleName=getModuleName(),
                                     errorClass="ArgumentError");
-                // throw new owned ArgumentError();
             } else {
                 mtLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                      "Registering symbol: %s ".format(userDefinedName));            

--- a/src/MultiTypeSymbolTable.chpl
+++ b/src/MultiTypeSymbolTable.chpl
@@ -55,8 +55,16 @@ module MultiTypeSymbolTable
 
             // check to see if userDefinedName is defined
             if (registry.contains(userDefinedName)) {
-                mtLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                     "regName: redefined symbol: %s ".format(userDefinedName));
+                mtLogger.error(getModuleName(),getRoutineName(),getLineNumber(),
+                                     "regName: requested symbol `%s` is already in use".format(userDefinedName));
+                // We should return an error here
+                throw getErrorWithContext(
+                                    msg=incompatibleArgumentsError("regName", name),
+                                    lineNumber=getLineNumber(),
+                                    routineName=getRoutineName(),
+                                    moduleName=getModuleName(),
+                                    errorClass="ArgumentError");
+                // throw new owned ArgumentError();
             } else {
                 mtLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                      "Registering symbol: %s ".format(userDefinedName));            

--- a/src/RegistrationMsg.chpl
+++ b/src/RegistrationMsg.chpl
@@ -42,12 +42,19 @@ module RegistrationMsg
                "cmd: %s name: %s userDefinedName: %s".format(cmd,name,userDefinedName));
 
         // register new user_defined_name for name
-        st.regName(name, userDefinedName);
-        
-        // response message
-        repMsg = "success";
-        regLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
-        return new MsgTuple(repMsg, MsgType.NORMAL);
+        var msgTuple:MsgTuple;
+        try {
+            st.regName(name, userDefinedName);
+            repMsg = "success";
+            regLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+            msgTuple = new MsgTuple(repMsg, MsgType.NORMAL);
+        } catch e: ArgumentError {
+            repMsg = "Error: requested name '%s' was already in use.".format(userDefinedName);
+            regLogger.error(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+            msgTuple = new MsgTuple(repMsg, MsgType.ERROR);
+        }
+
+        return msgTuple;
     }
 
     /* 

--- a/tests/registration_test.py
+++ b/tests/registration_test.py
@@ -1,5 +1,7 @@
 from context import arkouda as ak
 from base_test import ArkoudaTest
+from arkouda.pdarrayclass import RegistrationError
+
 
 class RegistrationTest(ArkoudaTest):
     
@@ -26,6 +28,26 @@ class RegistrationTest(ArkoudaTest):
         # Both ar_array and self.a_array point to the same object, so both should still be usable.
         str(ar_array)
         str(self.a_array)
+
+        try:
+            self.a_array.unregister()
+        except (RuntimeError, RegistrationError):
+            pass  # Will be tested in `test_unregister`
+
+    def test_double_register(self):
+        """
+        Tests the case when two objects get registered using the same user_defined_name
+        """
+        a = ak.ones(3, dtype=ak.int64)
+        b = ak.ones(3, dtype=ak.int64)
+        b.fill(2)
+        a.register("foo")
+
+        with self.assertRaises(RegistrationError, msg="Should raise an Error"):
+            b.register("foo")
+
+        # Clean up the registry
+        a.unregister()
 
     def test_unregister(self):
         '''


### PR DESCRIPTION
Issue #729 Follow up:  Registering two objects with the same name will now result in an error

Given the case:
```
a = ak.ones(3, dtype=ak.int64)
b = ak.ones(3, dtype=ak.int64)
b.fill(2)
a.register("foo")
b.register("foo")
```

This will now result in an error message from the server and present as a RegistrationError to the user.
Previously, this would have silently updated `a` to point to the object `b`.