### PR TITLE
fixed missing args string in trace message #745

### DIFF
--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -268,8 +268,7 @@ proc main() {
               try {
                 if (cmd != "array") {
                   asLogger.info(getModuleName(), getRoutineName(), getLineNumber(),
-                                                     ">>> %t %t".format(cmd, 
-                                                    payload.decode(decodePolicy.replace)));
+                                                     ">>> %t %t".format(cmd, args));
                 } else {
                   asLogger.info(getModuleName(), getRoutineName(), getLineNumber(),
                                                      ">>> %s [binary data]".format(cmd));


### PR DESCRIPTION
This PR fixes the trace logging statement bug where the cmd string failed to get passed to the string.format method.