### PR TITLE
replaced --v flag with LogLevel enum config and implemented module-level logging #728 #757

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,7 +511,6 @@ for all logged messages. An example is shown below:
 2021-04-15:06:22:59 [MultiTypeSymbolTable] addEntry Line 127 DEBUG [Chapel] adding symbol: id_4 
 ```
 
-
 Available logging levels are ERROR, CRITICAL, WARN, INFO, and DEBUG. The default logging level is INFO where all messages at the ERROR, CRITICAL, WARN, and INFO levels are printed. The log level can be set globally by passing in the --logLevel parameter upon arkouda\_server startup. For example, passing the --logLevel=LogLevel.DEBUG parameter as shown below sets the global log level to DEBUG:
 
 ```
@@ -524,7 +523,7 @@ In addition to setting the global logging level, the logging level for individua
 ./arkouda_server --MsgProcessing.logLevel=LogLevel.DEBUG --logLevel=LogLevel.WARN
 ```
 
-The logging level for all other Arkouda modules will be set to the global value, which in the example above is WARN.
+In this example, the logging level for all other Arkouda modules will be set to the global value WARN.
 
 <a id="typecheck-ak"></a>
 ## Type Checking in Arkouda <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>

--- a/README.md
+++ b/README.md
@@ -502,11 +502,29 @@ connect without specifying the token via the access_token parameter or token url
 <a id="log-ak"></a>
 ## Logging <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
 
-The Arkouda server features a Chapel logging framework that prints out the module name, routine name and line number
-for all logged messages. Available logging levels are ERROR, CRITICAL, WARN, INFO, and DEBUG. 
+The Arkouda server features a Chapel logging framework that prints out the module name, function name and line number
+for all logged messages. An example is shown below:
 
-The default logging level is INFO where all messages at the ERROR, CRITICAL, WARN, and INFO levels are printed. For debugging, 
-the DEBUG level is enabled by passing in the --v flag upon arkouda\_server startup.
+```
+2021-04-15:06:22:59 [ConcatenateMsg] concatenateMsg Line 193 DEBUG [Chapel] creating pdarray id_4 of type Int64
+2021-04-15:06:22:59 [ServerConfig] overMemLimit Line 175 INFO [Chapel] memory high watermark = 44720 memory limit = 30923764531
+2021-04-15:06:22:59 [MultiTypeSymbolTable] addEntry Line 127 DEBUG [Chapel] adding symbol: id_4 
+```
+
+
+Available logging levels are ERROR, CRITICAL, WARN, INFO, and DEBUG. The default logging level is INFO where all messages at the ERROR, CRITICAL, WARN, and INFO levels are printed. The log level can be set globally by passing in the --logLevel parameter upon arkouda\_server startup. For example, passing the --logLevel=LogLevel.DEBUG parameter as shown below sets the global log level to DEBUG:
+
+```
+./arkouda_server --logLevel=LogLevel.DEBUG
+```
+
+In addition to setting the global logging level, the logging level for individual Arkouda modules can also be configured. For example, to set MsgProcessing to DEBUG for the purposes of debugging Arkouda array creation, pass the MsgProcessing.logLevel=LogLevel.DEBUG parameter upon arkouda\_server startup as shown below:
+
+```
+./arkouda_server --MsgProcessing.logLevel=LogLevel.DEBUG --logLevel=LogLevel.WARN
+```
+
+The logging level for all other Arkouda modules will be set to the global value, which in the example above is WARN.
 
 <a id="typecheck-ak"></a>
 ## Type Checking in Arkouda <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>

--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -30,14 +30,9 @@ module ArgSortMsg
     use Logging;
     use Message;
 
-    const asLogger = new Logger();
+    private config const logLevel = ServerConfig.logLevel;
+    const asLogger = new Logger(logLevel);
 
-    if v {
-        asLogger.level = LogLevel.DEBUG;
-    } else {
-        asLogger.level = LogLevel.INFO;
-    }
-    
     // thresholds for different sized sorts
     var lgSmall = 10;
     var small = 2**lgSmall;

--- a/src/ArraySetopsMsg.chpl
+++ b/src/ArraySetopsMsg.chpl
@@ -24,13 +24,9 @@ module ArraySetopsMsg
     use Errors;
     use Logging;
     use Message;
-    
-    var asLogger = new Logger();
-    if v {
-        asLogger.level = LogLevel.DEBUG;
-    } else {
-        asLogger.level = LogLevel.INFO;    
-    }
+
+    private config const logLevel = ServerConfig.logLevel;
+    const asLogger = new Logger(logLevel);
     
     /*
     Parse, execute, and respond to a intersect1d message

--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -5,12 +5,8 @@ module AryUtil
     use Logging;
     use ServerConfig;
     
-    const auLogger = new Logger();
-    if v {
-        auLogger.level = LogLevel.DEBUG;
-    } else {
-        auLogger.level = LogLevel.INFO;    
-    }
+    private config const logLevel = ServerConfig.logLevel;
+    const auLogger = new Logger(logLevel);
     
     /*
       Threshold for the amount of data that will be printed. 

--- a/src/BroadcastMsg.chpl
+++ b/src/BroadcastMsg.chpl
@@ -7,15 +7,10 @@ module BroadcastMsg {
   use ServerConfig;
   use Logging;
   use Message;
-  
-  const bmLogger = new Logger();
 
-  if v {
-        bmLogger.level = LogLevel.DEBUG;
-  } else {
-        bmLogger.level = LogLevel.INFO;
-  }
-  
+  private config const logLevel = ServerConfig.logLevel;
+  const bmLogger = new Logger(logLevel);
+
   /* 
    * Broadcast a value per segment of a segmented array to the
    * full size of the array, optionally applying a permutation

--- a/src/CastMsg.chpl
+++ b/src/CastMsg.chpl
@@ -11,12 +11,8 @@ module CastMsg {
   use ServerConfig;
   use CommAggregation;
 
-  const castLogger = new Logger();
-  if v {
-      castLogger.level = LogLevel.DEBUG;
-  } else {
-      castLogger.level = LogLevel.INFO;    
-  }
+  private config const logLevel = ServerConfig.logLevel;
+  const castLogger = new Logger(logLevel);
 
   proc castMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
     use ServerConfig; // for string.splitMsgToTuple

--- a/src/ConcatenateMsg.chpl
+++ b/src/ConcatenateMsg.chpl
@@ -16,8 +16,9 @@ module ConcatenateMsg
     use PrivateDist;
     
     use AryUtil;
-
-    const cmLogger = new Logger(ServerConfig.logLevel);
+    
+    private config const logLevel = ServerConfig.logLevel;
+    const cmLogger = new Logger(logLevel);
 
     /* Concatenate a list of arrays together
        to form one array

--- a/src/ConcatenateMsg.chpl
+++ b/src/ConcatenateMsg.chpl
@@ -17,12 +17,7 @@ module ConcatenateMsg
     
     use AryUtil;
 
-    const cmLogger = new Logger();
-    if v {
-        cmLogger.level = LogLevel.DEBUG;
-    } else {
-        cmLogger.level = LogLevel.INFO;
-    }
+    const cmLogger = new Logger(ServerConfig.logLevel);
 
     /* Concatenate a list of arrays together
        to form one array

--- a/src/EfuncMsg.chpl
+++ b/src/EfuncMsg.chpl
@@ -14,14 +14,9 @@ module EfuncMsg
     use ServerErrorStrings;
     
     use AryUtil;
-    
-    const eLogger = new Logger();
 
-    if v {
-        eLogger.level = LogLevel.DEBUG;
-    } else {
-        eLogger.level = LogLevel.INFO;
-    }
+    private config const logLevel = ServerConfig.logLevel;
+    const eLogger = new Logger(logLevel);
     
     /* These ops are functions which take an array and produce an array.
        

--- a/src/FindSegmentsMsg.chpl
+++ b/src/FindSegmentsMsg.chpl
@@ -17,12 +17,8 @@ module FindSegmentsMsg
     use PrivateDist;
     use CommAggregation;
 
-    const fsLogger = new Logger();
-    if v {
-        fsLogger.level = LogLevel.DEBUG;
-    } else {
-        fsLogger.level = LogLevel.INFO;    
-    }
+    private config const logLevel = ServerConfig.logLevel;
+    const fsLogger = new Logger(logLevel);
 
     /*
 

--- a/src/FlattenMsg.chpl
+++ b/src/FlattenMsg.chpl
@@ -10,14 +10,8 @@ module FlattenMsg {
   use Logging;
   use Message;
   
-  const fmLogger = new Logger();
-  
-  if v {
-        fmLogger.level = LogLevel.DEBUG;
-  } else {
-        fmLogger.level = LogLevel.INFO;
-  } 
-  
+  private config const logLevel = ServerConfig.logLevel;
+  const fmLogger = new Logger(logLevel);
 
   proc segFlattenMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
     var (name, objtype, returnSegsStr, delimJson) = payload.splitMsgToTuple(4);

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -19,13 +19,7 @@ module GenSymIO {
     use Message;
     use ServerConfig;
     
-    const gsLogger = new Logger();
-  
-    if v {
-        gsLogger.level = LogLevel.DEBUG;
-    } else {
-        gsLogger.level = LogLevel.INFO;
-    } 
+    const gsLogger = new Logger(ServerConfig.logLevel);
 
     config const GenSymIO_DEBUG = false;
     config const SEGARRAY_OFFSET_NAME = "segments";

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -19,7 +19,8 @@ module GenSymIO {
     use Message;
     use ServerConfig;
     
-    const gsLogger = new Logger(ServerConfig.logLevel);
+    private config const logLevel = ServerConfig.logLevel;
+    const gsLogger = new Logger(logLevel);
 
     config const GenSymIO_DEBUG = false;
     config const SEGARRAY_OFFSET_NAME = "segments";

--- a/src/Histogram.chpl
+++ b/src/Histogram.chpl
@@ -9,14 +9,10 @@ module Histogram
     use SymArrayDmap;
     use Logging;
     use Reflection;
-    
-    const hgLogger = new Logger();
-    if v {
-        hgLogger.level = LogLevel.DEBUG;
-    } else {
-        hgLogger.level = LogLevel.INFO;    
-    }
-    
+
+    private config const logLevel = ServerConfig.logLevel;
+    const hgLogger = new Logger(logLevel);
+
     /*
     Takes the data in array a, creates an atomic histogram in parallel, 
     and copies the result of the histogram operation into a distributed int array

--- a/src/HistogramMsg.chpl
+++ b/src/HistogramMsg.chpl
@@ -12,13 +12,9 @@ module HistogramMsg
     use ServerErrorStrings;
 
     use Histogram;
-
-    const hgmLogger = new Logger();
-    if v {
-        hgmLogger.level = LogLevel.DEBUG;
-    } else {
-        hgmLogger.level = LogLevel.INFO;    
-    }
+ 
+    private config const logLevel = ServerConfig.logLevel;
+    const hgmLogger = new Logger(logLevel);
     
     private config const sBound = 2**12;
     private config const mBound = 2**25;

--- a/src/In1d.chpl
+++ b/src/In1d.chpl
@@ -12,13 +12,9 @@ module In1d
 
     use PrivateDist;
     use Logging;
-    
-    var inLogger = new Logger();
-    if v {
-        inLogger.level = LogLevel.DEBUG;
-    } else {
-        inLogger.level = LogLevel.INFO;    
-    }
+
+    private config const logLevel = ServerConfig.logLevel;
+    const inLogger = new Logger(logLevel);
 
     /* Brute force:
     forward-way reduction per element of ar1 over ar2.
@@ -93,23 +89,23 @@ module In1d
 
                 var t = new Time.Timer();
                 
-                if v {t.start();}
+                if logLevel == LogLevel.DEBUG {t.start();}
 
                 var ar2Set: domain(int, parSafe=false); // create a set to hold ar2, parSafe modification is OFF
                 ar2Set.requestCapacity(ar2.size); // request a capacity for the initial set
 
-                if v {t.stop(); timings[here.id][0] = t.elapsed(); t.clear(); t.start();}
+                if logLevel == LogLevel.DEBUG {t.stop(); timings[here.id][0] = t.elapsed(); t.clear(); t.start();}
 
                 // serially add all elements of ar2 to ar2Set
                 for e in ar2 { ar2Set += e; }
                 // all elements of ar2 have been added to ar2Set so modification done.
                 
-                if v {t.stop(); timings[here.id][1] = t.elapsed(); t.clear(); t.start();}
+                if logLevel == LogLevel.DEBUG {t.stop(); timings[here.id][1] = t.elapsed(); t.clear(); t.start();}
 
                 // in parallel check all elements of ar1 to see if ar2Set contains them
                 [i in truth.localSubdomain()] truth[i] = ar2Set.contains(ar1[i]);
 
-                if v {t.stop(); timings[here.id][2] = t.elapsed();}
+                if logLevel == LogLevel.DEBUG {t.stop(); timings[here.id][2] = t.elapsed();}
             }
         }
 

--- a/src/In1dMsg.chpl
+++ b/src/In1dMsg.chpl
@@ -14,12 +14,8 @@ module In1dMsg
 
     use In1d;
 
-    var iLogger = new Logger();
-    if v {
-        iLogger.level = LogLevel.DEBUG;
-    } else {
-        iLogger.level = LogLevel.INFO;    
-    }
+    private config const logLevel = ServerConfig.logLevel;
+    const iLogger = new Logger(logLevel);
     
     /*
     Small bound const. Brute force in1d implementation recommended.

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -13,13 +13,7 @@ module IndexingMsg
 
     use CommAggregation;
     
-    const imLogger = new Logger();
-
-    if v {
-        imLogger.level = LogLevel.DEBUG;
-    } else {
-        imLogger.level = LogLevel.INFO;
-    }
+    const imLogger = new Logger(ServerConfig.logLevel);
 
     /* intIndex "a[int]" response to __getitem__(int) */
     proc intIndexMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -12,8 +12,9 @@ module IndexingMsg
     use MultiTypeSymbolTable;
 
     use CommAggregation;
-    
-    const imLogger = new Logger(ServerConfig.logLevel);
+
+    private config const logLevel = ServerConfig.logLevel;
+    const imLogger = new Logger(logLevel);
 
     /* intIndex "a[int]" response to __getitem__(int) */
     proc intIndexMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
@@ -421,7 +422,7 @@ module IndexingMsg
         var gIV: borrowed GenSymEntry = st.lookup(iname);
         var gY: borrowed GenSymEntry = st.lookup(yname);
         
-        if v {
+        if logLevel == LogLevel.DEBUG {
             imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                              "cmd: %s gX: %t gIV: %t gY: %t".format(
                                               cmd, st.attrib(name), st.attrib(iname),

--- a/src/JoinEqWithDTMsg.chpl
+++ b/src/JoinEqWithDTMsg.chpl
@@ -18,15 +18,10 @@ module JoinEqWithDTMsg
     param TRUE_DT = 0;
     param ABS_DT = 1;
     param POS_DT = 2;
-    
-    const jeLogger = new Logger();
-  
-    if v {
-        jeLogger.level = LogLevel.DEBUG;
-    } else {
-        jeLogger.level = LogLevel.INFO;
-    }
-    
+
+    private config const logLevel = ServerConfig.logLevel;
+    const jeLogger = new Logger(logLevel);
+
     // operator overloads so + reduce and + scan can work on atomic int arrays
     proc +(x: atomic int, y: atomic int) {
         return x.read() + y.read();

--- a/src/KExtremeMsg.chpl
+++ b/src/KExtremeMsg.chpl
@@ -23,13 +23,8 @@ module KExtremeMsg
     use RadixSortLSD;
     use ArraySetopsMsg;
 
-    const keLogger = new Logger();
-  
-    if v {
-        keLogger.level = LogLevel.DEBUG;
-    } else {
-        keLogger.level = LogLevel.INFO;
-    }
+    private config const logLevel = ServerConfig.logLevel;
+    const keLogger = new Logger(logLevel);
 
     /*
     Parse, execute, and respond to a mink message

--- a/src/Logging.chpl
+++ b/src/Logging.chpl
@@ -2,6 +2,8 @@ module Logging {
     use Set;
     use IO;
     use DateTime;
+    use Reflection;
+    use Errors;
 
     /*
      * The LogLevel enum is used to provide a strongly-typed means of
@@ -14,7 +16,7 @@ module Logging {
      * of logging sensitivity analogous to other languages such as Python.
      */
     class Logger {
-        var level = LogLevel.WARN;
+        var level: LogLevel = LogLevel.INFO;
         
         var warnLevels = new set(LogLevel,[LogLevel.WARN, LogLevel.INFO,
                            LogLevel.DEBUG]);
@@ -28,6 +30,12 @@ module Logging {
         var infoLevels = new set(LogLevel,[LogLevel.INFO,LogLevel.DEBUG]);  
         
         var printDate: bool = true;
+        
+        proc init(logLevel : LogLevel) {
+            level = logLevel;
+        }
+        
+        proc init() {}
         
         proc debug(moduleName, routineName, lineNumber, msg: string) throws {
             if level == LogLevel.DEBUG  {
@@ -84,5 +92,27 @@ module Logging {
             var rawCms = vals(1).split(".");
             return "%s:%s".format(cd,rawCms(0));        
         }
+    }
+    
+    /*
+     * Returns the LogLevel enum corresponding to the supplied log
+     * level string.
+     */
+    proc getLogLevel(level : string) : LogLevel throws {
+        select level {
+            when 'DEBUG' { return LogLevel.DEBUG; }
+            when 'INFO' { return LogLevel.INFO; }
+            when 'WARN' { return LogLevel.WARN; }
+            when 'ERROR' { return LogLevel.ERROR; }
+            when 'CRITICAL' { return LogLevel.CRITICAL; }  
+            otherwise { 
+                throw new owned ErrorWithContext(
+                        "level must be DEBUG, INFO, WARN, ERROR, or CRITICAL",
+                        getLineNumber(),
+                        getRoutineName(),
+                        getModuleName(),
+                        "IllegalArgumentError");
+            }  
+        } 
     }
 }

--- a/src/Logging.chpl
+++ b/src/Logging.chpl
@@ -93,26 +93,4 @@ module Logging {
             return "%s:%s".format(cd,rawCms(0));        
         }
     }
-    
-    /*
-     * Returns the LogLevel enum corresponding to the supplied log
-     * level string.
-     */
-    proc getLogLevel(level : string) : LogLevel throws {
-        select level {
-            when 'DEBUG' { return LogLevel.DEBUG; }
-            when 'INFO' { return LogLevel.INFO; }
-            when 'WARN' { return LogLevel.WARN; }
-            when 'ERROR' { return LogLevel.ERROR; }
-            when 'CRITICAL' { return LogLevel.CRITICAL; }  
-            otherwise { 
-                throw new owned ErrorWithContext(
-                        "level must be DEBUG, INFO, WARN, ERROR, or CRITICAL",
-                        getLineNumber(),
-                        getRoutineName(),
-                        getModuleName(),
-                        "IllegalArgumentError");
-            }  
-        } 
-    }
 }

--- a/src/Merge.chpl
+++ b/src/Merge.chpl
@@ -6,13 +6,8 @@ module Merge {
   use ServerConfig;
   use Logging;
   
-  const mLogger = new Logger();
-  
-  if v {
-      mLogger.level = LogLevel.DEBUG;
-  } else {
-      mLogger.level = LogLevel.INFO;
-  }
+  private config const logLevel = ServerConfig.logLevel;
+  const mLogger = new Logger(logLevel);
   
   /* Given a *sorted*, zero-up array, use binary search to find the index of the first element 
    * that is greater than or equal to a target.

--- a/src/MsgProcessing.chpl
+++ b/src/MsgProcessing.chpl
@@ -37,13 +37,8 @@ module MsgProcessing
     public use BroadcastMsg;
     public use FlattenMsg;
     
-    const mpLogger = new Logger();
-    
-    if v {
-        mpLogger.level = LogLevel.DEBUG;
-    } else {
-        mpLogger.level = LogLevel.INFO;
-    }
+    private config const logLevel = ServerConfig.logLevel;
+    const mpLogger = new Logger(logLevel);
     
     /* 
     Parse, execute, and respond to a create message 

--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -2,6 +2,7 @@
 module MultiTypeSymEntry
 {
     use ServerConfig;
+    use Logging;
 
     public use NumPyDType;
 
@@ -107,7 +108,7 @@ module MultiTypeSymEntry
         Verbose flag utility method
         */
         proc deinit() {
-            if v {writeln("deinit SymEntry");try! stdout.flush();}
+            if logLevel == LogLevel.DEBUG {writeln("deinit SymEntry");try! stdout.flush();}
         }
         
         override proc writeThis(f) throws {

--- a/src/MultiTypeSymbolTable.chpl
+++ b/src/MultiTypeSymbolTable.chpl
@@ -10,7 +10,8 @@ module MultiTypeSymbolTable
     use MultiTypeSymEntry;
     use Map;
     
-    const mtLogger = new Logger(ServerConfig.logLevel);
+    private config const logLevel = ServerConfig.logLevel;
+    const mtLogger = new Logger(logLevel);
 
     /* symbol table */
     class SymTab

--- a/src/MultiTypeSymbolTable.chpl
+++ b/src/MultiTypeSymbolTable.chpl
@@ -10,12 +10,7 @@ module MultiTypeSymbolTable
     use MultiTypeSymEntry;
     use Map;
     
-    var mtLogger = new Logger();
-    if v {
-        mtLogger.level = LogLevel.DEBUG;
-    } else {
-        mtLogger.level = LogLevel.INFO;    
-    }
+    const mtLogger = new Logger(ServerConfig.logLevel);
 
     /* symbol table */
     class SymTab

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -15,12 +15,8 @@ module OperatorMsg
     use Logging;
     use Message;
     
-    const omLogger = new Logger();
-    if v {
-        omLogger.level = LogLevel.DEBUG;
-    } else {
-        omLogger.level = LogLevel.INFO;    
-    }
+    private config const logLevel = ServerConfig.logLevel;
+    const omLogger = new Logger(logLevel);
     
     /*
     Parse and respond to binopvv message.

--- a/src/RadixSortLSD.chpl
+++ b/src/RadixSortLSD.chpl
@@ -22,13 +22,9 @@ module RadixSortLSD
     use Reflection;
     use Logging;
     use ServerConfig;
-    
-    const rsLogger = new Logger();
-    if v {
-        rsLogger.level = LogLevel.DEBUG;
-    } else {
-        rsLogger.level = LogLevel.INFO;    
-    }
+
+    private config const logLevel = ServerConfig.logLevel;
+    const rsLogger = new Logger(logLevel);
 
     inline proc getBitWidth(a: [?aD] int): (int, bool) {
       var aMin = min reduce a;

--- a/src/RandArray.chpl
+++ b/src/RandArray.chpl
@@ -11,13 +11,8 @@ module RandArray {
   use ServerConfig;
   private use IO;
   
-  const raLogger = new Logger();
-  
-  if v {
-      raLogger.level = LogLevel.DEBUG;
-  } else {
-      raLogger.level = LogLevel.INFO;
-  } 
+  private config const logLevel = ServerConfig.logLevel;
+  const raLogger = new Logger(logLevel);
 
   proc fillInt(a:[] ?t, const aMin, const aMax, const seedStr:string="None") throws where isIntType(t) {
       if (seedStr.toLower() == "none") {

--- a/src/RandMsg.chpl
+++ b/src/RandMsg.chpl
@@ -13,14 +13,9 @@ module RandMsg
     use MultiTypeSymbolTable;
     use MultiTypeSymEntry;
     use ServerErrorStrings;
-    
-    const randLogger = new Logger();
-    
-    if v {
-        randLogger.level = LogLevel.DEBUG;
-    } else {
-        randLogger.level = LogLevel.INFO;
-    }   
+
+    private config const logLevel = ServerConfig.logLevel;
+    const randLogger = new Logger(logLevel);
 
     /*
     parse, execute, and respond to randint message

--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -21,13 +21,8 @@ module ReductionMsg
 
     private config const lBins = 2**25 * numLocales;
 
-    const rmLogger = new Logger();
-  
-    if v {
-        rmLogger.level = LogLevel.DEBUG;
-    } else {
-        rmLogger.level = LogLevel.INFO;
-    }
+    private config const logLevel = ServerConfig.logLevel;
+    const rmLogger = new Logger(logLevel);
 
     // these functions take an array and produce a scalar
     // parse and respond to reduction message

--- a/src/RegistrationMsg.chpl
+++ b/src/RegistrationMsg.chpl
@@ -13,12 +13,8 @@ module RegistrationMsg
     use MultiTypeSymEntry;
     use ServerErrorStrings;
 
-    const regLogger = new Logger();
-    if v {
-        regLogger.level = LogLevel.DEBUG;
-    } else {
-        regLogger.level = LogLevel.INFO;    
-    }
+    private config const logLevel = ServerConfig.logLevel;
+    const regLogger = new Logger(logLevel);
 
     /* 
     Parse, execute, and respond to a register message 

--- a/src/SegStringSort.chpl
+++ b/src/SegStringSort.chpl
@@ -20,14 +20,9 @@ module SegStringSort {
   private const MEMFACTOR = SSS_MEMFACTOR;
   private config const SSS_PARTITION_LONG_STRING = false;
   private const PARTITION_LONG_STRING = SSS_PARTITION_LONG_STRING;
- 
-  
-  const ssLogger = new Logger();
-  if v {
-      ssLogger.level = LogLevel.DEBUG;
-  } else {
-      ssLogger.level = LogLevel.INFO;    
-  }
+
+  private config const logLevel = ServerConfig.logLevel;
+  const ssLogger = new Logger(logLevel);
 
   record StringIntComparator {
     proc keyPart((a0,_): (string, int), in i: int) {

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -17,13 +17,7 @@ module SegmentedArray {
   use Logging;
   use Errors;
 
-  const saLogger = new Logger();
-  
-  if v {
-      saLogger.level = LogLevel.DEBUG;
-  } else {
-      saLogger.level = LogLevel.INFO;
-  }
+  const saLogger = new Logger(ServerConfig.logLevel);
 
   private config param useHash = true;
   param SegmentedArrayUseHash = useHash;

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -17,7 +17,8 @@ module SegmentedArray {
   use Logging;
   use Errors;
 
-  const saLogger = new Logger(ServerConfig.logLevel);
+  private config const logLevel = ServerConfig.logLevel;
+  const saLogger = new Logger(logLevel);
 
   private config param useHash = true;
   param SegmentedArrayUseHash = useHash;
@@ -236,7 +237,7 @@ module SegmentedArray {
       saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
                                 "aggregation in %i seconds".format(getCurrentTime() - t1));
       saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), "Copying values");
-      if v {
+      if logLevel == LogLevel.DEBUG {
           t1 = getCurrentTime();
       }
       var gatheredVals = makeDistArray(retBytes, uint(8));
@@ -329,7 +330,7 @@ module SegmentedArray {
       /* var gatheredOffsets = (+ scan gatheredLengths); */
       /* var retBytes = gatheredOffsets[newSize-1]; */
       /* gatheredOffsets -= gatheredLengths; */
-      /* if v { */
+      /* if logLevel == LogLevel.DEBUG { */
       /*     saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                   "%i seconds".format(getCurrentTime() - t1)); */
       /*     saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"Copying values"));*/
@@ -337,7 +338,7 @@ module SegmentedArray {
       /* } */
       /* var gatheredVals = makeDistArray(retBytes, uint(8)); */
       /* ref va = values.a; */
-      /* if v { */
+      /* if logLevel == LogLevel.DEBUG { */
       /*   printAry("gatheredOffsets: ", gatheredOffsets); */
       /*   printAry("gatheredLengths: ", gatheredLengths); */
       /*   printAry("segInds: ", segInds); */
@@ -386,10 +387,10 @@ module SegmentedArray {
       if useHash {
         // Hash all strings
         saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), "Hashing strings"); 
-        if v { t.start(); }
+        if logLevel == LogLevel.DEBUG { t.start(); }
         var hashes = this.hash();
 
-        if v { 
+        if logLevel == LogLevel.DEBUG { 
             t.stop();    
             saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                            "hashing took %t seconds\nSorting hashes".format(t.elapsed())); 
@@ -398,12 +399,12 @@ module SegmentedArray {
 
         // Return the permutation that sorts the hashes
         var iv = radixSortLSD_ranks(hashes);
-        if v { 
+        if logLevel == LogLevel.DEBUG { 
             t.stop(); 
             saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                             "sorting took %t seconds".format(t.elapsed())); 
         }
-        if v{
+        if logLevel == LogLevel.DEBUG {
           var sortedHashes = [i in iv] hashes[i];
           var diffs = sortedHashes[(iv.domain.low+1)..#(iv.size-1)] - 
                                                  sortedHashes[(iv.domain.low)..#(iv.size-1)];
@@ -460,14 +461,14 @@ module SegmentedArray {
       }
       var t = new Timer();
 
-      if v {
+      if logLevel == LogLevel.DEBUG {
            saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                 "Checking bytes of substr"); 
            t.start();
       }
       const truth = findSubstringInBytes(substr);
       const D = truth.domain;
-      if v {
+      if logLevel == LogLevel.DEBUG {
             t.stop(); 
             saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                   "took %t seconds\nTranslating to segments...".format(t.elapsed())); 
@@ -478,7 +479,7 @@ module SegmentedArray {
       const tail = + reduce (offsets.a > D.high);
       // oD is the right-truncated domain representing segments that are candidates for containing substr
       var oD: subdomain(offsets.aD) = offsets.aD[offsets.aD.low..#(offsets.size - tail)];
-      if v {
+      if logLevel == LogLevel.DEBUG {
              t.stop(); 
              saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                    "took %t seconds\ndetermining answer...".format(t.elapsed())); 
@@ -502,7 +503,7 @@ module SegmentedArray {
         hits[oD.interior(-(oD.size-1))] = truth[oa[oD.interior(oD.size-1)] - substr.numBytes - 1];
         hits[oD.high] = truth[D.high-1];
       }
-      if v {
+      if logLevel == LogLevel.DEBUG {
           t.stop(); 
           saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                    "took %t seconds".format(t.elapsed()));
@@ -880,9 +881,9 @@ module SegmentedArray {
     // Hash all strings for fast comparison
     var t = new Timer();
     saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"Hashing strings");
-    if v { t.start(); }
+    if logLevel == LogLevel.DEBUG { t.start(); }
     const hashes = mainStr.hash();
-    if v {
+    if logLevel == LogLevel.DEBUG {
         t.stop(); 
         saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
                                                 "%t seconds".format(t.elapsed())); 
@@ -907,7 +908,7 @@ module SegmentedArray {
         /* [i in truth.localSubdomain()] truth[i] = mySet.contains(hashes[i]); */
       }
     }
-    if v {
+    if logLevel == LogLevel.DEBUG {
       t.stop(); 
       saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                              "%t seconds".format(t.elapsed())); 
@@ -917,7 +918,7 @@ module SegmentedArray {
       t.start();
     }
     [i in truth.domain] truth[i] = localTestHashes[here.id].contains(hashes[i]);
-    if v {
+    if logLevel == LogLevel.DEBUG {
         t.stop(); 
         saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                              "%t seconds".format(t.elapsed()));
@@ -964,7 +965,7 @@ module SegmentedArray {
       const order = ar.argsort();
       const (sortedSegs, sortedVals) = ar[order];
       const sar = new owned SegString(sortedSegs, sortedVals, st);
-      if v { 
+      if logLevel == LogLevel.DEBUG { 
           saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                                             "Sorted concatenated unique strings:"); 
           sar.show(10); 
@@ -1005,7 +1006,7 @@ module SegmentedArray {
       forall (o, f) in zip(order, flag) with (var agg = newDstAggregator(bool)) {
         agg.copy(ret[o], f);
       }
-      if v {
+      if logLevel == LogLevel.DEBUG {
           saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                                 "Ret pop: %t".format(+ reduce ret));
       }

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -12,7 +12,8 @@ module SegmentedMsg {
   use IO;
   use GenSymIO only jsonToPdArray;
 
-  const smLogger = new Logger(ServerConfig.logLevel);
+  private config const logLevel = ServerConfig.logLevel;
+  const smLogger = new Logger(logLevel);
 
   proc randomStringsMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
       var pn = Reflection.getRoutineName();

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -12,13 +12,7 @@ module SegmentedMsg {
   use IO;
   use GenSymIO only jsonToPdArray;
 
-  const smLogger = new Logger();
-  
-  if v {
-      smLogger.level = LogLevel.DEBUG;
-  } else {
-      smLogger.level = LogLevel.INFO;
-  }
+  const smLogger = new Logger(ServerConfig.logLevel);
 
   proc randomStringsMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
       var pn = Reflection.getRoutineName();

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -24,6 +24,11 @@ module ServerConfig
     config const v = false;
 
     /*
+    Log level flag that defaults to LogLevel.INFO
+    */
+    config var logLevel = LogLevel.INFO;
+
+    /*
     Port for zeromq
     */
     config const ServerPort = 5555;
@@ -43,7 +48,7 @@ module ServerConfig
     */
     config const serverConnectionInfo: string = getEnv("ARKOUDA_SERVER_CONNECTION_INFO", "");
 
-    const scLogger = new Logger();
+    const scLogger = new Logger(logLevel);
   
     if v {
         scLogger.level = LogLevel.DEBUG;
@@ -89,6 +94,7 @@ module ServerConfig
             var LocaleConfigs: [LocaleSpace] owned LocaleConfig =
                 [loc in LocaleSpace] new owned LocaleConfig();
             var authenticate: bool;
+            var logLevel: LogLevel;
         }
         var (Zmajor, Zminor, Zmicro) = ZMQ.version;
         var H5major: c_uint, H5minor: c_uint, H5micro: c_uint;
@@ -105,6 +111,7 @@ module ServerConfig
         cfg.physicalMemory = getPhysicalMemHere();
         cfg.distributionType = (makeDistDom(10).type):string;
         cfg.authenticate = authenticate; 
+        cfg.logLevel = logLevel;
 
         for loc in Locales {
             on loc {

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -19,12 +19,7 @@ module ServerConfig
     config const trace = true;
 
     /*
-    Verbose debug flag
-    */
-    config const v = false;
-
-    /*
-    Log level flag that defaults to LogLevel.INFO
+    Global log level flag that defaults to LogLevel.INFO
     */
     config var logLevel = LogLevel.INFO;
 
@@ -48,14 +43,6 @@ module ServerConfig
     */
     config const serverConnectionInfo: string = getEnv("ARKOUDA_SERVER_CONNECTION_INFO", "");
 
-    const scLogger = new Logger(logLevel);
-  
-    if v {
-        scLogger.level = LogLevel.DEBUG;
-    } else {
-        scLogger.level = LogLevel.INFO;
-    }
-
     /*
     Hostname where I am running
     */
@@ -69,6 +56,9 @@ module ServerConfig
     Indicates whether token authentication is being used for Akrouda server requests
     */
     config const authenticate : bool = false;
+
+    private config const lLevel = ServerConfig.logLevel;
+    const scLogger = new Logger(lLevel);
    
     proc getConfig(): string {
         use SysCTypes;

--- a/src/SipHash.chpl
+++ b/src/SipHash.chpl
@@ -14,13 +14,8 @@ module SipHash {
 
   const defaultSipHashKey: [0..#16] uint(8) = for i in 0..#16 do i: uint(8);
 
-  const shLogger = new Logger();
-
-  if v {
-      shLogger.level = LogLevel.DEBUG;
-  } else {
-      shLogger.level = LogLevel.INFO;
-  }
+  private config const logLevel = ServerConfig.logLevel;
+  const shLogger = new Logger(logLevel);
 
   inline proc ROTL(x, b) {
     return (((x) << (b)) | ((x) >> (64 - (b))));

--- a/src/SortMsg.chpl
+++ b/src/SortMsg.chpl
@@ -14,15 +14,10 @@ module SortMsg
     use AryUtil;
     use Logging;
     use Message;
-    
-    const sortLogger = new Logger();
-  
-    if v {
-        sortLogger.level = LogLevel.DEBUG;
-    } else {
-        sortLogger.level = LogLevel.INFO;
-    }
-  
+
+    private config const logLevel = ServerConfig.logLevel;
+    const sortLogger = new Logger(logLevel);
+
     /* Sort the given pdarray using Radix Sort and
        return sorted keys as a block distributed array */
     proc sort(a: [?aD] ?t): [aD] t {

--- a/src/Unique.chpl
+++ b/src/Unique.chpl
@@ -27,15 +27,9 @@ module Unique
     use AryUtil;
     use Reflection;
     use Logging;
-    
-    const uLogger = new Logger();
-  
-    if v {
-        uLogger.level = LogLevel.DEBUG;
-    } else {
-        uLogger.level = LogLevel.INFO;
-    } 
 
+    private config const logLevel = ServerConfig.logLevel;
+    const uLogger = new Logger(logLevel);
 
     /* // thresholds for different unique counting algorithms */
     /* var sBins = 2**10; // small-range maybe for using reduce intents on forall loops */

--- a/src/UniqueMsg.chpl
+++ b/src/UniqueMsg.chpl
@@ -26,13 +26,8 @@ module UniqueMsg
 
     use Unique;
     
-    const umLogger = new Logger();
-  
-    if v {
-        umLogger.level = LogLevel.DEBUG;
-    } else {
-        umLogger.level = LogLevel.INFO;
-    }
+    private config const logLevel = ServerConfig.logLevel;
+    const umLogger = new Logger(logLevel);
     
     /* unique take a pdarray and returns a pdarray with the unique values */
     proc uniqueMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {

--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -21,13 +21,8 @@ use SymArrayDmap;
 use ServerErrorStrings;
 use Message;
 
-const asLogger = new Logger();
-
-if v {
-    asLogger.level = LogLevel.DEBUG;
-} else {
-    asLogger.level = LogLevel.INFO;
-}
+private config const logLevel = ServerConfig.logLevel;
+const asLogger = new Logger(logLevel);
 
 proc initArkoudaDirectory() {
     var arkDirectory = '%s%s%s'.format(here.cwd(), pathSep,'.arkouda');

--- a/test/COMPOPTS
+++ b/test/COMPOPTS
@@ -19,7 +19,7 @@ COMPAT_MODULES=$(cd $ARKOUDA_HOME && make print-ARKOUDA_COMPAT_MODULES)
 # Location of the configuration file, so we always include it and disable extra
 # debugging that might make noise in the tests
 CONFIG_FILE="${SRC_DIR}/ServerConfig.chpl"
-CONFIG_OPTS="${CONFIG_FILE} -sv=false -strace=false"
+CONFIG_OPTS="${CONFIG_FILE} -strace=false"
 
 TEST_OPTS="-sprintTimes=false -sprintDiags=false -sprintDiagsSum=false"
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -63,6 +63,7 @@ class ClientTest(ArkoudaTest):
             raise AssertionError(e)
         self.assertEqual(ArkoudaTest.port, config['ServerPort'])
         self.assertTrue('arkoudaVersion' in config)
+        self.assertTrue('INFO', config['logLevel'])
         
     def test_client_context(self):   
         '''

--- a/util/test/util.py
+++ b/util/test/util.py
@@ -180,7 +180,6 @@ def start_arkouda_server(numlocales, verbose=False, log=False, port=5555, host=N
     
     cmd = [get_arkouda_server(),
            '--trace={}'.format('true' if log else 'false'),
-           '--v={}'.format('true' if verbose else 'false'),
            '--serverConnectionInfo={}'.format(connection_file),
            '-nl {}'.format(numlocales), '--ServerPort={}'.format(port)]
 


### PR DESCRIPTION
This draft PR enhances logging configuration as follows:

1. Replaces --v flag with --logLevel flag to enable a global DEBUG, INFO. WARN, ERROR, or CRITICAL logging level
2. Enables module-level logging level setting (implemented in a subset of the modules)

If the design of (2) is cool, will rollout to rest of modules, remove --v flag, and remove no-arg Logger.init() function