### PR TITLE
763 improve performance of tohdf msg with strings v1

### DIFF
--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -94,7 +94,7 @@ class Strings:
             self.shape = self.offsets.shape
         except Exception as e:
             raise ValueError(e)   
-        self.offsets.register('{}_offsets'.format(self.bytes.name))
+
         self.dtype = npstr
         self.name:Optional[str] = None
         self.logger = getArkoudaLogger(name=__class__.__name__) # type: ignore
@@ -785,11 +785,11 @@ class Strings:
 
     @typechecked
     def save(self, prefix_path : str, dataset : str='strings_array', 
-             mode : str='truncate') -> None:
+             mode : str='truncate') -> str:
         """
         Save the Strings object to HDF5. The result is a collection of HDF5 files,
         one file per locale of the arkouda server, where each filename starts
-        with prefix_path. Each locale saves its chunk of the array to its
+        with prefix_path. Each locale saves its chunk of the Strings array to its
         corresponding file.
 
         Parameters
@@ -821,12 +821,26 @@ class Strings:
         Notes
         -----
         Important implementation notes: (1) Strings state is saved as two datasets
-        within an hdf5 group, (2) the hdf5 group is named via the dataset parameter, 
-        (3) the hdf5 group encompasses the two pdarrays composing a Strings object:
-        segments and values and (4) save logic is delegated to pdarray.save
+        within an hdf5 group: one for the string characters and one for the
+        segments corresponding to the start of each string, (2) the hdf5 group is named 
+        via the dataset parameter. 
         """       
