### PR TITLE
Closes #791: Remove duplicated check table in MultiTypeSymbolTable

### DIFF
--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -68,8 +68,8 @@ module SegmentedMsg {
     var (objtype, segName, valName) = payload.splitMsgToTuple(3);
 
     // check to make sure symbols defined
-    st.check(segName);
-    st.check(valName);
+    st.checkTable(segName);
+    st.checkTable(valName);
     
     var rname = st.nextName();
     smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
@@ -102,8 +102,8 @@ module SegmentedMsg {
                                               payload.splitMsgToTuple(6);
 
       // check to make sure symbols defined
-      st.check(segName);
-      st.check(valName);
+      st.checkTable(segName);
+      st.checkTable(valName);
 
       var json = jsonToPdArray(valStr, 1);
       var val = json[json.domain.low];
@@ -158,8 +158,8 @@ proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTup
          idStr, kpStr, lStr, jsonStr) = payload.splitMsgToTuple(10);
 
     // check to make sure symbols defined
-    st.check(segName);
-    st.check(valName);
+    st.checkTable(segName);
+    st.checkTable(valName);
 
     smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                          "cmd: %s subcmd: %s objtype: %t valtype: %t".format(
@@ -266,8 +266,8 @@ proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTup
     var (objtype, segName, valName) = payload.splitMsgToTuple(3);
 
     // check to make sure symbols defined
-    st.check(segName);
-    st.check(valName);
+    st.checkTable(segName);
+    st.checkTable(valName);
 
     select objtype {
         when "str" {
@@ -349,8 +349,8 @@ proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTup
       var pn = Reflection.getRoutineName();
 
       // check to make sure symbols defined
-      st.check(args[1]);
-      st.check(args[2]);
+      st.checkTable(args[1]);
+      st.checkTable(args[2]);
       
       select objtype {
           when "str" {
@@ -390,8 +390,8 @@ proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTup
     var pn = Reflection.getRoutineName();
 
     // check to make sure symbols defined
-    st.check(args[1]);
-    st.check(args[2]);
+    st.checkTable(args[1]);
+    st.checkTable(args[2]);
 
     select objtype {
         when "str" {
@@ -450,8 +450,8 @@ proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTup
     var pn = Reflection.getRoutineName();
 
     // check to make sure symbols defined
-    st.check(args[1]);
-    st.check(args[2]);
+    st.checkTable(args[1]);
+    st.checkTable(args[2]);
 
     var newSegName = st.nextName();
     var newValName = st.nextName();
@@ -518,10 +518,10 @@ proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTup
            = payload.splitMsgToTuple(9);
 
     // check to make sure symbols defined
-    st.check(lsegName);
-    st.check(lvalName);
-    st.check(rsegName);
-    st.check(rvalName);
+    st.checkTable(lsegName);
+    st.checkTable(lvalName);
+    st.checkTable(rsegName);
+    st.checkTable(rvalName);
 
     select (ltype, rtype) {
         when ("str", "str") {
@@ -583,8 +583,8 @@ proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTup
           = payload.splitMsgToTuple(6);
 
       // check to make sure symbols defined
-      st.check(segName);
-      st.check(valName);
+      st.checkTable(segName);
+      st.checkTable(valName);
 
       var json = jsonToPdArray(encodedVal, 1);
       var value = json[json.domain.low];
@@ -628,10 +628,10 @@ proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTup
          testValName, invertStr) = payload.splitMsgToTuple(7);
 
       // check to make sure symbols defined
-      st.check(mainSegName);
-      st.check(mainValName);
-      st.check(testSegName);
-      st.check(testValName);
+      st.checkTable(mainSegName);
+      st.checkTable(mainValName);
+      st.checkTable(testSegName);
+      st.checkTable(testValName);
 
       var invert: bool;
       if invertStr == "True" {invert = true;
@@ -672,8 +672,8 @@ proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTup
       var (objtype, segName, valName) = payload.splitMsgToTuple(3);
 
       // check to make sure symbols defined
-      st.check(segName);
-      st.check(valName);
+      st.checkTable(segName);
+      st.checkTable(valName);
       
       var rname = st.nextName();
       select (objtype) {


### PR DESCRIPTION
This PR (Closes #791)
- Changes name of `check` in `MultiTypeSymbolTable` to `checkTable`
- Updates functions in `MultiTypeSymbolTable.chpl` to use the existing `checkTable` function to check if a symbol is in the symbol table
- Replaces references to `check` in `SegmentedMsg.chpl` with `checkTable`