### PR TITLE
Issue #555: Changes & instructions for building a pip installable arkouda client package.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ Makefile.paths
 SysInfo.chpl
 Untitled.ipynb
 dist/
+env/
+build-client-env/
 arkouda.egg-info/
 build/
 dep/*-install/

--- a/README.md
+++ b/README.md
@@ -395,9 +395,9 @@ For more details regarding Arkouda testing, please consult the Python test [READ
 
 <a id="install-ak"></a>
 ## Installing the Arkouda Python Library and Dependencies <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
-Now that the arkouda\_server is built and tested, install the Python library.
+Now that the arkouda_server is built and tested, install the Python library.
 
-The Arkouda Python library along with it's dependent libraries are installed with pip. There are four types of 
+The Arkouda Python library along with its dependent libraries are installed with pip. There are four types of 
 Python dependencies for the Arkouda developer to install: requires, dev, test, and doc. The required libraries, 
 which are the runtime dependencies of the Arkouda python library, are installed as follows:
 
@@ -405,11 +405,30 @@ which are the runtime dependencies of the Arkouda python library, are installed 
  pip3 install -e .
 ```
 
-Arkouda and the Python libaries required for development, test, and doc generation activities are installed
+Arkouda and the Python libraries required for development, test, and doc generation activities are installed
 as follows:
 
 ```bash
 pip3 install -e .[dev]
+```
+
+Alternatively you can build a distributable package via
+```bash
+# We'll use a virtual environment to build
+python -m venv build-client-env
+source build-client-env/bin/activate
+python -m pip install --upgrade pip build wheel
+python setup.py clean --all
+python -m build
+
+# Clean up our virtual env
+deactivate
+rm -rf build-client-env
+
+# You should now have 2 files in the dist/ directory which can be installed via pip
+pip install dist/arkouda*.whl
+# or
+pip install dist/arkouda*.tar.gz
 ```
 
 <a id="run-ak"></a>

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 from os import path
-from subprocess import PIPE, Popen
-import installers
 
 
 here = path.abspath(path.dirname(__file__))
@@ -135,9 +133,13 @@ setup(
     #
     # For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['numpy>=1.16.5,<=1.19.5', 
-                      'pandas>=1.1.0', 'zmq', 
-                      'typeguard==2.10.0', 'pyfiglet'],  # Optional
+    install_requires=[
+        'numpy>=1.16.5,<=1.19.5',
+        'pandas>=1.1.0',
+        'pyzmq>=20.0.0',
+        'typeguard==2.10.0',
+        'pyfiglet'
+    ],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). Users will be able to install these using the "extras"
@@ -152,11 +154,11 @@ setup(
                 'pytest-env','Sphinx', 'sphinx-argparse', 
                 'sphinx-autoapi', 'mypy'],
     },
-    # replace orginal install command with version that also builds
+    # replace original install command with version that also builds
     # chapel and the arkouda server.
-    cmdclass={
-        "build_py": installers.ArkoudaInstall,
-    },
+    # cmdclass={
+    #     "build_py": installers.ArkoudaInstall,
+    # },
 
     # If there are data files included in your packages that need to be
     # installed, specify them here.


### PR DESCRIPTION
Issue #555 : Changes & instructions for building a pip installable arkouda client package.

I had worked on this a while back and just got around to rebasing it against master.  I know @hokiegeek2 had worked on something similar previously, but I'm not sure if it went anywhere.  Figured I should dust this off and put it up for review.

#### Summary of changes
It's mostly an update of README instructions and extra items added to the `.gitignore` file.  The `setup.py` piece which builds the server component was disabled since the ticket hinted that we weren't going to support packaging the chapel-based server component in a pip package, just the client.  Everything else is grammatical/spelling/formatting changes and removal of unused imports.

#### Limitations
-  This is only a _client_ package
-  This doesn't address versioning in any way.