-        self.bytes.save(prefix_path=prefix_path, 
-                                    dataset='{}/values'.format(dataset), mode=mode)
+        if mode.lower() in 'append':
+            m = 1
+        elif mode.lower() in 'truncate':
+            m = 0
+        else:
+            raise ValueError("Allowed modes are 'truncate' and 'append'")
+
+        try:
+            json_array = json.dumps([prefix_path])
+        except Exception as e:
+            raise ValueError(e)
+        
+        return cast(str, generic_msg(cmd="tohdf", args="{} {} {} {} {} {}".\
+                           format(self.bytes.name, dataset, m, json_array, 
+                                  self.dtype, self.offsets.name)))
+        
 
     def is_registered(self) -> np.bool_:
         """

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -94,7 +94,7 @@ class Strings:
             self.shape = self.offsets.shape
         except Exception as e:
             raise ValueError(e)   
-
+        self.offsets.register('{}_offsets'.format(self.bytes.name))
         self.dtype = npstr
         self.name:Union[str, None] = None
         self.logger = getArkoudaLogger(name=__class__.__name__) # type: ignore

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -1289,7 +1289,7 @@ module GenSymIO {
                         t1.stop();  
                         var elapsed = t1.elapsed();
                         gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                              "Time to adjust single string starting chars: %.17r".format(elapsed));  
+                              "Time to adjust single string starting chars for locale %i: %.17r".format(idx,elapsed));  
                     }
                 }
 
@@ -1327,7 +1327,7 @@ module GenSymIO {
                         t1.stop();  
                         var elapsed = t1.elapsed();
                         gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                              "Time to shuffle chars to complete last string: %.17r".format(elapsed)); 
+                              "Time to shuffle chars to complete last string for locale %i: %.17r".format(idx,elapsed)); 
                     }
                 }
 
@@ -2003,7 +2003,7 @@ module GenSymIO {
         t1.stop();  
         var elapsed = t1.elapsed();
         try! gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                  "Time to generateValuesMetadata: %.17r".format(elapsed)); 
+                                  "Time to generateValuesMetadata for locale %i: %.17r".format(idx,elapsed)); 
     }
 
     /*

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -1177,23 +1177,12 @@ module GenSymIO {
          * endsWithCompleteString, which indicates if the local slice array has 
          * a complete string at the end of the array.
          */
-
-        // initialize timer
-        var t1 = new Time.Timer();
-        t1.clear();
-        t1.start();
-
         coforall (loc, idx) in zip(A.targetLocales(), filenames.domain) 
                   with (ref leadingSliceIndices, ref trailingSliceIndices, 
                         ref isSingleString, ref endsWithCompleteString) do on loc {
              generateValuesMetadata(idx,leadingSliceIndices, trailingSliceIndices, 
                                     isSingleString, endsWithCompleteString, A, SA);
         }
-
-        t1.stop();  
-        var elapsed = t1.elapsed();
-        gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                              "Time for generating all values metadata: %.17r".format(elapsed));   
                                        
         /*
          * Iterate through each locale and (1) open the hdf5 file corresponding to the
@@ -1266,9 +1255,7 @@ module GenSymIO {
                  */
                 if isSingleString[idx] && idx > 0 {
                     var trailingIndex = trailingSliceIndices[idx-1];
-                    var t1 = new Time.Timer();
-                    t1.clear();
-                    t1.start(); 
+
                     if trailingIndex > -1 {
                         /*
                          * There are 1..n chars to be shuffled from the previous locale
@@ -1287,10 +1274,6 @@ module GenSymIO {
                             }
                         }
                         charList.insert(0, trailingValuesList);
-                        t1.stop();  
-                        var elapsed = t1.elapsed();
-                        gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                              "Time to adjust single string starting chars for locale %i: %.17r".format(idx,elapsed));  
                     }
                 }
 
@@ -1308,9 +1291,7 @@ module GenSymIO {
                     on Locales[idx+1] {
                         const locDom = A.localSubdomain();
                         var sliceList: list(uint(8), parSafe=false);
-                        var t1 = new Time.Timer();
-                        t1.clear();
-                        t1.start(); 
+
                         /*
                          * Iterate through the local slice values for the next locale and add
                          * each to the sliceList until the null uint(8) character is reached;
@@ -1325,10 +1306,6 @@ module GenSymIO {
                             }
                         }                       
                         charList.extend(sliceList);   
-                        t1.stop();  
-                        var elapsed = t1.elapsed();
-                        gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                              "Time to shuffle chars to complete last string for locale %i: %.17r".format(idx,elapsed)); 
                     }
                 }
 
@@ -1637,17 +1614,11 @@ module GenSymIO {
      */
     proc generateFilenames(prefix : string, extension : string, A) : [] string throws { 
         // Generate the filenames based upon the number of targetLocales.
-        var t1 = new Time.Timer();
-        t1.clear();
-        t1.start(); 
         var filenames: [0..#A.targetLocales().size] string;
         for i in 0..#A.targetLocales().size {
             filenames[i] = generateFilename(prefix, extension, i);
         }
-        t1.stop();  
-        var elapsed = t1.elapsed();
-        gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                  "Time to generateFilenames: %.17r".format(elapsed));    
+   
         return filenames;
     }
 
@@ -1671,11 +1642,6 @@ module GenSymIO {
                                             A, group: string) throws {
       // if appending, make sure number of files hasn't changed and all are present
       var warnFlag: bool;
-
-      // initialize timer
-      var t1 = new Time.Timer();
-      t1.clear();
-      t1.start();
       
       /*
        * Generate a list of matching filenames to test against. If in 
@@ -1768,11 +1734,7 @@ module GenSymIO {
                                     routineName=getRoutineName(), 
                                     moduleName=getModuleName(), 
                                     errorClass='IllegalArgumentError');
-        }  
-        t1.stop();  
-        var elapsed = t1.elapsed();
-        gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                             "Time to process file names: %.17r".format(elapsed));        
+        }        
         return warnFlag;
     }
 
@@ -1785,11 +1747,6 @@ module GenSymIO {
     proc processFilenames(filenames: [] string, matchingFilenames: [] string, mode: int, A) throws {
       // if appending, make sure number of files hasn't changed and all are present
       var warnFlag: bool;
-
-      // initialize timer
-      var t1 = new Time.Timer();
-      t1.clear();
-      t1.start();
 
       if (mode == APPEND) {
           var allexist = true;
@@ -1872,11 +1829,7 @@ module GenSymIO {
                                      routineName=getRoutineName(), 
                                      moduleName=getModuleName(), 
                                      errorClass='IllegalArgumentError');            
-        }    
-        t1.stop();  
-        var elapsed = t1.elapsed();
-        gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                       "Time to process file names: %.17r".format(elapsed));        
+        }       
 
         return warnFlag;
     }
@@ -1913,10 +1866,6 @@ module GenSymIO {
          * array has the null uint(8) as the final character, which means the final 
          * string in the locale is complete (does not span to the next locale).
          */
-        // initialize timer
-        var t1 = new Time.Timer();
-        t1.clear();
-        t1.start();
         on Locales[idx] {
             const locDom = A.localSubdomain();
             const segsLocDom = SA.localSubdomain();
@@ -2028,11 +1977,6 @@ module GenSymIO {
                 trailingSliceIndices[idx] = -1;
             }
         }
-        t1.stop();  
-        var elapsed = t1.elapsed();
-
-        try! gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                  "Time to generateValuesMetadata for locale %i: %.17r".format(idx,elapsed)); 
     }
     
     /*
@@ -2043,11 +1987,6 @@ module GenSymIO {
     private proc sliceToValuesAndSegments(rawChars) throws {
         var charList: list(uint(8), parSafe=false);
         var indices: list(int, parSafe=false);
-
-        // initialize timer
-        var t1 = new Time.Timer();
-        t1.clear();
-        t1.start();
 
         //initialize segments with index to first char in values
         indices.append(0);
@@ -2065,10 +2004,6 @@ module GenSymIO {
             }
         }
 
-        t1.stop();  
-        var elapsed = t1.elapsed();
-        gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                      "Time to convert raw chars via sliceToValuesAndSegments: %.17r".format(elapsed)); 
         return (charList, indices);
     }
 
@@ -2085,11 +2020,7 @@ module GenSymIO {
         var valuesList: list(uint(8), parSafe=false);
         var indices: list(int);
         var i: int = 0;
-        indices.append(0);
-        // initialize timer
-        var t1 = new Time.Timer();
-        t1.clear();
-        t1.start();       
+        indices.append(0);   
         var segmentsBound = charList.size - sliceIndex - 1;
 
         for value in charList(sliceIndex..charList.size-1)  {
@@ -2105,10 +2036,7 @@ module GenSymIO {
             }
             i+=1;
         }
-        t1.stop();  
-        var elapsed = t1.elapsed();
-        gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                  "Time to adjustForLeadingSlice: %.17r".format(elapsed)); 
+
         return (valuesList,indices);
     }
 
@@ -2126,9 +2054,7 @@ module GenSymIO {
         var indices: list(int);
         var i: int = 0;
         indices.append(0);
-        var t1 = new Time.Timer();
-        t1.clear();
-        t1.start();  
+
         for value in charList(0..sliceIndex-1)  {
             valuesList.append(value:uint(8));
             if value == NULL_STRINGS_VALUE && i < sliceIndex-1 {
@@ -2136,10 +2062,7 @@ module GenSymIO {
             }
             i+=1;
         }
-        t1.stop();  
-        var elapsed = t1.elapsed();
-        gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                  "Time to adjustForTrailingSlice: %.17r".format(elapsed)); 
+
         return (valuesList,indices);
     }
 
@@ -2179,10 +2102,6 @@ module GenSymIO {
      */
     private proc writeStringsToHdf(fileId: int, group: string, 
                               valuesList: list(uint(8)), segmentsList: list(int)) throws {
-        // initialize timer
-        var t1 = new Time.Timer();
-        t1.clear();
-        t1.start();
         H5LTmake_dataset_WAR(fileId, '/%s/values'.format(group).c_str(), 1,
                      c_ptrTo([valuesList.size:uint(64)]), getHDF5Type(uint(8)),
                             c_ptrTo(valuesList.toArray()));
@@ -2190,12 +2109,6 @@ module GenSymIO {
         H5LTmake_dataset_WAR(fileId, '/%s/segments'.format(group).c_str(), 1,
                      c_ptrTo([segmentsList.size:uint(64)]),getHDF5Type(int),
                            c_ptrTo(segmentsList.toArray()));
-                           
-        t1.stop();  
-        var elapsed = t1.elapsed();
-        gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                  "Time for writing Strings to hdf5: %.17r".format(elapsed));        
-
     }
     
     /*

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -1121,6 +1121,10 @@ module GenSymIO {
         var prefix: string;
         var extension: string;  
         var warnFlag: bool;      
+
+        var total = new Time.Timer();
+        total.clear();
+        total.start(); 
         
         (prefix,extension) = getFileMetadata(filename);
  
@@ -1466,7 +1470,7 @@ module GenSymIO {
                       var valuesList : list(uint(8));
                      
                       (charList, segmentsList) = sliceToValuesAndSegments(A.localSlice(locDom)); 
-          
+                       
                       /*
                        * Check to see if previous locale (idx-1) ends with a complete string.
                        * If not, then the leading slice of this string was used to complete
@@ -1487,6 +1491,9 @@ module GenSymIO {
             // Close the file now that the values and segments pdarrays have been written
             C_HDF5.H5Fclose(myFileID);
         }
+        total.stop();  
+        gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                  "Total write1DDistStrings time: %.17r".format(total.elapsed()));  
         return warnFlag;
     }
 

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -1933,10 +1933,22 @@ module GenSymIO {
             var numBytes = bytesArray.size;
             var numSegs = segsArray.size;
 
-            if bytesArray[numBytes-1] = NULL_STRINGS_VALUE {
+            if bytesArray[numBytes-1] == NULL_STRINGS_VALUE {
                 endsWithCompleteString[idx] = true;
             } else {
                 endsWithCompleteString[idx] = false;
+            }
+
+            if segsArray[0] == 0 {
+                leadingSliceIndices[idx] = -1;
+            } else {
+                leadingSliceIndices[idx] = segsArray[0];
+            }
+            
+            if !endsWithCompleteString[idx] {
+                trailingSliceIndices[idx] = segsArray[segsArray.size-1];
+            } else {
+                trailingSliceIndices[idx] = -1;
             }
 
             gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),


### PR DESCRIPTION
This PR does the following:

1. improves the performance of Strings tohdfMsg by refactoring the generateValuesMetadata by using the Strings segments array to generate the needed bytes array metadata, obviating the need for costly list generation. 
2. refactors the Strings.save method to send both the bytes and segments array names to enable (1)

Testing a 10 million length Strings save on the corp AWS instance with a 3-node Arkouda cluster in smp mode demonstrates that (1) decreases the generateValuesMetadata runtime from ~ 250 seconds to ~ 1 second and overall runtime down to ~ 36 seconds.

note: a second version of this work that should further improve tohdfMsg performance is currently under development.