### PR TITLE
Issue #761: Categorical, Strings, and pdarray registration updates

### DIFF
--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -16,7 +16,7 @@ import builtins
 __all__ = ["pdarray", "info", "clear", "any", "all", "is_sorted", "list_registry", "list_symbol_table",
            "sum", "prod", "min", "max", "argmin", "argmax", "mean", "var", "std", "mink",
            "maxk", "argmink", "argmaxk", "attach_pdarray",
-           "unregister_pdarray", "RegistrationError"]
+           "unregister_pdarray_by_name", "RegistrationError"]
 
 logger = getArkoudaLogger(name='pdarrayclass')    
 
@@ -1001,7 +1001,7 @@ class pdarray:
 
         See also
         --------
-        attach, unregister
+        attach, unregister, is_registered, list_registry, unregister_pdarray_by_name
 
         Notes
         -----
@@ -1048,7 +1048,7 @@ class pdarray:
         
         See also
         --------
-        register, unregister
+        register, unregister, is_registered, unregister_pdarray_by_name, list_registry
         
         Notes
         -----
@@ -1064,8 +1064,8 @@ class pdarray:
         >>> # ...other work...
         >>> b.unregister()
         """
-        unregister_pdarray(self)
-        
+        unregister_pdarray_by_name(self.name)
+
     # class method self is not passed in
     # invoke with ak.pdarray.attach('user_defined_name')
     @staticmethod
@@ -1092,7 +1092,7 @@ class pdarray:
         
         See also
         --------
-        register, unregister
+        register, unregister, is_registered, unregister_pdarray_by_name, list_registry
         
         Notes
         -----
@@ -1846,7 +1846,7 @@ def attach_pdarray(user_defined_name: str) -> pdarray:
 
     See also
     --------
-    register, unregister_pdarray
+    register, unregister, is_registered, unregister_pdarray_by_name, list_registry
 
     Notes
     -----
@@ -1860,20 +1860,22 @@ def attach_pdarray(user_defined_name: str) -> pdarray:
     >>> # potentially disconnect from server and reconnect to server
     >>> b = ak.attach_pdarray("my_zeros")
     >>> # ...other work...
-    >>> ak.unregister_pdarray(b)
+    >>> b.unregister()
     """
     repMsg = generic_msg(cmd="attach", args="{}".format(user_defined_name))
     return create_pdarray(repMsg)
 
 
 @typechecked
-def unregister_pdarray(pda: Union[str,pdarray]) -> None:
+def unregister_pdarray_by_name(user_defined_name:str) -> None:
     """
-    Unregister a pdarray in the arkouda server which was previously
+    Unregister a named pdarray in the arkouda server which was previously
     registered using register() and/or attahced to using attach_pdarray()
 
     Parameters
     ----------
+    user_defined_name : str
+        user defined name which array was registered under
 
     Returns
     -------
@@ -1886,7 +1888,7 @@ def unregister_pdarray(pda: Union[str,pdarray]) -> None:
 
     See also
     --------
-    register, unregister_pdarray
+    register, unregister, is_registered, list_registry, attach
 
     Notes
     -----
@@ -1900,13 +1902,9 @@ def unregister_pdarray(pda: Union[str,pdarray]) -> None:
     >>> # potentially disconnect from server and reconnect to server
     >>> b = ak.attach_pdarray("my_zeros")
     >>> # ...other work...
-    >>> ak.unregister_pdarray(b)
+    >>> ak.unregister_pdarray_by_name(b)
     """
-    if isinstance(pda, pdarray):
-        repMsg = generic_msg(cmd="unregister", args="{}".format(pda.name))
-
-    if isinstance(pda, str):
-        repMsg = generic_msg(cmd="unregister", args="{}".format(pda))
+    repMsg = generic_msg(cmd="unregister", args=user_defined_name)
 
 
 # TODO In the future move this to a specific errors file

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
-from typing import cast, Tuple, Union
+from typing import cast, Optional, Tuple, Union
 from typeguard import typechecked
 from arkouda.client import generic_msg
