### PR TITLE
Issue #753: Add doc strings and type checking for Strings registration

### DIFF
--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -949,45 +949,45 @@ class pdarray:
         return cast(str, generic_msg(cmd="tohdf", args="{} {} {} {} {}".\
                            format(self.name, dataset, m, json_array, self.dtype)))
 
-    def register(self, user_defined_name : str) -> pdarray:
+    @typechecked
+    def register(self, user_defined_name: str) -> pdarray:
         """
         Register this pdarray with a user defined name in the arkouda server
         so it can be attached to later using pdarray.attach()
         This is an in-place operation, registering a pdarray more than once will
         update the name in the registry and remove the previously registered name.
         A name can only be registered to one pdarray at a time.
-        
+
         Parameters
         ----------
         user_defined_name : str
             user defined name array is to be registered under
-        
+
         Returns
         -------
         pdarray
             The same pdarray which is now registered with the arkouda server and has an updated name.
             This is an in-place modification, the original is returned to support a fluid programming style.
             Please note you cannot register two different pdarrays with the same name.
-        
+
         Raises
         ------
         TypeError
-            Raised if pda is neither a pdarray nor a str or if 
-            user_defined_name is not a str
+            Raised if user_defined_name is not a str
         RegistrationError
             If the server was unable to register the pdarray with the user_defined_name
             If the user is attempting to register more than one pdarray with the same name, the former should be
             unregistered first to free up the registration name.
-        
+
         See also
         --------
         attach, unregister
-        
+
         Notes
         -----
-        Registered names/pdarrays in the server are immune to deletion 
+        Registered names/pdarrays in the server are immune to deletion
         until they are unregistered.
-        
+
         Examples
         --------
         >>> a = zeros(100)
@@ -997,9 +997,6 @@ class pdarray:
         >>> # ...other work...
         >>> b.unregister()
         """
-        if not isinstance(user_defined_name, str):
-            raise TypeError(f"user_defined_name must be of type str, was {type(user_defined_name)}")
-
         try:
             rep_msg = generic_msg(cmd="register", args=f"{self.name} {user_defined_name}")
             if isinstance(rep_msg, bytes):
@@ -1026,8 +1023,8 @@ class pdarray:
         
         Raises 
         ------
-        TypeError
-            Raised if pda is neither a pdarray nor a str
+        RuntimeError
+            Raised if the server could not find the internal name/symbol to remove
         
         See also
         --------
@@ -1052,9 +1049,10 @@ class pdarray:
     # class method self is not passed in
     # invoke with ak.pdarray.attach('user_defined_name')
     @staticmethod
-    def attach(user_defined_name : str) -> pdarray:
+    @typechecked
+    def attach(user_defined_name: str) -> pdarray:
         """
-        class method to return a pdarray attached to the a registered name in the arkouda 
+        class method to return a pdarray attached to the registered name in the arkouda
         server which was registered using register()
         
         Parameters
@@ -1065,8 +1063,7 @@ class pdarray:
         Returns
         -------
         pdarray
-            pdarray which points to pdarray registered with user defined
-            name in the arkouda server
+            pdarray which is bound to corresponding server side component that was registered with user_defined_name
         
         Raises
         ------

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -991,7 +991,7 @@ class pdarray:
         Examples
         --------
         >>> a = zeros(100)
-        >>> r_pda = a.register("my_zeros")
+        >>> a.register("my_zeros")
         >>> # potentially disconnect from server and reconnect to server
         >>> b = ak.pdarray.attach("my_zeros")
         >>> # ...other work...
@@ -1038,7 +1038,7 @@ class pdarray:
         Examples
         --------
         >>> a = zeros(100)
-        >>> r_pda = a.register("my_zeros")
+        >>> a.register("my_zeros")
         >>> # potentially disconnect from server and reconnect to server
         >>> b = ak.pdarray.attach("my_zeros")
         >>> # ...other work...
@@ -1082,7 +1082,7 @@ class pdarray:
         Examples
         --------
         >>> a = zeros(100)
-        >>> r_pda = a.register("my_zeros")
+        >>> a.register("my_zeros")
         >>> # potentially disconnect from server and reconnect to server
         >>> b = ak.pdarray.attach("my_zeros")
         >>> # ...other work...
@@ -1748,11 +1748,11 @@ def argmaxk(pda : pdarray, k : int_scalars) -> pdarray:
     return create_pdarray(repMsg)
 
 @typechecked
-def attach_pdarray(user_defined_name : str) -> pdarray:
+def attach_pdarray(user_defined_name: str) -> pdarray:
     """
