### PR TITLE
Closes #777: Re-enable GroupBy(Strings).aggregate()

### DIFF
--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -226,8 +226,8 @@ class GroupBy:
         return self.unique_keys, create_pdarray(repMsg)
     
     @typechecked
-    def aggregate(self, values : pdarray, operator : str, skipna : bool=True) \
-                    -> Tuple[Union[pdarray,List[Union[pdarray,Strings]]],pdarray]:
+    def aggregate(self, values: pdarray, operator: str, skipna: bool=True) \
+                    -> Tuple[Union[pdarray, Strings, List[Union[pdarray, Strings]]], pdarray]:
         '''
         Using the permutation stored in the GroupBy instance, group another 
         array of values and apply a reduction to each group's values. 
@@ -670,17 +670,21 @@ class GroupBy:
             
         Examples
         --------
-        >>> a = ak.randint(1,5,10)
-        >>> a
-        array([3, 3, 4, 3, 3, 2, 3, 2, 4, 2])
-        >>> g = ak.GroupBy(a)
+        >>> data = ak.array([3, 4, 3, 1, 1, 4, 3, 4, 1, 4])
+        >>> data
+        array([3, 4, 3, 1, 1, 4, 3, 4, 1, 4])
+        >>> labels = ak.array([1, 1, 1, 2, 2, 2, 3, 3, 3, 4])
+        >>> labels
+        ak.array([1, 1, 1, 2, 2, 2, 3, 3, 3, 4])
+        >>> g = ak.GroupBy(labels)
         >>> g.keys
-        array([3, 3, 4, 3, 3, 2, 3, 2, 4, 2])
-        >>> b = ak.randint(1,5,10)
-        >>> b
-        array([3, 3, 3, 4, 1, 1, 3, 3, 3, 4])
-        >>> g.nunique(b)
-        (array([2, 3, 4]), array([3, 3, 1]))
+        ak.array([1, 1, 1, 2, 2, 2, 3, 3, 3, 4])
+        >>> g.nunique(data)
+        array([1,2,3,4]), array([2, 2, 3, 1])
+        #    Group (1,1,1) has values [3,4,3] -> there are 2 unique values 3&4
+        #    Group (2,2,2) has values [1,1,4] -> 2 unique values 1&4
+        #    Group (3,3,3) has values [3,4,1] -> 3 unique values
+        #    Group (4) has values [4] -> 1 unique value
         """
         if values.dtype != int64:
             raise TypeError('the pdarray dtype must be int64')

--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -283,3 +283,14 @@ class GroupByTest(ArkoudaTest):
             self.igb.argmax(ak.randint(0,1,10,dtype=bool))
         self.assertEqual('argmax is only supported for pdarrays of dtype float64 and int64', 
                          cm.exception.args[0])  
+
+    def test_aggregate_strings(self):
+        s = ak.array(['a', 'b', 'a', 'b', 'c'])
+        i = ak.arange(s.size)
+        grouping = ak.GroupBy(s)
+        labels, values = grouping.nunique(i)
+
+        expected = {'a': 2, 'b': 2, 'c': 1}
+        actual = {label: value for (label, value) in zip(labels.to_ndarray(), values.to_ndarray())}
+
+        self.assertDictEqual(expected, actual)


### PR DESCRIPTION
This PR (Issue #777) :
- Adds `Strings` to aggregate function return types
- Updates example in the `Groupby.nunique` doc string
- Adds `test_aggregate_strings` to `groupby_test` suite