-from arkouda.pdarrayclass import pdarray, create_pdarray, parse_single_value, list_registry
+from arkouda.pdarrayclass import pdarray, create_pdarray, parse_single_value, unregister_pdarray_by_name, RegistrationError
 from arkouda.logger import getArkoudaLogger
 import numpy as np # type: ignore
 from arkouda.dtypes import npstr, int_scalars, str_scalars
@@ -96,7 +96,7 @@ class Strings:
             raise ValueError(e)   
 
         self.dtype = npstr
-        self.name:Union[str, None] = None
+        self.name:Optional[str] = None
         self.logger = getArkoudaLogger(name=__class__.__name__) # type: ignore
 
     def __iter__(self):
@@ -846,7 +846,12 @@ class Strings:
         RuntimeError
             Raised if there's a server-side error thrown
         """
-        return np.bool_(self.offsets.is_registered() and self.bytes.is_registered())
+        parts_registered = [np.bool_(self.offsets.is_registered()), self.bytes.is_registered()]
+        if np.any(parts_registered) and not np.all(parts_registered):  # test for error
+            raise RegistrationError(f"Not all registerable components of Strings {self.name} are registered.")
+
+        return np.bool_(np.any(parts_registered))
+
 
     @typechecked
     def register(self, user_defined_name: str) -> Strings:
@@ -887,8 +892,8 @@ class Strings:
         Registered names/Strings objects in the server are immune to deletion
         until they are unregistered.
         """
-        self.offsets.register(user_defined_name+'_offsets')
-        self.bytes.register(user_defined_name+'_bytes')
+        self.offsets.register(f"{user_defined_name}.offsets")
+        self.bytes.register(f"{user_defined_name}.bytes")
         self.name = user_defined_name
         return self
 
@@ -911,7 +916,7 @@ class Strings:
 
         See also
         --------
-        register, unregister
+        register, attach
 
         Notes
         -----
@@ -920,6 +925,7 @@ class Strings:
         """
         self.offsets.unregister()
         self.bytes.unregister()
+        self.name = None
 
     @staticmethod
     @typechecked
@@ -952,7 +958,25 @@ class Strings:
         Registered names/Strings objects in the server are immune to deletion
         until they are unregistered.
         """
-        s = Strings(pdarray.attach(user_defined_name+'_offsets'),
-                       pdarray.attach(user_defined_name+'_bytes'))
+        s = Strings(pdarray.attach(f"{user_defined_name}.offsets"),
+                    pdarray.attach(f"{user_defined_name}.bytes"))
         s.name = user_defined_name
         return s
+
+    @staticmethod
+    @typechecked
+    def unregister_strings_by_name(user_defined_name : str) -> None:
+        """
+        Unregister a Strings object in the arkouda server previously registered via register()
+
+        Parameters
+        ----------
+        user_defined_name : str
+            The registered name of the Strings object
+
+        See also
+        --------
+        register, unregister, attach, is_registered
+        """
+        unregister_pdarray_by_name(f"{user_defined_name}.bytes")
+        unregister_pdarray_by_name(f"{user_defined_name}.offsets")


### PR DESCRIPTION
PR for Issue #761

Categorical.py
Added registration suite of functions to Categorical
- register
- is_registered
- attach (static)
- unregister
- unregister_categorical_by_name (static)

Strings.py
- Modifies Strings sub-component names to use '.' for extensions (i.e. `abc.offsets` and `abc.bytes`
- Modifed Strings.is_registered to verify all parts are registered or unregistered
- Adds static `unregister_strings_by_name`

pdarrayclass.py
- Updates static method name `unregister_pdarray_by_name`
- `unregister_pdarray_by_name` now only takes string argument

Updates to documentation
Additional unit tests for `registration_test.py`

NOTE: These changes were based on feedback from previous PR#768 and discussion regarding registration changes with @mhmerrill 