### PR TITLE
Optimize the aggregation copy routines

### DIFF
--- a/src/CommAggregation.chpl
+++ b/src/CommAggregation.chpl
@@ -46,11 +46,12 @@ module CommAggregation {
 
     proc postinit() {
       lBuffers = c_malloc(c_ptr(aggType), numLocales);
+      bufferIdxs = c_aligned_alloc(int, 64, numLocales);
       for loc in myLocaleSpace {
         lBuffers[loc] = c_malloc(aggType, bufferSize);
+        bufferIdxs[loc] = 0;
         rBuffers[loc] = new remoteBuffer(aggType, bufferSize, loc);
       }
-      bufferIdxs = c_calloc(int, numLocales);
     }
 
     proc deinit() {
@@ -162,13 +163,14 @@ module CommAggregation {
     proc postinit() {
       dstAddrs = c_malloc(c_ptr(aggType), numLocales);
       lSrcAddrs = c_malloc(c_ptr(aggType), numLocales);
+      bufferIdxs = c_aligned_alloc(int, 64, numLocales);
       for loc in myLocaleSpace {
         dstAddrs[loc] = c_malloc(aggType, bufferSize);
         lSrcAddrs[loc] = c_malloc(aggType, bufferSize);
+        bufferIdxs[loc] = 0;
         rSrcAddrs[loc] = new remoteBuffer(aggType, bufferSize, loc);
         rSrcVals[loc] = new remoteBuffer(elemType, bufferSize, loc);
       }
-      bufferIdxs = c_calloc(int, numLocales);
     }
 
     proc deinit() {

--- a/src/CommAggregation.chpl
+++ b/src/CommAggregation.chpl
@@ -40,18 +40,26 @@ module CommAggregation {
     const bufferSize = dstBuffSize;
     const myLocaleSpace = LocaleSpace;
     var opsUntilYield = yieldFrequency;
-    var lBuffers: [myLocaleSpace] [0..#bufferSize] aggType;
+    var lBuffers: c_ptr(c_ptr(aggType));
     var rBuffers: [myLocaleSpace] remoteBuffer(aggType);
-    var bufferIdxs: [myLocaleSpace] int;
+    var bufferIdxs: c_ptr(int);
 
     proc postinit() {
+      lBuffers = c_malloc(c_ptr(aggType), numLocales);
       for loc in myLocaleSpace {
+        lBuffers[loc] = c_malloc(aggType, bufferSize);
         rBuffers[loc] = new remoteBuffer(aggType, bufferSize, loc);
       }
+      bufferIdxs = c_calloc(int, numLocales);
     }
 
     proc deinit() {
       flush();
+      for loc in myLocaleSpace {
+        c_free(lBuffers[loc]);
+      }
+      c_free(lBuffers);
+      c_free(bufferIdxs);
     }
 
     proc flush() {


### PR DESCRIPTION
Optimize the local portion of aggregation and resolve a performance issue caused by false-sharing.

This switches from using chapel arrays to c_ptr's for things that are locally aggregated in order to clean up the generated code for the aggregator's copy routine. This squashes some wide pointers, which has the effect of eliminating some branches at runtime. These branches are always correctly predicted so there's not a huge performance difference but I wanted to eliminate this is as a possible source of overhead.

This also cacheline aligns bufferIdxs to avoid false-sharing. Previously we were seeing odd aggregation performance issues at specific node counts (5, 6, 9, 10) that ended up being caused by false-sharing between bufferIdxs and some an internal data structure (LocBlockDom) that is read when indexing into block distributed arrays. 1 thread would be writing to bufferIdxs, invalidating the internal data structure for all other threads causing a lot of cache-thrashing.  Aligning bufferIdx prevents it from sharing a cacheline with internal data structures and fixes the performance issue. This was a longstanding issue, but we didn't realize it previously since scalability studies up to this point have used powers-of-two node counts which don't encounter this issue.

Lastly this moves a SrcAggregator assert into a boundsChecking branch. This assert was computing `here.id` each time, which is slightly expensive and had some overhead with how often it's called.

The most important parts of this PR are to cacheline align and avoid the `here.id` call, but the c_ptr optimization also helps slightly.

16-node-xc:
 ---

Here's results from the nightly '16-node-xc' machine up to 16 nodes (running at every node count instead of just powers of two)

![ak-gather-perf-xc](https://user-images.githubusercontent.com/1588337/116606521-d98d2e80-a8fe-11eb-8bd7-cd94e1bf24c1.png)
![ak-scatter-perf-xc](https://user-images.githubusercontent.com/1588337/116606524-dbef8880-a8fe-11eb-8a4d-2fe5b76af565.png)

Where gather benefits the most from removing the `here.id` and performance now increases monotonically rather than having regressions at 5,6,9,10 node counts.

16-node-cs-hdr:
 ---

And results from the nightly '16-node-cs-hdr' machine up to 32 nodes (again running at every node count):

![ak-gather-perf-cs](https://user-images.githubusercontent.com/1588337/116610970-cf216380-a903-11eb-830c-0f0dd8fbe1cc.png)
![ak-scatter-perf-cs](https://user-images.githubusercontent.com/1588337/116610972-cfb9fa00-a903-11eb-899d-c10e75c4c856.png)
