### PR TITLE
Closes #771: Update deleteMsg for registered objects

### DIFF
--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -3,7 +3,7 @@ from typing import cast, Sequence, Union, List
 from typeguard import typechecked
 import json, struct
 import numpy as np # type: ignore
-from arkouda.client import generic_msg, RegisteredSymbols, EmptyRegistry, EmptySymbolTable
+from arkouda.client import generic_msg, RegisteredSymbols, AllSymbols, EmptyRegistry, EmptySymbolTable
 from arkouda.dtypes import dtype, DTypes, resolve_scalar_dtype, \
      structDtypeCodes, translate_np_dtype, NUMBER_FORMAT_STRINGS, \
      int_scalars, numeric_scalars, numpy_scalars
@@ -13,8 +13,8 @@ from arkouda.dtypes import bool as npbool
 from arkouda.logger import getArkoudaLogger
 import builtins
 
-__all__ = ["pdarray", "info", "clear", "any", "all", "is_sorted", "list_registry", "sum", "prod",
-           "min", "max", "argmin", "argmax", "mean", "var", "std", "mink", 
+__all__ = ["pdarray", "info", "clear", "any", "all", "is_sorted", "list_registry", "list_symbol_table",
+           "sum", "prod", "min", "max", "argmin", "argmax", "mean", "var", "std", "mink",
            "maxk", "argmink", "argmaxk", "attach_pdarray",
            "unregister_pdarray", "RegistrationError"]
 
@@ -1216,6 +1216,35 @@ def list_registry() -> List[str]:
                 registered_list.append(name)
 
     return registered_list
+
+def list_symbol_table() -> List[str]:
+    """
+    Return a list containing the names of all objects in the symbol table
+
+    Parameters
+    ----------
+    None
+
+    Returns
+    -------
+    list
+        List of all object names in the symbol table
+
+    Raises
+    ------
+    RuntimeError
+        Raised if there's a server-side error thrown
+    """
+    symbol_list: List[str] = []
+
+    if info(AllSymbols) not in [EmptyRegistry, EmptySymbolTable]:
+        symbol: str
+        for symbol in filter(None, info(AllSymbols).split('\n')):
+            if symbol is not None:
+                name = symbol.split()[0].split(':')[1].replace('"', '')
+                symbol_list.append(name)
+
+    return symbol_list
 
 def clear() -> None:
     """

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1207,14 +1207,13 @@ def list_registry() -> List[str]:
         Raised if there's a server-side error thrown
     """
     registered_list: List[str] = []
-
-    if info(RegisteredSymbols) not in [EmptyRegistry, EmptySymbolTable]:
+    all_registered = info(RegisteredSymbols)
+    if all_registered not in [EmptyRegistry, EmptySymbolTable]:
         registered_object: str
-        for registered_object in filter(None, info(RegisteredSymbols).split('\n')):
-            if registered_object is not None:
+        for registered_object in all_registered.split('\n'):
+            if registered_object:
                 name = registered_object.split()[0].split(':')[1].replace('"', '')
                 registered_list.append(name)
-
     return registered_list
 
 def list_symbol_table() -> List[str]:
@@ -1236,14 +1235,13 @@ def list_symbol_table() -> List[str]:
         Raised if there's a server-side error thrown
     """
     symbol_list: List[str] = []
-
-    if info(AllSymbols) not in [EmptyRegistry, EmptySymbolTable]:
+    all_symbols = info(AllSymbols)
+    if all_symbols not in [EmptyRegistry, EmptySymbolTable]:
         symbol: str
-        for symbol in filter(None, info(AllSymbols).split('\n')):
-            if symbol is not None:
+        for symbol in all_symbols.split('\n'):
+            if symbol:
                 name = symbol.split()[0].split(':')[1].replace('"', '')
                 symbol_list.append(name)
-
     return symbol_list
 
 def clear() -> None:

--- a/src/MsgProcessing.chpl
+++ b/src/MsgProcessing.chpl
@@ -98,9 +98,12 @@ module MsgProcessing
         mpLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
                                      "cmd: %s array: %s".format(cmd,st.attrib(name)));
         // delete entry from symbol table
-        st.deleteEntry(name);
-
-        repMsg =  "deleted %s".format(name);      
+        if st.deleteEntry(name) {
+            repMsg = "deleted %s".format(name);
+        }
+        else {
+            repMsg = "failed to delete registered symbol %s".format(name);
+        }
         mpLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);       
         return new MsgTuple(repMsg, MsgType.NORMAL);
     }

--- a/src/MsgProcessing.chpl
+++ b/src/MsgProcessing.chpl
@@ -102,7 +102,7 @@ module MsgProcessing
             repMsg = "deleted %s".format(name);
         }
         else {
-            repMsg = "failed to delete registered symbol %s".format(name);
+            repMsg = "registered symbol, %s, not deleted".format(name);
         }
         mpLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);       
         return new MsgTuple(repMsg, MsgType.NORMAL);

--- a/src/MultiTypeSymbolTable.chpl
+++ b/src/MultiTypeSymbolTable.chpl
@@ -195,7 +195,7 @@ module MultiTypeSymbolTable
         :arg name: name of the array
         :type name: string
 
-        :returns: bool indicating whether deletion was successful
+        :returns: bool indicating whether the deletion occurred
         */
         proc deleteEntry(name: string): bool throws {
             if tab.contains(name) { 

--- a/src/MultiTypeSymbolTable.chpl
+++ b/src/MultiTypeSymbolTable.chpl
@@ -1,4 +1,3 @@
-
 module MultiTypeSymbolTable
 {
     use ServerConfig;
@@ -195,16 +194,20 @@ module MultiTypeSymbolTable
 
         :arg name: name of the array
         :type name: string
+
+        :returns: bool indicating whether deletion was successful
         */
-        proc deleteEntry(name: string) throws {
+        proc deleteEntry(name: string): bool throws {
             if tab.contains(name) { 
                if !registry.contains(name) {
                    mtLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                            "Deleting unregistered entry: %s".format(name)); 
                    tab.remove(name);
+                   return true;
                } else {
                     mtLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                            "Skipping registered entry: %s".format(name)); 
+                    return false;
                }            
             } else {
                 if registry.contains(name) {
@@ -213,7 +216,13 @@ module MultiTypeSymbolTable
                 } else {
                     mtLogger.error(getModuleName(),getRoutineName(),getLineNumber(),
                                      "Unregistered entry is not in SymTab: %s".format(name));    
-                }           
+                }
+                throw getErrorWithContext(
+                    msg=unknownSymbolError(pname="deleteEntry", sname=name),
+                    lineNumber=getLineNumber(),
+                    routineName=getRoutineName(),
+                    moduleName=getModuleName(),
+                    errorClass="UnknownSymbolError");
             }
         }
 

--- a/tests/registration_test.py
+++ b/tests/registration_test.py
@@ -1,5 +1,5 @@
 from context import arkouda as ak
-from typing import Tuple, List
+from typing import Tuple
 import numpy as np
 from collections import Counter
 from base_test import ArkoudaTest
@@ -320,30 +320,18 @@ class RegistrationTest(ArkoudaTest):
 
         # registered objects are not deleted from symbol table
         a.register('keep')
-        self.assertEqual(ak.client.generic_msg(cmd='delete', args='keep'),
-                         'failed to delete registered symbol keep')
-        self.assertTrue(a.name in list_symbol_table())
+        self.assertEqual(ak.client.generic_msg(cmd='delete', args=a.name),
+                         f'registered symbol, {a.name}, not deleted')
+        self.assertTrue(a.name in ak.list_symbol_table())
 
         # non-registered objects are deleted from symbol table
         self.assertEqual(ak.client.generic_msg(cmd='delete', args=b.name),
                          'deleted ' + b.name)
-        self.assertTrue(b.name not in list_symbol_table())
+        self.assertTrue(b.name not in ak.list_symbol_table())
 
         # RuntimeError when calling delete on an object not in the symbol table
         with self.assertRaises(RuntimeError):
             ak.client.generic_msg(cmd='delete', args='not_in_table')
-
-def list_symbol_table() -> List[str]:
-    symbol_list: List[str] = []
-
-    if ak.info(ak.AllSymbols) not in [ak.EmptyRegistry, ak.EmptySymbolTable]:
-        bject: str
-        for object in filter(None, ak.info(ak.AllSymbols).split('\n')):
-            if object is not None:
-                name = object.split()[0].split(':')[1].replace('"', '')
-                symbol_list.append(name)
-
-    return symbol_list
 
 def cleanup():
     ak.clear()

--- a/tests/registration_test.py
+++ b/tests/registration_test.py
@@ -1,5 +1,5 @@
 from context import arkouda as ak
-from typing import Tuple
+from typing import Tuple, List
 import numpy as np
 from collections import Counter
 from base_test import ArkoudaTest
@@ -306,6 +306,44 @@ class RegistrationTest(ArkoudaTest):
         self.assertFalse(keep.is_registered())
         ak.clear()
 
+    def test_delete_registered(self):
+        """
+        Tests the following:
+
+        1. delete cmd doesn't delete registered objects and returns appropriate message
+        2. delete cmd does delete non-registered objects and returns appropriate message
+        3. delete cmd raises RuntimeError for unknown symbols
+        """
+        cleanup()
+        a = ak.ones(3, dtype=ak.int64)
+        b = ak.ones(3, dtype=ak.int64)
+
+        # registered objects are not deleted from symbol table
+        a.register('keep')
+        self.assertEqual(ak.client.generic_msg(cmd='delete', args='keep'),
+                         'failed to delete registered symbol keep')
+        self.assertTrue(a.name in list_symbol_table())
+
+        # non-registered objects are deleted from symbol table
+        self.assertEqual(ak.client.generic_msg(cmd='delete', args=b.name),
+                         'deleted ' + b.name)
+        self.assertTrue(b.name not in list_symbol_table())
+
+        # RuntimeError when calling delete on an object not in the symbol table
+        with self.assertRaises(RuntimeError):
+            ak.client.generic_msg(cmd='delete', args='not_in_table')
+
+def list_symbol_table() -> List[str]:
+    symbol_list: List[str] = []
+
+    if ak.info(ak.AllSymbols) not in [ak.EmptyRegistry, ak.EmptySymbolTable]:
+        bject: str
+        for object in filter(None, ak.info(ak.AllSymbols).split('\n')):
+            if object is not None:
+                name = object.split()[0].split(':')[1].replace('"', '')
+                symbol_list.append(name)
+
+    return symbol_list
 
 def cleanup():
     ak.clear()


### PR DESCRIPTION
This PR (Issue #771 )
- Updates `repMsg` when `deleteMsg` is called on a registered object
- Adds bool return for `deleteEntry` indicating successful or failed deletion
- Raises `UnknownSymbolError` when `deleteEntry` is called on an object not found in the Symbol Table
- Adds a test for this new behavior in `registration_test.py`
- Adds `ak.list_symbol_table`  to functions available to user