### PR TITLE
Closes #761: Adding registration suite of functions for Categorical

### DIFF
--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -911,7 +911,7 @@ class Strings:
 
         See also
         --------
-        register, unregister
+        register, attach
 
         Notes
         -----
@@ -920,6 +920,7 @@ class Strings:
         """
         self.offsets.unregister()
         self.bytes.unregister()
+        self.name = None
 
     @staticmethod
     @typechecked
@@ -956,3 +957,28 @@ class Strings:
                        pdarray.attach(user_defined_name+'_bytes'))
         s.name = user_defined_name
         return s
+
+    @staticmethod
+    @typechecked
+    def unregister_strings_by_name(user_defined_name : str) -> None:
+        """
+        Unregister a Strings object in the arkouda server previously registered via register()
+        WARNING: This will cause the underlying object to go out-of-scope issuing a deletion
+         message to the server.  If you wish to retain access to the underlying
+         object, you should attach manually and then unregister the object so you
+         can maintain a python reference to it, keeping it in scope.
+
+        Parameters
+        ----------
+        user_defined_name : str
+            The name of the Strings object
+
+        See also
+        --------
+        register, unregister, attach
+
+        Notes
+        -----
+        Will attempt to Strings.attach(user_defined_name).unregister()
+        """
+        Strings.attach(user_defined_name).unregister()


### PR DESCRIPTION
(Issue #761)  Adding registration suite of functions for Categorical
  This adds the following methods/functions to Categorical
    - register
    - is_registered
    - attach (static)
    - unregister
    - unregister_categorical_by_name (static)
  Unit tests were added to test and document various usage.
  Changes to other classes were also made to support Categorical registration.

This is required to support registration changes for GroupBy (part of Issue #729 )

NOTE: The static unregister_*_by_name methods have a warning denoting the fact that object deletion messages will be sent to the server because the objects will go out of scope.  This is _not_ a change introduced in this PR, rather it was a side-effect introduced by the switch to in-place object registration.  See the included unit test in `registration_test.py:test_attach_weak_binding` which illustrates the current behavior in `pdarrayclass`.

Feedback welcomed ;)