### PR TITLE
Issue #736: Adding isna functionality for float based arrays

### DIFF
--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -13,7 +13,7 @@ from arkouda.strings import Strings
 Categorical = ForwardRef('Categorical')
 
 __all__ = ["cast", "abs", "log", "exp", "cumsum", "cumprod", "sin", "cos", 
-           "where", "histogram", "value_counts"]    
+           "where", "histogram", "value_counts", "isna"]
 
 @typechecked
 def cast(pda : Union[pdarray, Strings], dt: Union[np.dtype,str]) -> Union[pdarray, Strings]:
@@ -508,3 +508,28 @@ def value_counts(pda : pdarray) -> Union[Categorical, # type: ignore
     (array([0, 2, 4]), array([3, 2, 1]))
     """
     return unique(pda, return_counts=True)
+
+
+@typechecked
+def isna(pda : pdarray) -> pdarray:
+    """
+    Test a pdarray for missing values / NaN
+    Currently only supports float-value-based arrays
+
+    Parameters
+    ----------
+    pda : pdarray to test
+
+    Returns
+    -------
+    pdarray consisting of True / False values; True where NaN, False otherwise
+
+    Raises
+    ------
+    TypeError
+        Raised if the parameter is not a pdarray
+    RuntimeError
+        if the underlying component is not a float-based array
+    """
+    rep_msg = generic_msg(cmd="efunc", args=f"isna {pda.name}")
+    return create_pdarray(type_cast(str, rep_msg))

--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -13,7 +13,7 @@ from arkouda.strings import Strings
 Categorical = ForwardRef('Categorical')
 
 __all__ = ["cast", "abs", "log", "exp", "cumsum", "cumprod", "sin", "cos", 
-           "where", "histogram", "value_counts", "isna"]
+           "where", "histogram", "value_counts", "isnan"]
 
 @typechecked
 def cast(pda : Union[pdarray, Strings], dt: Union[np.dtype,str]) -> Union[pdarray, Strings]:
@@ -511,9 +511,9 @@ def value_counts(pda : pdarray) -> Union[Categorical, # type: ignore
 
 
 @typechecked
-def isna(pda : pdarray) -> pdarray:
+def isnan(pda : pdarray) -> pdarray:
     """
-    Test a pdarray for missing values / NaN
+    Test a pdarray for Not a number / NaN values
     Currently only supports float-value-based arrays
 
     Parameters
@@ -529,7 +529,7 @@ def isna(pda : pdarray) -> pdarray:
     TypeError
         Raised if the parameter is not a pdarray
     RuntimeError
-        if the underlying component is not a float-based array
+        if the underlying pdarray is not float-based
     """
-    rep_msg = generic_msg(cmd="efunc", args=f"isna {pda.name}")
+    rep_msg = generic_msg(cmd="efunc", args=f"isnan {pda.name}")
     return create_pdarray(type_cast(str, rep_msg))

--- a/src/EfuncMsg.chpl
+++ b/src/EfuncMsg.chpl
@@ -118,7 +118,7 @@ module EfuncMsg
                         var a = st.addEntry(rname, e.size, real);
                         a.a = Math.cos(e.a);
                     }
-                    when "isna" {
+                    when "isnan" {
                         var a = st.addEntry(rname, e.size, bool);
                         a.a = isnan(e.a);
                     }

--- a/src/EfuncMsg.chpl
+++ b/src/EfuncMsg.chpl
@@ -118,6 +118,10 @@ module EfuncMsg
                         var a = st.addEntry(rname, e.size, real);
                         a.a = Math.cos(e.a);
                     }
+                    when "isna" {
+                        var a = st.addEntry(rname, e.size, bool);
+                        a.a = isnan(e.a);
+                    }
                     otherwise {
                         var errorMsg = notImplementedError(pn,efunc,gEnt.dtype);
                         eLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg); 

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -175,3 +175,20 @@ class NumericTest(ArkoudaTest):
             ak.value_counts([0]) 
         self.assertEqual('type of argument "pda" must be arkouda.pdarrayclass.pdarray; got list instead', 
                         cm.exception.args[0])   
+
+    def test_isna(self):
+        """
+        Test efunc `isna`; it returns a pdarray of element-wise T/F values for whether it is NaN (not a number)
+        Currently we only support float based arrays since numpy doesn't support NaN in int-based arrays
+        """
+        npa = np.array([1, 2, None, 3, 4], dtype="float64")
+        ark_s_float64 = ak.array(npa)
+        ark_isna_float64 = ak.isna(ark_s_float64)
+        actual = ark_isna_float64.to_ndarray()
+        expected = np.isnan(npa)
+        self.assertTrue(np.array_equal(expected, actual))
+
+        # Currently we can't make an int64 array with a NaN in it so verify that we throw an Exception
+        ark_s_int64 = ak.array(np.array([1, 2, 3, 4], dtype="int64"))
+        with self.assertRaises(RuntimeError, msg="Currently isna on int64 is not supported"):
+            ak.isna(ark_s_int64)

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -176,19 +176,19 @@ class NumericTest(ArkoudaTest):
         self.assertEqual('type of argument "pda" must be arkouda.pdarrayclass.pdarray; got list instead', 
                         cm.exception.args[0])   
 
-    def test_isna(self):
+    def test_isnan(self):
         """
-        Test efunc `isna`; it returns a pdarray of element-wise T/F values for whether it is NaN (not a number)
+        Test efunc `isnan`; it returns a pdarray of element-wise T/F values for whether it is NaN (not a number)
         Currently we only support float based arrays since numpy doesn't support NaN in int-based arrays
         """
         npa = np.array([1, 2, None, 3, 4], dtype="float64")
         ark_s_float64 = ak.array(npa)
-        ark_isna_float64 = ak.isna(ark_s_float64)
+        ark_isna_float64 = ak.isnan(ark_s_float64)
         actual = ark_isna_float64.to_ndarray()
         expected = np.isnan(npa)
         self.assertTrue(np.array_equal(expected, actual))
 
         # Currently we can't make an int64 array with a NaN in it so verify that we throw an Exception
         ark_s_int64 = ak.array(np.array([1, 2, 3, 4], dtype="int64"))
-        with self.assertRaises(RuntimeError, msg="Currently isna on int64 is not supported"):
-            ak.isna(ark_s_int64)
+        with self.assertRaises(RuntimeError, msg="Currently isnan on int64 is not supported"):
+            ak.isnan(ark_s_int64)


### PR DESCRIPTION
Issue #736:  Adding isna functionality for float based arrays

### Changes:
Adding isna to efunc on server side and wiring isna capability on client side.  isna(pdarray) returns T/F pdarrary for
NaN detection on **_float64_** arrays.  Int-based is not supported at this time.

### Limitations
My understanding is that numpy only supports NaN in float-based arrays as they use the IEEE 754 standard; [numpy_doc](https://numpy.org/doc/stable/reference/constants.html#numpy.NAN) for reference.

If you create a Pandas series from a list containing a None value (i.e. `pd.Series([1, 2, None, 3, 4])`) it gets coerced into a float64.  (Note: the Pandas team does have a custom implementation of an _Int64_ array (capital I) where they have added support for their own type of NaN for integers but I think they are using object wrappers around ints instead of primitives, so something similar may need to b implemented for Arkouda/Chapel to support something like this?)

It doesn't look like you can make an integer based array in Arkouda/Chapel containing missing values (you also can't assign a `nil` value to an int in Chapel).  Given these limitations I only added the `isna` function for float based arrays.  While we could add it to the API for int64 it won't ever return true because NaN values would likely have been coerced to a default (0, -1?) or the array would have been coerced to a Float, so currently I let it traverse the error route if you call isna on an integer based array in Arkouda.

### Draft
I'm marking this PR as a draft until we can have a discussion or confirm my assumptions about the float vs. int thing in Chapel regarding NaN / missing values.