-    Return a pdarray attached to the a registered name in the arkouda 
-    server which was registered using register_pdarray()
-    
+    class method to return a pdarray attached to the registered name in the arkouda
+    server which was registered using register()
+
     Parameters
     ----------
     user_defined_name : str
@@ -1761,27 +1761,26 @@ def attach_pdarray(user_defined_name : str) -> pdarray:
     Returns
     -------
     pdarray
-        pdarray which points to pdarray registered with user defined
-        name in the arkouda server
-        
+        pdarray which is bound to corresponding server side component that was registered with user_defined_name
+
     Raises
     ------
     TypeError
-        Raised if user_defined_name is not a str
+      Raised if user_defined_name is not a str
 
     See also
     --------
-    register_pdarray, unregister_pdarray
+    register, unregister_pdarray
 
     Notes
     -----
-    Registered names/pdarrays in the server are immune to deletion 
+    Registered names/pdarrays in the server are immune to deletion
     until they are unregistered.
 
     Examples
     --------
     >>> a = zeros(100)
-    >>> r_pda = ak.register_pdarray(a, "my_zeros")
+    >>> a.register("my_zeros")
     >>> # potentially disconnect from server and reconnect to server
     >>> b = ak.attach_pdarray("my_zeros")
     >>> # ...other work...
@@ -1792,38 +1791,36 @@ def attach_pdarray(user_defined_name : str) -> pdarray:
 
 
 @typechecked
-def unregister_pdarray(pda : Union[str,pdarray]) -> None:
+def unregister_pdarray(pda: Union[str,pdarray]) -> None:
     """
-    Unregister a pdarray in the arkouda server which was previously 
-    registered using register_pdarray() and/or attached to using attach_pdarray()
-    
+    Unregister a pdarray in the arkouda server which was previously
+    registered using register() and/or attahced to using attach_pdarray()
+
     Parameters
     ----------
-    pda : str or pdarray
-        user define name which array was registered under
 
     Returns
     -------
     None
 
-    Raises 
+    Raises
     ------
-    TypeError
-        Raised if pda is neither a pdarray nor a str
+    RuntimeError
+        Raised if the server could not find the internal name/symbol to remove
 
     See also
     --------
-    register_pdarray, unregister_pdarray
+    register, unregister_pdarray
 
     Notes
     -----
-    Registered names/pdarrays in the server are immune to deletion until 
+    Registered names/pdarrays in the server are immune to deletion until
     they are unregistered.
 
     Examples
     --------
     >>> a = zeros(100)
-    >>> r_pda = ak.register_pdarray(a, "my_zeros")
+    >>> a.register("my_zeros")
     >>> # potentially disconnect from server and reconnect to server
     >>> b = ak.attach_pdarray("my_zeros")
     >>> # ...other work...

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -828,17 +828,114 @@ class Strings:
         self.bytes.save(prefix_path=prefix_path, 
                                     dataset='{}/values'.format(dataset), mode=mode)
 
-    def register(self, user_defined_name : str) -> Strings:
+    def register(self, user_defined_name: str) -> Strings:
+        """
+        Register this Strings object with a user defined name in the arkouda server
+        so it can be attached to later using Strings.attach()
+        This is an in-place operation, registering a Strings object more than once will
+        update the name in the registry and remove the previously registered name.
+        A name can only be registered to one object at a time.
+
+        Parameters
+        ----------
+        user_defined_name : str
+            user defined name which the Strings object is to be registered under
+
+        Returns
+        -------
+        Strings
+            The same Strings object which is now registered with the arkouda server and has an updated name.
+            This is an in-place modification, the original is returned to support a fluid programming style.
+            Please note you cannot register two different objects with the same name.
+
+        Raises
+        ------
+        TypeError
+            Raised if pda is neither a pdarray nor a str or if
+            user_defined_name is not a str
+        RegistrationError
+            If the server was unable to register the Strings object with the user_defined_name
+            If the user is attempting to register more than one object with the same name, the former should be
+            unregistered first to free up the registration name.
+
+        See also
+        --------
+        attach, unregister
+
+        Notes
+        -----
+        Registered names/Strings objects in the server are immune to deletion
+        until they are unregistered.
+        """
+        if not isinstance(user_defined_name, str):
+            raise TypeError(f"user_defined_name must be of type str, was {type(user_defined_name)}")
+
         self.offsets.register(user_defined_name+'_offsets')
         self.bytes.register(user_defined_name+'_bytes')
         self.name = user_defined_name
         return self
 
     def unregister(self) -> None:
+        """
+        Unregister a Strings object in the arkouda server which was previously
+        registered using register() and/or attached to using attach()
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        TypeError
+            Raised if pda is neither a pdarray nor a str
+
+        See also
+        --------
+        register, unregister
+
+        Notes
+        -----
+        Registered names/Strings objects in the server are immune to deletion until
+        they are unregistered.
+        """
         self.offsets.unregister()
         self.bytes.unregister()
 
     @staticmethod
     def attach(user_defined_name : str) -> Strings:
+        """
+        class method to return a Strings object attached to the registered name in the arkouda
+        server which was registered using register()
+
+        Parameters
+        ----------
+        user_defined_name : str
+            user defined name which the Strings object was registered under
+
+        Returns
+        -------
+        Strings object
+            the Strings object registered with user_defined_name in the arkouda server
+
+        Raises
+        ------
+        TypeError
+            Raised if user_defined_name is not a str
+
+        See also
+        --------
+        register, unregister
+
+        Notes
+        -----
+        Registered names/Strings objects in the server are immune to deletion
+        until they are unregistered.
+        """
+        if not isinstance(user_defined_name, str):
+            raise TypeError(f"user_defined_name must be of type str, was {type(user_defined_name)}")
+
         return Strings(pdarray.attach(user_defined_name+'_offsets'),
                        pdarray.attach(user_defined_name+'_bytes'))

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -828,6 +828,7 @@ class Strings:
         self.bytes.save(prefix_path=prefix_path, 
                                     dataset='{}/values'.format(dataset), mode=mode)
 
+    @typechecked
     def register(self, user_defined_name: str) -> Strings:
         """
         Register this Strings object with a user defined name in the arkouda server
