### PR TITLE
Closes #788: Reducing duplicative code for datastr and datarepr in MultiTypeSymbolTable

### DIFF
--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -51,6 +51,30 @@ module MultiTypeSymEntry
         inline proc toSymEntry(type etype) {
             return try! this :borrowed SymEntry(etype);
         }
+
+        /* 
+        Formats and returns data in this entry up to the specified threshold. 
+        Arrays of size less than threshold will be printed in their entirety. 
+        Arrays of size greater than or equal to threshold will print the first 3 and last 3 elements
+
+            :arg thresh: threshold for data to return
+            :type thresh: int
+
+            :arg prefix: String to prepend to the front of the data string
+            :type prefix: string
+
+            :arg suffix: String to append to the tail of the data string
+            :type suffix: string
+
+            :arg baseFormat: String which represents the base format string for the data type
+            :type baseFormat: string
+
+            :returns: s (string) containing the array data
+        */
+        proc __str__(thresh:int=1, prefix:string="", suffix:string="", baseFormat:string=""): string throws {
+            var s = "DType: %s, itemsize: %t, size: %t".format(this.dtype, this.itemsize, this.size);
+            return prefix + s + suffix;
+        }
     }
 
     /* Symbol table entry
@@ -130,6 +154,48 @@ module MultiTypeSymEntry
           }
           writeField(f, nFields-1);
           f <~> "}";
+        }
+
+        /*
+        Formats and returns data in this entry up to the specified threshold. 
+        Arrays of size less than threshold will be printed in their entirety. 
+        Arrays of size greater than or equal to threshold will print the first 3 and last 3 elements
+
+            :arg thresh: threshold for data to return
+            :type thresh: int
+
+            :arg prefix: String to pre-pend to the front of the data string
+            :type prefix: string
+
+            :arg suffix: String to append to the tail of the data string
+            :type suffix: string
+
+            :arg baseFormat: String which represents the base format string for the data type
+            :type baseFormat: string
+
+            :returns: s (string) containing the array data
+        */
+        override proc __str__(thresh:int=6, prefix:string = "[", suffix:string = "]", baseFormat:string = "%t"): string throws {
+            var s:string = "";
+            if (this.size == 0) {
+                s =  ""; // Unnecessary, but left for clarity
+            } else if (this.size < thresh || this.size <= 6) {
+                for i in 0..(this.size-2) {s += try! baseFormat.format(this.a[i]) + " ";}
+                s += try! baseFormat.format(this.a[this.size-1]);
+            } else {
+                var b = baseFormat + " " + baseFormat + " " + baseFormat + " ... " +
+                            baseFormat + " " + baseFormat + " " + baseFormat;
+                s = try! b.format(
+                            this.a[0], this.a[1], this.a[2],
+                            this.a[this.size-3], this.a[this.size-2], this.a[this.size-1]);
+            }
+            
+            if (bool == this.etype) {
+                s = s.replace("true","True");
+                s = s.replace("false","False");
+            }
+
+            return prefix + s + suffix;
         }
     }
 

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -1,10 +1,8 @@
 import numpy as np
-import numpy
-import warnings, os
+import warnings
 from itertools import product
 from base_test import ArkoudaTest
 from context import arkouda as ak
-from context import arkouda
 SIZE = 10
 verbose = ArkoudaTest.verbose
 
@@ -294,8 +292,35 @@ class OperatorsTest(ArkoudaTest):
 
         self.assertEqual('Error: concatenateMsg: Incompatible arguments: ' +
                          'Expected float64 dtype but got bool dtype', 
-                         cm.exception.args[0])     
-        
+                         cm.exception.args[0])
+
+    def test_str_repr(self):
+        """
+        Test 3 different types: int, float, bool with lengths under/over threshold
+        Do this for both __str__() and __repr__()
+        """
+        ak.client.pdarrayIterThresh = 5
+        # Test __str__()
+        self.assertEqual("[1 2 3]", ak.array([1, 2, 3]).__str__())
+        self.assertEqual("[1 2 3 ... 17 18 19]", ak.arange(1, 20).__str__())
+        self.assertEqual("[1.100000e+00 2.300000e+00 5.000000e+00]", ak.array([1.1, 2.3, 5]).__str__())
+        self.assertEqual("[0.000000e+00 5.263158e-01 1.052632e+00 ... 8.947368e+00 9.473684e+00 1.000000e+01]",
+                         ak.linspace(0, 10, 20).__str__())
+        self.assertEqual("[False False False]", ak.isnan(ak.array([1.1, 2.3, 5])).__str__())
+        self.assertEqual("[False False False ... False False False]", ak.isnan(ak.linspace(0, 10, 20)).__str__())
+
+        # Test __repr__()
+        self.assertEqual("array([1 2 3])", ak.array([1, 2, 3]).__repr__())
+        self.assertEqual("array([1 2 3 ... 17 18 19])", ak.arange(1, 20).__repr__())
+        self.assertEqual("array([1.1000000000000001 2.2999999999999998 5])", ak.array([1.1, 2.3, 5]).__repr__())
+        self.assertEqual("array([0 0.52631578947368418 1.0526315789473684 ... 8.9473684210526319 9.473684210526315 10])",
+                         ak.linspace(0, 10, 20).__repr__())
+        self.assertEqual("array([False False False])", ak.isnan(ak.array([1.1, 2.3, 5])).__repr__())
+        self.assertEqual("array([False False False ... False False False])", ak.isnan(ak.linspace(0, 10, 20)).__repr__())
+        ak.client.pdarrayIterThresh = ak.client.pdarrayIterThreshDefVal  # Don't forget to set this back for other tests.
+
+
+
 if __name__ == '__main__':
     '''
     Enables invocation of operator tests outside of pytest test harness


### PR DESCRIPTION
Closes #788: Reducing duplicative code for datastr and datarepr in MultiTypeSymbolTable.
Added unit tests for __str__() and __repr__().

This PR adds a `__str__(...)` method to `GenSymEntry` & ` SymEntry` which can be used by both the `datastr` and `datarepr` methods.  It reduces the amount of code/logic which was previously duplicated between those two functions.

One possible down-side with this approach (mostly philosophical) is that it pushes behavior into the `SymEntry` class... although arguably a `toString` style method is within bounds of a Class's responsibility.

*This PR does _not_ change behavior only the underlying implementation.