### PR TITLE
Fix categorical bug

### DIFF
--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -520,8 +520,7 @@ class Categorical:
                                        [o.categories for o in others],
                                        ordered=True))
             newidx = g.unique_keys
-            wherediditgo = zeros(newidx.size, dtype=akint64)
-            wherediditgo[g.permutation] = arange(newidx.size)
+            wherediditgo = g.broadcast(arange(newidx.size), permute=True)
             idxsizes = np.array([self.categories.size] + \
                                 [o.categories.size for o in others])
             idxoffsets = np.cumsum(idxsizes) - idxsizes

--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -518,7 +518,7 @@ class Categorical:
         else:
             g = GroupBy(concatenate([self.categories] + \
                                        [o.categories for o in others],
-                                       ordered=False))
+                                       ordered=True))
             newidx = g.unique_keys
             wherediditgo = zeros(newidx.size, dtype=akint64)
             wherediditgo[g.permutation] = arange(newidx.size)

--- a/tests/categorical_test.py
+++ b/tests/categorical_test.py
@@ -155,3 +155,17 @@ class CategoricalTest(ArkoudaTest):
         # that both permutation and segments are None
         self.assertFalse(resultCat.permutation)
         self.assertFalse(resultCat.segments)
+        
+        # Concatenate two Categoricals with different categories, and test result against original strings
+        s1 = ak.array(['abc', 'de', 'abc', 'fghi', 'de'])
+        s2 = ak.array(['jkl', 'mno', 'fghi', 'abc', 'fghi', 'mno'])
+        c1 = ak.Categorical(s1)
+        c2 = ak.Categorical(s2)
+        # Ordered concatenation
+        s12ord = ak.concatenate([s1, s2], ordered=True)
+        c12ord = ak.concatenate([c1, c2], ordered=True)
+        self.assertTrue((ak.Categorical(s12ord) == c12ord).all())
+        # Unordered (but still deterministic) concatenation
+        s12unord = ak.concatenate([s1, s2], ordered=False)
+        c12unord = ak.concatenate([c1, c2], ordered=False)
+        self.assertTrue((ak.Categorical(s12unord) == c12unord).all())


### PR DESCRIPTION
This PR attempts to fix a bug when concatenating two Categoricals with different categories that scrambles the mapping of codes to categories and results in completely wrong output. I believe I traced the bug back to a wrong flag in the `Categorical.concatenate()` method. I added a test case that addresses the scenario in question.

Marked as draft until CI passes.