@@ -851,8 +852,7 @@ class Strings:
         Raises
         ------
         TypeError
-            Raised if pda is neither a pdarray nor a str or if
-            user_defined_name is not a str
+            Raised if user_defined_name is not a str
         RegistrationError
             If the server was unable to register the Strings object with the user_defined_name
             If the user is attempting to register more than one object with the same name, the former should be
@@ -867,9 +867,6 @@ class Strings:
         Registered names/Strings objects in the server are immune to deletion
         until they are unregistered.
         """
-        if not isinstance(user_defined_name, str):
-            raise TypeError(f"user_defined_name must be of type str, was {type(user_defined_name)}")
-
         self.offsets.register(user_defined_name+'_offsets')
         self.bytes.register(user_defined_name+'_bytes')
         self.name = user_defined_name
@@ -889,8 +886,8 @@ class Strings:
 
         Raises
         ------
-        TypeError
-            Raised if pda is neither a pdarray nor a str
+        RuntimeError
+            Raised if the server could not find the internal name/symbol to remove
 
         See also
         --------
@@ -905,7 +902,8 @@ class Strings:
         self.bytes.unregister()
 
     @staticmethod
-    def attach(user_defined_name : str) -> Strings:
+    @typechecked
+    def attach(user_defined_name: str) -> Strings:
         """
         class method to return a Strings object attached to the registered name in the arkouda
         server which was registered using register()
@@ -934,8 +932,5 @@ class Strings:
         Registered names/Strings objects in the server are immune to deletion
         until they are unregistered.
         """
-        if not isinstance(user_defined_name, str):
-            raise TypeError(f"user_defined_name must be of type str, was {type(user_defined_name)}")
-
         return Strings(pdarray.attach(user_defined_name+'_offsets'),
                        pdarray.attach(user_defined_name+'_bytes'))

--- a/tests/registration_test.py
+++ b/tests/registration_test.py
@@ -49,6 +49,20 @@ class RegistrationTest(ArkoudaTest):
         # Clean up the registry
         a.unregister()
 
+    def test_registration_type_check(self):
+        """
+        Tests type checking of user_defined_name for register and attach
+        """
+
+        a = ak.ones(3, dtype=ak.int64)
+
+        with self.assertRaises(TypeError, msg="register() should raise TypeError when user_defined_name is not a str"):
+            a.register(7)
+        with self.assertRaises(TypeError, msg="attach() should raise TypeError when user_defined_name is not a str"):
+            a.attach(7)
+
+        ak.clear()
+
     def test_unregister(self):
         '''
         Tests the following:


### PR DESCRIPTION
This pull request (Issue #753) updates doc strings and type checking for registration functions in `strings.py` and `pdarrayclass.py` 

- Adds doc strings to the `register`, `unregister`, and `attach` functions in `strings.py`
- Updates doc strings to the `register`, `unregister`, and `attach` functions in `pdarrayclass.py`
- Adds `@typechecked`  check to ensure `user_defined_name`  is of type `str` for `register` and `attach` functions in both `strings.py` and `pdarrayclass.py`
- Adds `test_registration_type_check` to test the type checking of the `register` and `attach` functions